### PR TITLE
fix(ui): replace workspace prompt with dialog and add default cwd fallback

### DIFF
--- a/crates/agent/src/simple/agent.rs
+++ b/crates/agent/src/simple/agent.rs
@@ -464,7 +464,11 @@ impl Agent {
 
     #[cfg(feature = "dashboard")]
     pub fn dashboard(&self) -> AgentServer {
-        AgentServer::new(self.inner.clone(), self.view_store.clone())
+        AgentServer::new(
+            self.inner.clone(),
+            self.view_store.clone(),
+            self.cwd.clone(),
+        )
     }
 
     /// Start an ACP server with the specified transport.

--- a/crates/agent/src/simple/quorum.rs
+++ b/crates/agent/src/simple/quorum.rs
@@ -357,7 +357,7 @@ impl Quorum {
 
     #[cfg(feature = "dashboard")]
     pub fn dashboard(&self) -> AgentServer {
-        AgentServer::new(self.planner(), self.view_store.clone())
+        AgentServer::new(self.planner(), self.view_store.clone(), self.cwd.clone())
     }
 
     /// Start an ACP server with the specified transport.

--- a/crates/agent/src/ui/connection.rs
+++ b/crates/agent/src/ui/connection.rs
@@ -109,12 +109,17 @@ pub async fn send_state(state: &ServerState, conn_id: &str, tx: &mpsc::Sender<St
 
     let agents = build_agent_list(state);
     let agent_mode = state.agent.get_agent_mode().as_str().to_string();
+    let default_cwd = state
+        .default_cwd
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
     let _ = send_message(
         tx,
         UiServerMessage::State {
             routing_mode,
             active_agent_id,
             active_session_id,
+            default_cwd,
             agents,
             sessions_by_agent,
             agent_mode,

--- a/crates/agent/src/ui/handlers.rs
+++ b/crates/agent/src/ui/handlers.rs
@@ -61,7 +61,7 @@ pub async fn handle_ui_message(
             send_state(state, conn_id, tx).await;
         }
         UiClientMessage::NewSession { cwd, request_id } => {
-            let cwd = resolve_cwd(cwd);
+            let cwd = resolve_cwd(cwd).or_else(|| state.default_cwd.clone());
 
             // Clear existing sessions for this connection to start fresh
             {

--- a/crates/agent/src/ui/messages.rs
+++ b/crates/agent/src/ui/messages.rs
@@ -150,6 +150,8 @@ pub enum UiServerMessage {
         routing_mode: RoutingMode,
         active_agent_id: String,
         active_session_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<String>,
         agents: Vec<UiAgentInfo>,
         sessions_by_agent: HashMap<String, String>,
         agent_mode: String,

--- a/crates/agent/src/ui/undo_handler_tests.rs
+++ b/crates/agent/src/ui/undo_handler_tests.rs
@@ -156,6 +156,7 @@ async fn test_undo_handler_single_agent() -> Result<()> {
     let state = super::ServerState {
         agent: Arc::new(agent),
         view_store: storage.clone(),
+        default_cwd: None,
         event_sources: vec![],
         connections: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         session_agents: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
@@ -352,6 +353,7 @@ async fn test_undo_handler_cross_session() -> Result<()> {
     let state = super::ServerState {
         agent: Arc::new(agent),
         view_store: storage.clone(),
+        default_cwd: None,
         event_sources: vec![],
         connections: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         session_agents: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),

--- a/crates/agent/ui/src/components/ChatView.tsx
+++ b/crates/agent/ui/src/components/ChatView.tsx
@@ -152,7 +152,7 @@ export function ChatView() {
     };
   }, [sessionId, clearRateLimitState]);
 
-  // Keyboard shortcuts (Cmd+N, double Esc, etc. moved to AppShell)
+  // Keyboard shortcuts (Ctrl+X chords, double Esc, etc. moved to AppShell)
 
   const handleSendPrompt = async () => {
     if (!prompt.trim() || loading || !sessionId) return;
@@ -469,7 +469,7 @@ export function ChatView() {
                       </button>
                       <p className="text-xs text-ui-muted mt-3">
                         or press <kbd className="px-2 py-1 bg-surface-canvas border border-surface-border rounded text-accent-primary font-mono text-[10px]">
-                          {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}+N
+                          {navigator.platform.includes('Mac') ? '⌘+X N' : 'Ctrl+X N'}
                         </kbd> to create a session
                       </p>
                     </div>

--- a/crates/agent/ui/src/components/HomePage.tsx
+++ b/crates/agent/ui/src/components/HomePage.tsx
@@ -92,7 +92,7 @@ export function HomePage() {
           <p className="text-xs text-ui-muted mt-3">
             or press{' '}
             <kbd className="px-2 py-1 bg-surface-canvas border border-surface-border rounded text-accent-primary font-mono text-[10px]">
-              {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}+N
+              {navigator.platform.includes('Mac') ? '⌘+X N' : 'Ctrl+X N'}
             </kbd>{' '}
             to create a session
           </p>

--- a/crates/agent/ui/src/components/SessionPicker.tsx
+++ b/crates/agent/ui/src/components/SessionPicker.tsx
@@ -274,7 +274,7 @@ export function SessionPicker({ groups, onSelectSession, onNewSession, disabled,
           <p className="text-xs text-ui-muted mt-2">
             or press{' '}
             <kbd className="px-2 py-1 bg-surface-canvas border border-surface-border rounded text-accent-primary font-mono text-[10px]">
-              {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}+N
+              {navigator.platform.includes('Mac') ? '⌘+X N' : 'Ctrl+X N'}
             </kbd>{' '}
             to create a session, or{' '}
             <kbd className="px-2 py-1 bg-surface-canvas border border-surface-border rounded text-accent-primary font-mono text-[10px]">

--- a/crates/agent/ui/src/components/SessionSwitcher.tsx
+++ b/crates/agent/ui/src/components/SessionSwitcher.tsx
@@ -347,7 +347,7 @@ export function SessionSwitcher({
                 <Plus className="w-4 h-4 text-accent-primary flex-shrink-0" />
                 <span className="flex-1 text-sm text-ui-primary">New Session</span>
                 <kbd className="hidden sm:inline-block px-2 py-1 text-[10px] font-mono bg-surface-canvas border border-surface-border rounded text-ui-muted">
-                  {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}N
+                  {navigator.platform.includes('Mac') ? '⌘+X N' : 'Ctrl+X N'}
                 </kbd>
               </Command.Item>
             </Command.Group>

--- a/crates/agent/ui/src/components/ShortcutGateway.test.tsx
+++ b/crates/agent/ui/src/components/ShortcutGateway.test.tsx
@@ -7,6 +7,7 @@ describe('ShortcutGateway', () => {
   const defaultProps = {
     open: true,
     onOpenChange: vi.fn(),
+    onStartNewSession: vi.fn(),
     onSelectTheme: vi.fn(),
   };
 
@@ -17,8 +18,20 @@ describe('ShortcutGateway', () => {
   it('renders when open is true', () => {
     render(<ShortcutGateway {...defaultProps} />);
     expect(screen.getByText('Shortcut Gateway')).toBeInTheDocument();
+    expect(screen.getByText('Start New Session')).toBeInTheDocument();
     expect(screen.getByText('Theme Selector')).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/type command/i)).toBeInTheDocument();
+  });
+
+  it('calls onStartNewSession when clicking start new session command', async () => {
+    const user = userEvent.setup();
+    render(<ShortcutGateway {...defaultProps} />);
+
+    const startSessionItem = screen.getByText('Start New Session').closest('[cmdk-item]');
+    expect(startSessionItem).toBeTruthy();
+    await user.click(startSessionItem!);
+
+    expect(defaultProps.onStartNewSession).toHaveBeenCalledTimes(1);
   });
 
   it('does not render when open is false', () => {
@@ -52,6 +65,7 @@ describe('ShortcutGateway', () => {
 
     const input = screen.getByPlaceholderText(/type command/i);
     await user.click(input);
+    await user.type(input, 'theme');
     await user.keyboard('{ArrowDown}{Enter}');
 
     expect(defaultProps.onSelectTheme).toHaveBeenCalledTimes(1);

--- a/crates/agent/ui/src/components/ShortcutGateway.tsx
+++ b/crates/agent/ui/src/components/ShortcutGateway.tsx
@@ -1,18 +1,25 @@
 import { useEffect, useRef, useState } from 'react';
 import { Command } from 'cmdk';
-import { Keyboard, Palette } from 'lucide-react';
+import { Keyboard, Palette, Plus } from 'lucide-react';
 import { useUiStore } from '../store/uiStore';
 
 interface ShortcutGatewayProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onStartNewSession: () => void;
   onSelectTheme: () => void;
 }
 
-export function ShortcutGateway({ open, onOpenChange, onSelectTheme }: ShortcutGatewayProps) {
+export function ShortcutGateway({
+  open,
+  onOpenChange,
+  onStartNewSession,
+  onSelectTheme,
+}: ShortcutGatewayProps) {
   const [search, setSearch] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const { focusMainInput } = useUiStore();
+  const shortcutGatewayPrefix = navigator.platform.includes('Mac') ? '⌘+X' : 'Ctrl+X';
 
   const close = () => {
     onOpenChange(false);
@@ -63,7 +70,7 @@ export function ShortcutGateway({ open, onOpenChange, onSelectTheme }: ShortcutG
           </div>
 
           <div className="flex items-center gap-2 px-4 py-2.5 border-b border-surface-border/40">
-            <span className="text-xs text-ui-muted font-mono">Ctrl+X</span>
+            <span className="text-xs text-ui-muted font-mono">{shortcutGatewayPrefix}</span>
             <Command.Input
               ref={inputRef}
               value={search}
@@ -78,7 +85,25 @@ export function ShortcutGateway({ open, onOpenChange, onSelectTheme }: ShortcutG
               No shortcut commands found
             </Command.Empty>
 
-            <Command.Group heading="Available Commands" className="mb-1">
+            <Command.Group className="mb-1">
+              <Command.Item
+                value="start new session"
+                keywords={['new', 'session', 'start', 'n']}
+                onSelect={() => onStartNewSession()}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-surface-border/20 cursor-pointer transition-colors data-[selected=true]:bg-accent-primary/15 data-[selected=true]:border-accent-primary/35 hover:bg-surface-elevated/60 hover:border-surface-border/40"
+              >
+                <div className="w-7 h-7 rounded-md border border-accent-primary/35 bg-accent-primary/10 flex items-center justify-center">
+                  <Plus className="w-3.5 h-3.5 text-accent-primary" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm text-ui-primary">Start New Session</div>
+                  <div className="text-xs text-ui-muted">Create a fresh session and jump in</div>
+                </div>
+                <kbd className="px-2 py-1 text-[10px] font-mono bg-surface-canvas border border-surface-border rounded text-ui-secondary">
+                  N
+                </kbd>
+              </Command.Item>
+
               <Command.Item
                 value="theme selector"
                 keywords={['theme', 'themes', 't', 'palette']}

--- a/crates/agent/ui/src/components/WorkspacePathDialog.test.tsx
+++ b/crates/agent/ui/src/components/WorkspacePathDialog.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WorkspacePathDialog } from './WorkspacePathDialog';
+
+describe('WorkspacePathDialog', () => {
+  it('renders with the provided default value', () => {
+    render(
+      <WorkspacePathDialog
+        open={true}
+        defaultValue="/workspace/demo"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Workspace path (optional)')).toHaveValue('/workspace/demo');
+  });
+
+  it('calls onSubmit with the typed path', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <WorkspacePathDialog open={true} defaultValue="" onSubmit={onSubmit} onCancel={vi.fn()} />,
+    );
+
+    const input = screen.getByLabelText('Workspace path (optional)');
+    await user.type(input, '/tmp/new-workspace');
+    await user.click(screen.getByRole('button', { name: 'Start Session' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('/tmp/new-workspace');
+  });
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+
+    render(
+      <WorkspacePathDialog open={true} defaultValue="" onSubmit={vi.fn()} onCancel={onCancel} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crates/agent/ui/src/components/WorkspacePathDialog.tsx
+++ b/crates/agent/ui/src/components/WorkspacePathDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+
+interface WorkspacePathDialogProps {
+  open: boolean;
+  defaultValue: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}
+
+export function WorkspacePathDialog({
+  open,
+  defaultValue,
+  onSubmit,
+  onCancel,
+}: WorkspacePathDialogProps) {
+  const [workspacePath, setWorkspacePath] = useState(defaultValue);
+
+  useEffect(() => {
+    if (open) {
+      setWorkspacePath(defaultValue);
+    }
+  }, [open, defaultValue]);
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onCancel();
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-surface-canvas/75 backdrop-blur-sm animate-fade-in" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(92vw,560px)] -translate-x-1/2 -translate-y-1/2 rounded-xl border-2 border-accent-primary/30 bg-surface-elevated shadow-[0_0_40px_rgba(var(--accent-primary-rgb),0.25)] p-5">
+          <Dialog.Title className="text-base font-semibold text-accent-primary">
+            Start New Session
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-ui-secondary">
+            Set a workspace path for this session, or leave it blank.
+          </Dialog.Description>
+
+          <form
+            className="mt-4 space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              onSubmit(workspacePath);
+            }}
+          >
+            <div className="space-y-2">
+              <label htmlFor="workspace-path-input" className="text-xs font-mono text-ui-muted">
+                Workspace path (optional)
+              </label>
+              <input
+                id="workspace-path-input"
+                type="text"
+                value={workspacePath}
+                onChange={(event) => setWorkspacePath(event.target.value)}
+                placeholder="/path/to/workspace"
+                autoFocus
+                className="w-full rounded-lg border border-surface-border bg-surface-canvas px-3 py-2 text-sm text-ui-primary placeholder:text-ui-muted focus:border-accent-primary/60 focus:outline-none"
+              />
+            </div>
+
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="rounded-lg border border-surface-border bg-surface-canvas px-3 py-1.5 text-sm text-ui-secondary transition-colors hover:border-surface-border/80 hover:bg-surface-elevated"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-lg border border-accent-primary/50 bg-accent-primary/12 px-3 py-1.5 text-sm text-accent-primary transition-colors hover:bg-accent-primary/20"
+              >
+                Start Session
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/crates/agent/ui/src/types.ts
+++ b/crates/agent/ui/src/types.ts
@@ -324,6 +324,7 @@ export type UiServerMessage =
       routing_mode: RoutingMode;
       active_agent_id: string;
       active_session_id?: string | null;
+      default_cwd?: string | null;
       agents: UiAgentInfo[];
       sessions_by_agent: Record<string, string>;
       agent_mode: string;


### PR DESCRIPTION
Use a custom workspace-path modal for session creation and include default_cwd in UI state so new sessions have a reliable cwd when no active session exists.

<img width="1112" height="784" alt="image" src="https://github.com/user-attachments/assets/e70dfae0-fab3-41c6-9307-c90ad0cdbe3d" />

<img width="1033" height="421" alt="image" src="https://github.com/user-attachments/assets/6ef369c9-7feb-4597-8173-bdff9a0cc46a" />
