### PR TITLE
fix: codeblocks overflow and syntax highlight in messages

### DIFF
--- a/crates/agent/ui/src/components/MessageContent.test.tsx
+++ b/crates/agent/ui/src/components/MessageContent.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MessageContent } from './MessageContent';
+
+vi.mock('./HighlightedCode', () => ({
+  HighlightedCode: ({ code, language }: { code: string; language?: string }) => (
+    <div data-testid="highlighted-code" data-language={language ?? ''}>
+      {code}
+    </div>
+  ),
+}));
+
+describe('MessageContent', () => {
+  it('renders fenced code blocks without language via the highlighter', () => {
+    const longLine = 'x'.repeat(400);
+    const markdown = ['```', longLine, '```'].join('\n');
+    render(<MessageContent content={markdown} />);
+
+    const highlighted = screen.getByTestId('highlighted-code');
+    expect(highlighted).toHaveTextContent(longLine);
+    expect(highlighted).toHaveAttribute('data-language', '');
+  });
+
+  it('passes fenced block language to the highlighter', () => {
+    const markdown = ['```ts', 'const value = 1;', '```'].join('\n');
+    const { container } = render(<MessageContent content={markdown} />);
+
+    const highlighted = screen.getByTestId('highlighted-code');
+    expect(highlighted).toHaveAttribute('data-language', 'ts');
+    expect(container.querySelectorAll('[data-testid="highlighted-code"]')).toHaveLength(1);
+  });
+
+  it('keeps inline code styled as inline and does not wrap it in pre', () => {
+    const { container } = render(<MessageContent content={'Use `querymt` here.'} />);
+
+    expect(container.querySelectorAll('pre')).toHaveLength(0);
+    expect(container.querySelector('code')).toHaveClass('bg-surface-canvas/50');
+  });
+});


### PR DESCRIPTION

<img width="1232" height="501" alt="image" src="https://github.com/user-attachments/assets/04740e10-7531-4a22-81ee-73ec3dcc95f5" />

<img width="1087" height="1174" alt="image" src="https://github.com/user-attachments/assets/f9477fa9-9fe8-4356-86a4-a42f50e655ab" />
