### PR TITLE
fix(agent): respect inline api_key from provider config before external credential resolution

### DIFF
--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -586,6 +586,17 @@ impl SessionProvider {
 
             let api_key = if let Some(key) = api_key_override {
                 Some(key.to_string())
+            } else if let Some(serde_json::Value::String(key)) = builder_config
+                .get("api_key")
+                .filter(|v| v.as_str().is_some_and(|s| !s.is_empty()))
+            {
+                // API key already present in builder_config from params or
+                // static provider config — use it directly.
+                log::debug!(
+                    "Using inline API key from config for provider '{}'",
+                    provider_name
+                );
+                Some(key.clone())
             } else {
                 let preferred_method = preferred_auth_method(provider_name);
 


### PR DESCRIPTION


The build_provider() method ignored api_key values already present in builder_config (injected via static provider config or params merge) and unconditionally fell through to OAuth/keyring/env-var resolution. When all external sources failed, it errored with "No API key found" even though a valid key was already available.