### PR TITLE
fix: provider provided trough `cli` should be handled before `default`

### DIFF
--- a/crates/cli/src/provider.rs
+++ b/crates/cli/src/provider.rs
@@ -18,13 +18,13 @@ pub fn split_provider(s: &str) -> (String, Option<String>) {
 
 /// Retrieves provider and model information from CLI args or default store
 pub fn get_provider_info(args: &CliArgs) -> Option<(String, Option<String>)> {
+    if let Some(ref s) = args.backend {
+        return Some(split_provider(s));
+    }
     if let Ok(store) = SecretStore::new() {
         if let Some(default) = store.get_default_provider() {
             return Some(split_provider(default));
         }
-    }
-    if let Some(ref s) = args.backend {
-        return Some(split_provider(s));
     }
     None
 }


### PR DESCRIPTION
Closes #29 