### PR TITLE
fix: version and features difference between lock and `cargo.toml`

### DIFF
--- a/crates/querymt/Cargo.toml
+++ b/crates/querymt/Cargo.toml
@@ -34,7 +34,7 @@ either.workspace = true
 url.workspace = true
 http.workspace = true
 libloading = { version = "0.8", optional = true}
-rmcp = { version = "0.6.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client", "transport-sse-client"], optional = true }
+rmcp = { version = "0.6.1", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-sse-client-reqwest"], optional = true }
 toml = { version = "0.8", optional = true}
 thiserror = "1.0"
 extism = { version = "1.11", optional = true}


### PR DESCRIPTION
version and features difference fails build of version from main.

```
$ cargo build
   Compiling querymt v0.1.3 (/projects/personal/github/querymt/crates/querymt)
warning: unused import: `ProviderInfo`
  --> crates/querymt/src/plugin/extism_impl/host/mod.rs:10:44
   |
10 |     providers::{read_providers_from_cache, ProviderInfo},
   |                                            ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `FunctionTool`
 --> crates/querymt/src/tool_decorator.rs:2:58
  |
2 |     chat::{BasicChatProvider, ChatMessage, ChatResponse, FunctionTool, ToolChatProvider},
  |                                                          ^^^^^^^^^^^^

warning: unused import: `schemars::JsonSchema`
  --> crates/querymt/src/tool_decorator.rs:10:5
   |
10 | use schemars::JsonSchema;
   |     ^^^^^^^^^^^^^^^^^^^^

warning: unused import: `serde::Serialize`
  --> crates/querymt/src/tool_decorator.rs:11:5
   |
11 | use serde::Serialize;
   |     ^^^^^^^^^^^^^^^^

warning: unused import: `std::future::Future`
  --> crates/querymt/src/tool_decorator.rs:14:5
   |
14 | use std::future::Future;
   |     ^^^^^^^^^^^^^^^^^^^

warning: unused import: `std::pin::Pin`
  --> crates/querymt/src/tool_decorator.rs:15:5
   |
15 | use std::pin::Pin;
   |     ^^^^^^^^^^^^^

warning: unused import: `std::sync::Arc`
  --> crates/querymt/src/tool_decorator.rs:16:5
   |
16 | use std::sync::Arc;
   |     ^^^^^^^^^^^^^^

warning: unused import: `std::fmt::Debug`
 --> crates/querymt/src/providers/registry.rs:3:5
  |
3 | use std::fmt::Debug;
  |     ^^^^^^^^^^^^^^^

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:67:29
    |
66  |                         SseClientTransport::start_with_client(
    |                         ------------------------------------- required by a bound introduced by this call
67  |                             client,
    |                             ^^^^^^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport::<C>::start_with_client`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:189:9
    |
189 | impl<C: SseClient> SseClientTransport<C> {
    |         ^^^^^^^^^ required by this bound in `SseClientTransport::<C>::start_with_client`
190 |     pub async fn start_with_client(
    |                  ----------------- required by a bound in this associated function

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:66:25
    |
66  | /                         SseClientTransport::start_with_client(
67  | |                             client,
68  | |                             SseClientConfig {
69  | |                                 sse_endpoint: url.clone().into(),
70  | |                                 ..Default::default()
71  | |                             },
72  | |                         )
    | |_________________________^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport<C>`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:189:9
    |
189 | impl<C: SseClient> SseClientTransport<C> {
    |         ^^^^^^^^^ required by this bound in `SseClientTransport<C>`

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:73:26
    |
73  |                         .await?
    |                          ^^^^^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport<C>`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:189:9
    |
189 | impl<C: SseClient> SseClientTransport<C> {
    |         ^^^^^^^^^ required by this bound in `SseClientTransport<C>`

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:66:25
    |
66  | /                         SseClientTransport::start_with_client(
67  | |                             client,
68  | |                             SseClientConfig {
69  | |                                 sse_endpoint: url.clone().into(),
...   |
73  | |                         .await?
    | |______________________________^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:154:34
    |
154 | pub struct SseClientTransport<C: SseClient> {
    |                                  ^^^^^^^^^ required by this bound in `SseClientTransport`

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:66:25
    |
66  | /                         SseClientTransport::start_with_client(
67  | |                             client,
68  | |                             SseClientConfig {
69  | |                                 sse_endpoint: url.clone().into(),
...   |
73  | |                         .await?
    | |_______________________________^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:154:34
    |
154 | pub struct SseClientTransport<C: SseClient> {
    |                                  ^^^^^^^^^ required by this bound in `SseClientTransport`

error[E0599]: no function or associated item named `start` found for struct `SseClientTransport` in the current scope
  --> crates/querymt/src/mcp/config.rs:75:49
   |
75 |                     None => SseClientTransport::start(url.as_str()).await?,
   |                                                 ^^^^^ function or associated item not found in `SseClientTransport<_>`

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:75:29
    |
75  |                     None => SseClientTransport::start(url.as_str()).await?,
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:154:34
    |
154 | pub struct SseClientTransport<C: SseClient> {
    |                                  ^^^^^^^^^ required by this bound in `SseClientTransport`

error[E0277]: the trait bound `SseClientTransport<reqwest::Client>: IntoTransport<RoleClient, _, _>` is not satisfied
   --> crates/querymt/src/mcp/config.rs:77:31
    |
77  |                 ().into_dyn().serve(transport).await?
    |                               ^^^^^ the trait `IntoTransport<RoleClient, _, _>` is not implemented for `SseClientTransport<reqwest::Client>`
    |
    = help: the following other types implement trait `IntoTransport<R, E, A>`:
              `(R, W)` implements `IntoTransport<Role, std::io::Error, TransportAdapterAsyncRW>`
              `(Si, St)` implements `IntoTransport<Role, <Si as futures::Sink<JsonRpcMessage<<Role as ServiceRole>::Req, <Role as ServiceRole>::Resp, <Role as ServiceRole>::Not>>>::Error, TransportAdapterSinkStream>`
note: required by a bound in `ServiceExt::serve::{anon_assoc#0}`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/service.rs:121:12
    |
121 |         T: IntoTransport<R, E, A>,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServiceExt::serve::{anon_assoc#0}`

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:77:17
    |
77  |                 ().into_dyn().serve(transport).await?
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:154:34
    |
154 | pub struct SseClientTransport<C: SseClient> {
    |                                  ^^^^^^^^^ required by this bound in `SseClientTransport`

error[E0277]: the trait bound `SseClientTransport<reqwest::Client>: IntoTransport<RoleClient, _, _>` is not satisfied
   --> crates/querymt/src/mcp/config.rs:77:17
    |
77  |                 ().into_dyn().serve(transport).await?
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoTransport<RoleClient, _, _>` is not implemented for `SseClientTransport<reqwest::Client>`
    |
    = help: the following other types implement trait `IntoTransport<R, E, A>`:
              `(R, W)` implements `IntoTransport<Role, std::io::Error, TransportAdapterAsyncRW>`
              `(Si, St)` implements `IntoTransport<Role, <Si as futures::Sink<JsonRpcMessage<<Role as ServiceRole>::Req, <Role as ServiceRole>::Resp, <Role as ServiceRole>::Not>>>::Error, TransportAdapterSinkStream>`
note: required by a bound in `serve`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/service.rs:121:12
    |
116 |     fn serve<T, E, A>(
    |        ----- required by a bound in this associated function
...
121 |         T: IntoTransport<R, E, A>,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServiceExt::serve`

error[E0277]: the trait bound `SseClientTransport<reqwest::Client>: IntoTransport<RoleClient, _, _>` is not satisfied
   --> crates/querymt/src/mcp/config.rs:77:48
    |
77  |                 ().into_dyn().serve(transport).await?
    |                                                ^^^^^ the trait `IntoTransport<RoleClient, _, _>` is not implemented for `SseClientTransport<reqwest::Client>`
    |
    = help: the following other types implement trait `IntoTransport<R, E, A>`:
              `(R, W)` implements `IntoTransport<Role, std::io::Error, TransportAdapterAsyncRW>`
              `(Si, St)` implements `IntoTransport<Role, <Si as futures::Sink<JsonRpcMessage<<Role as ServiceRole>::Req, <Role as ServiceRole>::Resp, <Role as ServiceRole>::Not>>>::Error, TransportAdapterSinkStream>`
note: required by a bound in `serve`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/service.rs:121:12
    |
116 |     fn serve<T, E, A>(
    |        ----- required by a bound in this associated function
...
121 |         T: IntoTransport<R, E, A>,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServiceExt::serve`

error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:77:48
    |
77  |                 ().into_dyn().serve(transport).await?
    |                                                ^^^^^ the trait `SseClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `SseClientTransport`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/sse_client.rs:154:34
    |
154 | pub struct SseClientTransport<C: SseClient> {
    |                                  ^^^^^^^^^ required by this bound in `SseClientTransport`

error[E0277]: the trait bound `reqwest::Client: StreamableHttpClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:93:29
    |
92  |                         StreamableHttpClientTransport::with_client(
    |                         ------------------------------------------ required by a bound introduced by this call
93  |                             client,
    |                             ^^^^^^ the trait `StreamableHttpClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `streamable_http_client::<impl WorkerTransport<StreamableHttpClientWorker<C>>>::with_client`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/streamable_http_client.rs:587:9
    |
587 | impl<C: StreamableHttpClient> StreamableHttpClientTransport<C> {
    |         ^^^^^^^^^^^^^^^^^^^^ required by this bound in `streamable_http_client::<impl WorkerTransport<StreamableHttpClientWorker<C>>>::with_client`
...
662 |     pub fn with_client(client: C, config: StreamableHttpClientTransportConfig) -> Self {
    |            ----------- required by a bound in this associated function

error[E0277]: the trait bound `reqwest::Client: StreamableHttpClient` is not satisfied
   --> crates/querymt/src/mcp/config.rs:92:25
    |
92  | /                         StreamableHttpClientTransport::with_client(
93  | |                             client,
94  | |                             StreamableHttpClientTransportConfig {
95  | |                                 uri: url.clone().into(),
96  | |                                 ..Default::default()
97  | |                             },
98  | |                         )
    | |_________________________^ the trait `StreamableHttpClient` is not implemented for `reqwest::Client`
    |
note: required by a bound in `StreamableHttpClientWorker`
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/streamable_http_client.rs:187:42
    |
187 | pub struct StreamableHttpClientWorker<C: StreamableHttpClient> {
    |                                          ^^^^^^^^^^^^^^^^^^^^ required by this bound in `StreamableHttpClientWorker`

error[E0599]: no function or associated item named `from_uri` found for struct `WorkerTransport` in the current scope
   --> crates/querymt/src/mcp/config.rs:100:60
    |
100 |                     None => StreamableHttpClientTransport::from_uri(url.clone()),
    |                                                            ^^^^^^^^ function or associated item not found in `WorkerTransport<StreamableHttpClientWorker<_>>`
    |
note: if you're trying to build a new `WorkerTransport<StreamableHttpClientWorker<_>>` consider using one of the following associated functions:
      WorkerTransport::<W>::spawn
      WorkerTransport::<W>::spawn_with_ct
      streamable_http_client::<impl WorkerTransport<StreamableHttpClientWorker<C>>>::with_client
   --> /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/streamable_http_client.rs:662:5
    |
662 |     pub fn with_client(client: C, config: StreamableHttpClientTransportConfig) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: /home/ivan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rmcp-0.6.1/src/transport/worker.rs:93:5
    |
93  |     pub fn spawn(worker: W) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
96  |     pub fn spawn_with_ct(worker: W, transport_task_ct: CancellationToken) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: there is an associated function `from` with a similar name
    |
100 -                     None => StreamableHttpClientTransport::from_uri(url.clone()),
100 +                     None => StreamableHttpClientTransport::from(url.clone()),
    |

warning: variable `seen_type` is assigned to, but never used
   --> crates/querymt/src/chat/mod.rs:269:25
    |
269 |                 let mut seen_type: Option<String> = None;
    |                         ^^^^^^^^^
    |
    = note: consider using `_seen_type` instead
    = note: `#[warn(unused_variables)]` on by default

warning: value assigned to `seen_type` is never read
   --> crates/querymt/src/chat/mod.rs:282:29
    |
282 | ...                   seen_type = Some(t);
    |                       ^^^^^^^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` on by default

warning: unused variable: `gen`
   --> crates/querymt/src/chat/mod.rs:315:20
    |
315 |     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
    |                    ^^^ help: if this is intentional, prefix it with an underscore: `_gen`

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
warning: `querymt` (lib) generated 11 warnings
error: could not compile `querymt` (lib) due to 15 previous errors; 11 warnings emitted
```