### PR TITLE
feat: added `qmtui` into install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = "Stop"
 
-$Repo = "querymt/querymt"
+$QuerymtRepo = "querymt/querymt"
+$QmtuiRepo = "querymt/qmtui"
 $Channel = if ($env:QMT_CHANNEL -eq "nightly") { "nightly" } else { "latest" }
 $InstallDir = if ($env:QMT_INSTALL_DIR) { $env:QMT_INSTALL_DIR } else { Join-Path $env:USERPROFILE ".local\bin" }
 
@@ -11,7 +12,16 @@ switch ($arch) {
     default { throw "Unsupported Windows architecture: $arch" }
 }
 
-function Get-ReleaseApiUrl {
+function Get-RepoForBinary([string]$Binary) {
+    switch ($Binary) {
+        "qmt" { return $QuerymtRepo }
+        "qmtcode" { return $QuerymtRepo }
+        "qmtui" { return $QmtuiRepo }
+        default { throw "Unsupported binary: $Binary" }
+    }
+}
+
+function Get-ReleaseApiUrl([string]$Repo) {
     if ($Channel -eq "nightly") {
         return "https://api.github.com/repos/$Repo/releases/tags/nightly"
     }
@@ -19,7 +29,8 @@ function Get-ReleaseApiUrl {
 }
 
 function Get-AssetUrl([string]$Binary) {
-    $release = Invoke-RestMethod -Uri (Get-ReleaseApiUrl)
+    $repo = Get-RepoForBinary -Binary $Binary
+    $release = Invoke-RestMethod -Uri (Get-ReleaseApiUrl -Repo $repo)
     if ($Channel -eq "nightly") {
         $regex = "^$Binary-nightly-.*-$Target\.zip$"
     } else {
@@ -28,7 +39,7 @@ function Get-AssetUrl([string]$Binary) {
 
     $asset = $release.assets | Where-Object { $_.name -match $regex } | Select-Object -First 1
     if (-not $asset) {
-        throw "Could not find asset for $Binary ($Target, $Channel)"
+        throw "Could not find asset for $Binary in $repo ($Target, $Channel)"
     }
 
     return $asset.browser_download_url
@@ -41,9 +52,10 @@ function Install-Binary([string]$Binary) {
     try {
         $zipPath = Join-Path $tmpRoot "$Binary.zip"
         $extractDir = Join-Path $tmpRoot "extract"
+        $repo = Get-RepoForBinary -Binary $Binary
 
         $url = Get-AssetUrl -Binary $Binary
-        Write-Host "Downloading $Binary ($Channel, $Target)..."
+        Write-Host "Downloading $Binary from $repo ($Channel, $Target)..."
         Invoke-WebRequest -Uri $url -OutFile $zipPath
 
         Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
@@ -61,8 +73,13 @@ function Install-Binary([string]$Binary) {
     }
 }
 
+function Show-Version([string]$Binary) {
+    & (Join-Path $InstallDir "$Binary.exe") --version
+}
+
 Install-Binary -Binary "qmt"
 Install-Binary -Binary "qmtcode"
+Install-Binary -Binary "qmtui"
 
 Write-Host "Installed to: $InstallDir"
 
@@ -77,5 +94,6 @@ if ($pathParts -notcontains $InstallDir) {
     Write-Host "Added $InstallDir to user PATH. Restart your shell to pick it up."
 }
 
-& (Join-Path $InstallDir "qmt.exe") --version
-& (Join-Path $InstallDir "qmtcode.exe") --version
+Show-Version -Binary "qmt"
+Show-Version -Binary "qmtcode"
+Show-Version -Binary "qmtui"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -eu
 
-REPO="querymt/querymt"
+QUERYMT_REPO="querymt/querymt"
+QMTUI_REPO="querymt/qmtui"
 INSTALL_DIR="${QMT_INSTALL_DIR:-$HOME/.local/bin}"
 CHANNEL="latest"
 
@@ -17,7 +18,7 @@ while [ "$#" -gt 0 ]; do
             cat <<'EOF'
 Usage: install.sh [--nightly|--latest]
 
-Installs qmt and qmtcode into ~/.local/bin (or $QMT_INSTALL_DIR).
+Installs qmt, qmtcode, and qmtui into ~/.local/bin (or $QMT_INSTALL_DIR).
 Set QMT_CHANNEL=nightly as an alternative to --nightly.
 EOF
             exit 0
@@ -95,17 +96,30 @@ else
 fi
 
 release_api_url() {
+    repo="$1"
+
     if [ "$CHANNEL" = "nightly" ]; then
-        echo "https://api.github.com/repos/$REPO/releases/tags/nightly"
+        echo "https://api.github.com/repos/$repo/releases/tags/nightly"
     else
-        echo "https://api.github.com/repos/$REPO/releases/latest"
+        echo "https://api.github.com/repos/$repo/releases/latest"
     fi
+}
+
+repo_for_binary() {
+    binary="$1"
+
+    case "$binary" in
+        qmt|qmtcode) printf '%s\n' "$QUERYMT_REPO" ;;
+        qmtui) printf '%s\n' "$QMTUI_REPO" ;;
+        *) echo "Unsupported binary: $binary" >&2; exit 1 ;;
+    esac
 }
 
 asset_url_for() {
     binary="$1"
+    repo="$(repo_for_binary "$binary")"
 
-    json="$(fetch_text "$(release_api_url)")"
+    json="$(fetch_text "$(release_api_url "$repo")")"
     urls="$(printf '%s' "$json" | grep -o '"browser_download_url":[[:space:]]*"[^"]*"' | sed 's/^"browser_download_url":[[:space:]]*"//; s/"$//')"
 
     if [ "$CHANNEL" = "nightly" ]; then
@@ -116,7 +130,7 @@ asset_url_for() {
 
     url="$(printf '%s\n' "$urls" | grep -E "$pattern" | head -n 1 || true)"
     if [ -z "$url" ]; then
-        echo "Could not find asset for ${binary} (${TARGET}, ${CHANNEL})" >&2
+        echo "Could not find asset for ${binary} in ${repo} (${TARGET}, ${CHANNEL})" >&2
         exit 1
     fi
 
@@ -131,9 +145,10 @@ mkdir -p "$INSTALL_DIR"
 install_binary() {
     binary="$1"
     archive="$TMP_DIR/${binary}.${EXT}"
+    repo="$(repo_for_binary "$binary")"
     url="$(asset_url_for "$binary")"
 
-    echo "Downloading ${binary} (${CHANNEL}, ${TARGET})..."
+    echo "Downloading ${binary} from ${repo} (${CHANNEL}, ${TARGET})..."
     fetch_file "$url" "$archive"
 
     extract_dir="$TMP_DIR/extract-${binary}"
@@ -149,20 +164,24 @@ install_binary() {
     install -m 0755 "$src" "$INSTALL_DIR/$binary"
 }
 
+print_version() {
+    binary="$1"
+
+    if command -v "$binary" >/dev/null 2>&1; then
+        "$binary" --version || true
+    else
+        "$INSTALL_DIR/$binary" --version || true
+    fi
+}
+
 install_binary "qmt"
 install_binary "qmtcode"
+install_binary "qmtui"
 
 echo "Installed to: $INSTALL_DIR"
-if command -v qmt >/dev/null 2>&1; then
-    qmt --version || true
-else
-    "$INSTALL_DIR/qmt" --version || true
-fi
-if command -v qmtcode >/dev/null 2>&1; then
-    qmtcode --version || true
-else
-    "$INSTALL_DIR/qmtcode" --version || true
-fi
+print_version "qmt"
+print_version "qmtcode"
+print_version "qmtui"
 
 case ":$PATH:" in
     *":$INSTALL_DIR:"*) ;;


### PR DESCRIPTION
@vigsterkr  tested on Linux only

```
$ bash install.sh
Downloading qmt from querymt/querymt (latest, x86_64-unknown-linux-musl)...
Downloading qmtcode from querymt/querymt (latest, x86_64-unknown-linux-musl)...
Downloading qmtui from querymt/qmtui (latest, x86_64-unknown-linux-musl)...
Installed to: /home/ivan/.local/bin
qmt 0.2.5
qmtcode 0.2.5
qmtui 0.1.1
Add to PATH if needed: export PATH="/home/ivan/.local/bin:$PATH"
```