### PR TITLE
feat(remote): remote session handling and resuming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10700,7 +10700,7 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "qmt-alibaba"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "extism-pdk",
  "futures",
@@ -10716,7 +10716,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-anthropic"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "extism-pdk",
@@ -10732,7 +10732,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-codex"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "extism-pdk",
@@ -10749,7 +10749,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-deepseek"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "extism-pdk",
  "http 1.4.0",
@@ -10764,7 +10764,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-google"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "extism-pdk",
@@ -10779,7 +10779,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-groq"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "either",
  "extism-pdk",
@@ -10796,7 +10796,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-izwi"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10812,7 +10812,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-kimi-code"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "extism-pdk",
  "http 1.4.0",
@@ -10829,7 +10829,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-llama-cpp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -10849,7 +10849,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-mistral"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "either",
  "extism-pdk",
@@ -10866,7 +10866,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-moonshot"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "either",
  "extism-pdk",
@@ -10883,7 +10883,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-mrs"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -10902,7 +10902,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-ollama"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "extism-pdk",
@@ -10918,7 +10918,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-openai"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "either",
  "extism-pdk",
@@ -10934,7 +10934,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-openrouter"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "extism-pdk",
  "futures",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-xai"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "either",
  "extism-pdk",
@@ -10967,7 +10967,7 @@ dependencies = [
 
 [[package]]
 name = "qmt-zai"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "extism-pdk",
  "http 1.4.0",
@@ -11000,7 +11000,7 @@ dependencies = [
 
 [[package]]
 name = "querymt"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11043,7 +11043,7 @@ dependencies = [
 
 [[package]]
 name = "querymt-agent"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -11133,7 +11133,7 @@ dependencies = [
 
 [[package]]
 name = "querymt-cli"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "querymt-extism-macros"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "extism-pdk",
@@ -11172,7 +11172,7 @@ dependencies = [
 
 [[package]]
 name = "querymt-provider-common"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "dirs 6.0.0",
  "hf-hub 0.5.0",
@@ -11182,7 +11182,7 @@ dependencies = [
 
 [[package]]
 name = "querymt-utils"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anthropic-auth",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 

--- a/crates/agent/examples/confs/single_coder.toml
+++ b/crates/agent/examples/confs/single_coder.toml
@@ -122,7 +122,7 @@ max_turns = 50
 type = "context"
 warn_at_percent = 80
 compact_at_percent = 90
-fallback_max_tokens = 128000
+fallback_max_tokens = 150000
 
 # Detect when code is similar to existing code
 [[middleware]]

--- a/crates/agent/src/agent/execution/llm_retry.rs
+++ b/crates/agent/src/agent/execution/llm_retry.rs
@@ -110,9 +110,21 @@ where
                     );
 
                     continue;
+                } else if is_transient_error(&e) && attempt < max_retries {
+                    Span::current().record("rate_limited", false);
+                    let wait_secs =
+                        calculate_rate_limit_wait(config, e.retry_after_secs(), attempt);
+                    debug!(
+                        "Session {} transient setup error on attempt {}, retrying in {}s: {}",
+                        session_id, attempt, wait_secs, e
+                    );
+                    let cancelled = wait_with_cancellation(wait_secs, cancel_token).await;
+                    if cancelled {
+                        return Err(anyhow::anyhow!("Cancelled during retry wait"));
+                    }
+                    continue;
                 } else {
                     Span::current().record("rate_limited", false);
-                    // Convert non-rate-limit errors to anyhow::Error
                     return Err(anyhow::Error::from(e));
                 }
             }
@@ -160,6 +172,11 @@ fn extract_rate_limit_info(error: &LLMError) -> Option<(String, Option<u64>)> {
             message,
             retry_after_secs,
         } => Some((message.clone(), *retry_after_secs)),
+        LLMError::HttpStatus {
+            status_code,
+            message,
+            retry_after_secs,
+        } if *status_code == 429 => Some((message.clone(), *retry_after_secs)),
         _ => None,
     }
 }
@@ -248,14 +265,13 @@ where
 
                     continue;
                 } else if is_transient_error(&e) && attempt < max_retries {
-                    // Transient errors get exponential backoff
-                    let delay_secs = config.execution_policy.rate_limit.default_wait_secs
-                        * 2u64.saturating_pow(attempt as u32 - 1);
+                    let wait_secs =
+                        calculate_rate_limit_wait(config, e.retry_after_secs(), attempt);
                     debug!(
                         "Session {} transient stream error on attempt {}, retrying in {}s: {}",
-                        session_id, attempt, delay_secs, e
+                        session_id, attempt, wait_secs, e
                     );
-                    let cancelled = wait_with_cancellation(delay_secs, cancel_token).await;
+                    let cancelled = wait_with_cancellation(wait_secs, cancel_token).await;
                     if cancelled {
                         return Err(anyhow::anyhow!("Cancelled during retry wait"));
                     }
@@ -268,9 +284,9 @@ where
     }
 }
 
-/// Returns true for errors that are worth retrying (connection-level failures).
+/// Returns true for setup errors that are worth retrying.
 fn is_transient_error(e: &LLMError) -> bool {
-    matches!(e, LLMError::HttpError(_))
+    e.is_retryable_setup_failure()
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -411,7 +427,20 @@ mod tests {
 
     #[test]
     fn test_is_transient_error_http_error() {
-        let err = LLMError::HttpError("connection reset".to_string());
+        let err = LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::ConnectionReset,
+            message: "connection reset".to_string(),
+        };
+        assert!(is_transient_error(&err));
+    }
+
+    #[test]
+    fn test_is_transient_error_http_status_503() {
+        let err = LLMError::HttpStatus {
+            status_code: 503,
+            message: "upstream unavailable".to_string(),
+            retry_after_secs: None,
+        };
         assert!(is_transient_error(&err));
     }
 
@@ -420,10 +449,6 @@ mod tests {
         assert!(!is_transient_error(&LLMError::GenericError(
             "oops".to_string()
         )));
-        assert!(!is_transient_error(&LLMError::RateLimited {
-            message: "rate".to_string(),
-            retry_after_secs: None,
-        }));
     }
 
     // ── wait_with_cancellation tests ─────────────────────────────────────────
@@ -496,6 +521,36 @@ mod tests {
 
         // Non-rate-limit errors should fail immediately without retrying
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_call_llm_with_retry_retries_transient_setup_errors() {
+        let (config, _temp) = make_config().await;
+        let token = CancellationToken::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+
+        let result = call_llm_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            async move {
+                let attempt = count.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Err::<Box<dyn ChatResponse>, _>(LLMError::HttpStatus {
+                        status_code: 503,
+                        message: "upstream connect error".to_string(),
+                        retry_after_secs: Some(0),
+                    })
+                } else {
+                    Ok::<Box<dyn ChatResponse>, _>(Box::new(
+                        crate::test_utils::MockChatResponse::text_only("ok"),
+                    ) as Box<dyn ChatResponse>)
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/agent/src/agent/execution/llm_retry.rs
+++ b/crates/agent/src/agent/execution/llm_retry.rs
@@ -286,7 +286,7 @@ where
 
 /// Returns true for setup errors that are worth retrying.
 fn is_transient_error(e: &LLMError) -> bool {
-    e.is_retryable_setup_failure()
+    e.is_retryable()
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -430,6 +430,29 @@ mod tests {
         let err = LLMError::Transport {
             kind: querymt::error::TransportErrorKind::ConnectionReset,
             message: "connection reset".to_string(),
+        };
+        assert!(is_transient_error(&err));
+    }
+
+    #[test]
+    fn test_is_transient_error_http_error_generic() {
+        // HttpError (previously "error decoding response body" fell through here)
+        let err = LLMError::HttpError("error decoding response body".to_string());
+        assert!(is_transient_error(&err));
+    }
+
+    #[test]
+    fn test_is_transient_error_plugin_error() {
+        let err = LLMError::PluginError("wasm stream failed".to_string());
+        assert!(is_transient_error(&err));
+    }
+
+    #[test]
+    fn test_is_transient_error_transport_body() {
+        // The new typed path for reqwest is_body() errors
+        let err = LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::Other,
+            message: "error decoding response body".to_string(),
         };
         assert!(is_transient_error(&err));
     }

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -231,6 +231,8 @@ pub(super) async fn transition_call_llm(
             let mut tool_call_ids = std::collections::HashSet::new();
             #[allow(unused_assignments)]
             let mut usage: Option<querymt::Usage> = None;
+            #[allow(unused_assignments)]
+            let mut stream_finish_reason: Option<FinishReason> = None;
 
             // Batching buffers — we flush at most every 50ms or 256 chars to
             // avoid per-token React state updates on fast local models.
@@ -298,6 +300,7 @@ pub(super) async fn transition_call_llm(
                 stream_tool_calls.clear();
                 tool_call_ids.clear();
                 usage = None;
+                stream_finish_reason = None;
                 text_buffer.clear();
                 thinking_buffer.clear();
                 last_flush = Instant::now();
@@ -443,10 +446,11 @@ pub(super) async fn transition_call_llm(
                                 None => u,
                             });
                         }
-                        StreamChunk::Done { .. } => {
+                        StreamChunk::Done { finish_reason } => {
+                            stream_finish_reason = Some(finish_reason);
                             trace!(
-                                "stream chunk: session={} message_id={} type=done",
-                                session_id, message_id
+                                "stream chunk: session={} message_id={} type=done finish_reason={:?}",
+                                session_id, message_id, finish_reason
                             );
                             // Some providers emit Usage AFTER Done in the same SSE
                             // batch. Drain remaining items to capture any trailing
@@ -509,11 +513,16 @@ pub(super) async fn transition_call_llm(
                 return Ok(ExecutionState::Cancelled);
             }
 
-            let finish_reason = if stream_tool_calls.is_empty() {
-                Some(FinishReason::Stop)
-            } else {
-                Some(FinishReason::ToolCalls)
-            };
+            // Use the provider-mapped finish_reason from the Done chunk.
+            // Fall back to a tool-call heuristic when the stream ended
+            // without a Done chunk (e.g. unexpected EOF).
+            let finish_reason = stream_finish_reason.or({
+                if stream_tool_calls.is_empty() {
+                    Some(FinishReason::Stop)
+                } else {
+                    Some(FinishReason::ToolCalls)
+                }
+            });
 
             // Stash message_id in response so transition_after_llm reuses it
             // (see LlmResponse::with_message_id)

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -209,7 +209,7 @@ pub(super) async fn transition_call_llm(
         let provider = session_handle
             .provider()
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to build provider: {}", e))?;
+            .map_err(|e| anyhow::Error::from(e).context("Failed to build provider"))?;
 
         if provider.supports_streaming() {
             // === STREAMING PATH (all capable providers) ===
@@ -319,7 +319,7 @@ pub(super) async fn transition_call_llm(
                         );
                         continue;
                     }
-                    Err(e) => return Err(anyhow::anyhow!("LLM streaming error: {}", e)),
+                    Err(e) => return Err(anyhow::Error::from(e).context("LLM streaming error")),
                 };
 
                 match chunk {

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -216,34 +216,27 @@ pub(super) async fn transition_call_llm(
             let message_id = Uuid::new_v4().to_string();
             streaming_message_id = Some(message_id.clone());
 
-            let mut stream = super::llm_retry::create_stream_with_retry(
-                config,
-                session_id,
-                &exec_ctx.cancellation_token,
-                || {
-                    let provider = &provider;
-                    let messages_with_cache = &messages_with_cache;
-                    let tools_slice = tools.as_ref();
-                    async move {
-                        provider
-                            .chat_stream_with_tools(messages_with_cache, Some(tools_slice))
-                            .await
-                    }
-                },
-            )
-            .await?;
+            let max_stream_retries = config.execution_policy.rate_limit.max_stream_retries;
 
+            // Accumulators live outside the retry loop so the post-stream
+            // processing below can read them regardless of how many attempts
+            // were needed.  On each retry they are reset to empty.
             let mut text = String::new();
             let mut thinking = String::new();
+            // Initial values are always overwritten inside the retry loop below
+            // before first read, so suppress the unused-assignment lint.
+            #[allow(unused_assignments)]
             let mut thinking_signature: Option<String> = None;
             let mut stream_tool_calls: Vec<ToolCall> = Vec::new();
             let mut tool_call_ids = std::collections::HashSet::new();
+            #[allow(unused_assignments)]
             let mut usage: Option<querymt::Usage> = None;
 
             // Batching buffers — we flush at most every 50ms or 256 chars to
             // avoid per-token React state updates on fast local models.
             let mut text_buffer = String::new();
             let mut thinking_buffer = String::new();
+            #[allow(unused_assignments)]
             let mut last_flush = Instant::now();
             const BATCH_INTERVAL: Duration = Duration::from_millis(50);
             const BATCH_CHARS: usize = 256;
@@ -291,149 +284,211 @@ pub(super) async fn transition_call_llm(
                 };
             }
 
-            loop {
-                let item = tokio::select! {
-                    item = stream.next() => item,
-                    _ = exec_ctx.cancellation_token.cancelled() => {
-                        return Ok(ExecutionState::Cancelled);
-                    }
-                };
+            // ── Outer retry loop ─────────────────────────────────────────────
+            // On transient mid-stream errors we discard accumulated text and
+            // re-create the stream.  The provider treats it as a fresh request.
+            let mut stream_attempt = 0;
+            'stream: loop {
+                stream_attempt += 1;
 
-                let Some(item) = item else {
-                    break;
-                };
+                // Reset accumulators on retry so we start fresh.
+                text.clear();
+                thinking.clear();
+                thinking_signature = None;
+                stream_tool_calls.clear();
+                tool_call_ids.clear();
+                usage = None;
+                text_buffer.clear();
+                thinking_buffer.clear();
+                last_flush = Instant::now();
 
-                let chunk = match item {
-                    Ok(chunk) => chunk,
-                    Err(LLMError::RemoteStreamDisconnected { message }) => {
-                        flush_buffers!(true);
-                        config.emit_event(
-                            session_id,
-                            AgentEventKind::RemoteStreamDisconnected {
-                                message,
-                                message_id: Some(message_id.clone()),
-                            },
-                        );
-                        continue;
-                    }
-                    Err(LLMError::RemoteStreamReconnected { message }) => {
-                        config.emit_event(
-                            session_id,
-                            AgentEventKind::RemoteStreamReconnected {
-                                message,
-                                message_id: Some(message_id.clone()),
-                            },
-                        );
-                        continue;
-                    }
-                    Err(e) => return Err(anyhow::Error::from(e).context("LLM streaming error")),
-                };
-
-                match chunk {
-                    StreamChunk::Text(delta) => {
-                        trace!(
-                            "stream chunk: session={} message_id={} type=text len={}",
-                            session_id,
-                            message_id,
-                            delta.len()
-                        );
-                        text.push_str(&delta);
-                        text_buffer.push_str(&delta);
-                    }
-                    StreamChunk::Thinking(delta) => {
-                        trace!(
-                            "stream chunk: session={} message_id={} type=thinking len={}",
-                            session_id,
-                            message_id,
-                            delta.len()
-                        );
-                        thinking.push_str(&delta);
-                        thinking_buffer.push_str(&delta);
-                    }
-                    StreamChunk::ThinkingSignature(signature) => {
-                        trace!(
-                            "stream chunk: session={} message_id={} type=thinking_signature len={}",
-                            session_id,
-                            message_id,
-                            signature.len()
-                        );
-                        thinking_signature = Some(signature);
-                    }
-                    StreamChunk::ToolUseComplete { tool_call, .. } => {
-                        // Flush before tool use so UI sees final text before tool starts
-                        trace!(
-                            "stream chunk: session={} message_id={} type=tool_use_complete id={}",
-                            session_id, message_id, tool_call.id
-                        );
-                        flush_buffers!(true);
-                        if tool_call_ids.insert(tool_call.id.clone()) {
-                            stream_tool_calls.push(tool_call);
+                let mut stream = super::llm_retry::create_stream_with_retry(
+                    config,
+                    session_id,
+                    &exec_ctx.cancellation_token,
+                    || {
+                        let provider = &provider;
+                        let messages_with_cache = &messages_with_cache;
+                        let tools_slice = tools.as_ref();
+                        async move {
+                            provider
+                                .chat_stream_with_tools(messages_with_cache, Some(tools_slice))
+                                .await
                         }
-                    }
-                    StreamChunk::Usage(u) => {
-                        trace!(
-                            "stream chunk: session={} message_id={} type=usage input={} output={} reasoning={}",
-                            session_id,
-                            message_id,
-                            u.input_tokens,
-                            u.output_tokens,
-                            u.reasoning_tokens
-                        );
-                        // Anthropic (and potentially other providers) split usage across
-                        // multiple streaming events: `input_tokens` arrives in
-                        // `message_start`, while cumulative `output_tokens` arrives in
-                        // `message_delta`.  Taking the field-wise maximum merges both
-                        // events correctly regardless of order.
-                        usage = Some(match usage {
-                            Some(prev) => prev.merge_max(u),
-                            None => u,
-                        });
-                    }
-                    StreamChunk::Done { .. } => {
-                        trace!(
-                            "stream chunk: session={} message_id={} type=done",
-                            session_id, message_id
-                        );
-                        // Some providers emit Usage AFTER Done in the same SSE
-                        // batch. Drain remaining items to capture any trailing
-                        // Usage events before exiting the loop.
-                        loop {
-                            let remaining = tokio::select! {
-                                remaining = stream.next() => remaining,
-                                _ = exec_ctx.cancellation_token.cancelled() => {
-                                    return Ok(ExecutionState::Cancelled);
-                                }
-                            };
-                            let Some(remaining) = remaining else {
-                                break;
-                            };
-                            match remaining {
-                                Ok(StreamChunk::Usage(u)) => {
-                                    trace!(
-                                        "stream chunk: session={} message_id={} type=usage (post-done drain) input={} output={}",
-                                        session_id, message_id, u.input_tokens, u.output_tokens
-                                    );
-                                    usage = Some(match usage {
-                                        Some(prev) => prev.merge_max(u),
-                                        None => u,
-                                    });
-                                }
-                                Err(_) | Ok(_) => break,
+                    },
+                )
+                .await?;
+
+                // ── Inner consume loop ───────────────────────────────────────
+                loop {
+                    let item = tokio::select! {
+                        item = stream.next() => item,
+                        _ = exec_ctx.cancellation_token.cancelled() => {
+                            return Ok(ExecutionState::Cancelled);
+                        }
+                    };
+
+                    let Some(item) = item else {
+                        break 'stream;
+                    };
+
+                    let chunk = match item {
+                        Ok(chunk) => chunk,
+                        Err(LLMError::RemoteStreamDisconnected { message }) => {
+                            flush_buffers!(true);
+                            config.emit_event(
+                                session_id,
+                                AgentEventKind::RemoteStreamDisconnected {
+                                    message,
+                                    message_id: Some(message_id.clone()),
+                                },
+                            );
+                            continue;
+                        }
+                        Err(LLMError::RemoteStreamReconnected { message }) => {
+                            config.emit_event(
+                                session_id,
+                                AgentEventKind::RemoteStreamReconnected {
+                                    message,
+                                    message_id: Some(message_id.clone()),
+                                },
+                            );
+                            continue;
+                        }
+                        Err(e) if e.is_retryable() && stream_attempt <= max_stream_retries => {
+                            debug!(
+                                "Session {}: retryable mid-stream error on attempt {}/{}: {}",
+                                session_id, stream_attempt, max_stream_retries, e
+                            );
+                            flush_buffers!(true);
+                            config.emit_event(
+                                session_id,
+                                AgentEventKind::StreamRecovering {
+                                    message: e.to_string(),
+                                    attempt: u32_from_usize(
+                                        stream_attempt,
+                                        "stream_attempt",
+                                        Some(session_id),
+                                    ),
+                                    max_attempts: u32_from_usize(
+                                        max_stream_retries,
+                                        "max_stream_retries",
+                                        Some(session_id),
+                                    ),
+                                    message_id: Some(message_id.clone()),
+                                },
+                            );
+                            continue 'stream; // retry with fresh stream + accumulators
+                        }
+                        Err(e) => return Err(anyhow::Error::from(e).context("LLM streaming error")),
+                    };
+
+                    match chunk {
+                        StreamChunk::Text(delta) => {
+                            trace!(
+                                "stream chunk: session={} message_id={} type=text len={}",
+                                session_id,
+                                message_id,
+                                delta.len()
+                            );
+                            text.push_str(&delta);
+                            text_buffer.push_str(&delta);
+                        }
+                        StreamChunk::Thinking(delta) => {
+                            trace!(
+                                "stream chunk: session={} message_id={} type=thinking len={}",
+                                session_id,
+                                message_id,
+                                delta.len()
+                            );
+                            thinking.push_str(&delta);
+                            thinking_buffer.push_str(&delta);
+                        }
+                        StreamChunk::ThinkingSignature(signature) => {
+                            trace!(
+                                "stream chunk: session={} message_id={} type=thinking_signature len={}",
+                                session_id,
+                                message_id,
+                                signature.len()
+                            );
+                            thinking_signature = Some(signature);
+                        }
+                        StreamChunk::ToolUseComplete { tool_call, .. } => {
+                            // Flush before tool use so UI sees final text before tool starts
+                            trace!(
+                                "stream chunk: session={} message_id={} type=tool_use_complete id={}",
+                                session_id, message_id, tool_call.id
+                            );
+                            flush_buffers!(true);
+                            if tool_call_ids.insert(tool_call.id.clone()) {
+                                stream_tool_calls.push(tool_call);
                             }
                         }
-                        break;
+                        StreamChunk::Usage(u) => {
+                            trace!(
+                                "stream chunk: session={} message_id={} type=usage input={} output={} reasoning={}",
+                                session_id,
+                                message_id,
+                                u.input_tokens,
+                                u.output_tokens,
+                                u.reasoning_tokens
+                            );
+                            // Anthropic (and potentially other providers) split usage across
+                            // multiple streaming events: `input_tokens` arrives in
+                            // `message_start`, while cumulative `output_tokens` arrives in
+                            // `message_delta`.  Taking the field-wise maximum merges both
+                            // events correctly regardless of order.
+                            usage = Some(match usage {
+                                Some(prev) => prev.merge_max(u),
+                                None => u,
+                            });
+                        }
+                        StreamChunk::Done { .. } => {
+                            trace!(
+                                "stream chunk: session={} message_id={} type=done",
+                                session_id, message_id
+                            );
+                            // Some providers emit Usage AFTER Done in the same SSE
+                            // batch. Drain remaining items to capture any trailing
+                            // Usage events before exiting the loop.
+                            loop {
+                                let remaining = tokio::select! {
+                                    remaining = stream.next() => remaining,
+                                    _ = exec_ctx.cancellation_token.cancelled() => {
+                                        return Ok(ExecutionState::Cancelled);
+                                    }
+                                };
+                                let Some(remaining) = remaining else {
+                                    break;
+                                };
+                                match remaining {
+                                    Ok(StreamChunk::Usage(u)) => {
+                                        trace!(
+                                            "stream chunk: session={} message_id={} type=usage (post-done drain) input={} output={}",
+                                            session_id, message_id, u.input_tokens, u.output_tokens
+                                        );
+                                        usage = Some(match usage {
+                                            Some(prev) => prev.merge_max(u),
+                                            None => u,
+                                        });
+                                    }
+                                    Err(_) | Ok(_) => break,
+                                }
+                            }
+                            break 'stream;
+                        }
+                        _ => {}
                     }
-                    _ => {}
-                }
 
-                // Time- or size-based flush
-                if last_flush.elapsed() >= BATCH_INTERVAL
-                    || text_buffer.len() >= BATCH_CHARS
-                    || thinking_buffer.len() >= BATCH_CHARS
-                {
-                    flush_buffers!(true);
-                }
-            }
+                    // Time- or size-based flush
+                    if last_flush.elapsed() >= BATCH_INTERVAL
+                        || text_buffer.len() >= BATCH_CHARS
+                        || thinking_buffer.len() >= BATCH_CHARS
+                    {
+                        flush_buffers!(true);
+                    }
+                } // end inner consume loop
+            } // end outer retry loop ('stream)
 
             // Final flush of any remaining buffered content (no timer reset needed)
             flush_buffers!(false);

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -291,10 +291,17 @@ pub(super) async fn transition_call_llm(
                 };
             }
 
-            while let Some(item) = stream.next().await {
-                if exec_ctx.cancellation_token.is_cancelled() {
-                    return Ok(ExecutionState::Cancelled);
-                }
+            loop {
+                let item = tokio::select! {
+                    item = stream.next() => item,
+                    _ = exec_ctx.cancellation_token.cancelled() => {
+                        return Ok(ExecutionState::Cancelled);
+                    }
+                };
+
+                let Some(item) = item else {
+                    break;
+                };
 
                 let chunk = match item {
                     Ok(chunk) => chunk,
@@ -390,7 +397,16 @@ pub(super) async fn transition_call_llm(
                         // Some providers emit Usage AFTER Done in the same SSE
                         // batch. Drain remaining items to capture any trailing
                         // Usage events before exiting the loop.
-                        while let Some(remaining) = stream.next().await {
+                        loop {
+                            let remaining = tokio::select! {
+                                remaining = stream.next() => remaining,
+                                _ = exec_ctx.cancellation_token.cancelled() => {
+                                    return Ok(ExecutionState::Cancelled);
+                                }
+                            };
+                            let Some(remaining) = remaining else {
+                                break;
+                            };
                             match remaining {
                                 Ok(StreamChunk::Usage(u)) => {
                                     trace!(

--- a/crates/agent/src/agent/handle.rs
+++ b/crates/agent/src/agent/handle.rs
@@ -1251,85 +1251,44 @@ impl LocalAgentHandle {
             .map_err(|e| agent_client_protocol::Error::from(AgentError::RemoteActor(e.to_string())))
     }
 
-    /// Create a session on a remote node and attach it to the local registry.
+    /// Create a session on a remote node and return the owning node's live session ref.
     ///
-    /// 1. Sends `CreateRemoteSession` to the remote `RemoteNodeManager`
-    /// 2. Gets back `(session_id, actor_id)` for the new remote `SessionActor`
-    /// 3. Looks up `RemoteActorRef<SessionActor>` by the session-scoped DHT name
-    ///    that `RemoteNodeManager` registered under `"session::{session_id}"`.
-    /// 4. Calls `attach_remote_session` on the local registry to insert it
-    ///    and set up event relay
-    ///
-    /// Returns the new session's ID and a `SessionActorRef` for it.
+    /// Callers can immediately finalize local attachment from the returned capability
+    /// while DHT registration continues as background discoverability for reconnects.
     #[cfg(feature = "remote")]
     pub async fn create_remote_session(
         &self,
         node_manager_ref: &kameo::actor::RemoteActorRef<crate::agent::remote::RemoteNodeManager>,
-        remote_node_id: String,
-        peer_label: String,
         cwd: Option<String>,
-    ) -> Result<(String, crate::agent::remote::SessionActorRef), agent_client_protocol::Error> {
+    ) -> Result<crate::agent::remote::CreateRemoteSessionResponse, agent_client_protocol::Error>
+    {
         use crate::agent::remote::CreateRemoteSession;
-        use crate::agent::session_actor::SessionActor;
-
         use crate::error::AgentError;
-        let mesh = self
-            .mesh()
-            .ok_or_else(|| agent_client_protocol::Error::from(AgentError::MeshNotBootstrapped))?;
 
-        let resp = node_manager_ref
+        node_manager_ref
             .ask(&CreateRemoteSession { cwd })
             .await
-            .map_err(|e| {
-                agent_client_protocol::Error::from(AgentError::RemoteActor(e.to_string()))
-            })?;
+            .map_err(|e| agent_client_protocol::Error::from(AgentError::RemoteActor(e.to_string())))
+    }
 
-        let session_id = resp.session_id.clone();
+    /// Fork a session on a remote node and return the forked child's live session ref.
+    #[cfg(feature = "remote")]
+    pub async fn fork_remote_session(
+        &self,
+        node_manager_ref: &kameo::actor::RemoteActorRef<crate::agent::remote::RemoteNodeManager>,
+        source_session_id: String,
+        message_id: String,
+    ) -> Result<crate::agent::remote::ForkRemoteSessionResponse, agent_client_protocol::Error> {
+        use crate::agent::remote::ForkRemoteSession;
+        use crate::error::AgentError;
 
-        // Resolve the RemoteActorRef<SessionActor> via DHT lookup.
-        // RemoteNodeManager registers the session under "session::{session_id}"
-        // in its CreateRemoteSession handler once the swarm is up.
-        let dht_name = crate::agent::remote::dht_name::session(&session_id);
-        let remote_session_ref = mesh
-            .lookup_actor::<SessionActor>(dht_name.clone())
+        node_manager_ref
+            .ask(&ForkRemoteSession {
+                source_session_id,
+                message_id,
+            })
             .await
-            .map_err(|e| {
-                agent_client_protocol::Error::from(AgentError::SwarmLookupFailed {
-                    key: dht_name.clone(),
-                    reason: e.to_string(),
-                })
-            })?
-            .ok_or_else(|| {
-                agent_client_protocol::Error::from(AgentError::RemoteSessionNotFound {
-                    details: format!(
-                        "session {} (actor_id={}) not found in DHT under '{}'; \
-                     remote node may not have registered it yet",
-                        session_id, resp.actor_id, dht_name
-                    ),
-                })
-            })?;
-
-        // Attach to local registry (spawns EventRelayActor, sends SubscribeEvents)
-        // Persist the remote owner node id (not our local node id).
-        let node_id_str = remote_node_id;
-        let mut registry = self.registry.lock().await;
-        let session_actor_ref = registry
-            .attach_remote_session(
-                session_id.clone(),
-                remote_session_ref,
-                peer_label,
-                Some(mesh),
-                Some(node_id_str),
-            )
-            .await;
-
-        log::info!(
-            "create_remote_session: attached {} from DHT lookup '{}'",
-            session_id,
-            dht_name
-        );
-
-        Ok((session_id, session_actor_ref))
+            .map_err(|e| agent_client_protocol::Error::from(AgentError::RemoteActor(e.to_string())))
     }
 
     /// Attach an existing remote session (already has a `RemoteActorRef`) to

--- a/crates/agent/src/agent/handle.rs
+++ b/crates/agent/src/agent/handle.rs
@@ -1311,6 +1311,105 @@ impl LocalAgentHandle {
             .attach_remote_session(session_id, remote_ref, peer_label, mesh, remote_node_id)
             .await
     }
+
+    #[cfg(feature = "remote")]
+    pub async fn resume_remote_session(
+        &self,
+        node_manager_ref: &kameo::actor::RemoteActorRef<crate::agent::remote::RemoteNodeManager>,
+        session_id: String,
+    ) -> Result<crate::agent::remote::CreateRemoteSessionResponse, agent_client_protocol::Error>
+    {
+        use crate::agent::remote::ResumeRemoteSession;
+        use crate::error::AgentError;
+
+        node_manager_ref
+            .ask(&ResumeRemoteSession { session_id })
+            .await
+            .map_err(|e| agent_client_protocol::Error::from(AgentError::RemoteActor(e.to_string())))
+    }
+
+    pub async fn stop_session(&self, session_id: &str) -> Result<(), Error> {
+        use crate::agent::messages::SessionRuntimeStatus;
+
+        const STOP_ESCALATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+        let session_ref = {
+            let registry = self.registry.lock().await;
+            registry.get(session_id).cloned()
+        };
+
+        let Some(session_ref) = session_ref else {
+            log::warn!(
+                "Stop requested for session {} but not found in registry",
+                session_id
+            );
+            return Ok(());
+        };
+
+        self.config
+            .emit_event(session_id, AgentEventKind::SessionStopRequested);
+        let _ = session_ref.cancel().await;
+
+        tokio::time::sleep(STOP_ESCALATION_TIMEOUT).await;
+
+        let status = session_ref
+            .get_runtime_status()
+            .await
+            .unwrap_or(SessionRuntimeStatus::Running);
+        if matches!(status, SessionRuntimeStatus::Idle) {
+            return Ok(());
+        }
+
+        self.config.emit_event(
+            session_id,
+            AgentEventKind::SessionForceStopped {
+                escalated_after_ms: STOP_ESCALATION_TIMEOUT.as_millis() as u64,
+                reason: "graceful cancellation timeout elapsed".to_string(),
+            },
+        );
+
+        if session_ref.is_remote() {
+            #[cfg(feature = "remote")]
+            {
+                let bookmark = self
+                    .config
+                    .provider
+                    .history_store()
+                    .list_remote_session_bookmarks()
+                    .await
+                    .map_err(|e| Error::internal_error().data(e.to_string()))?
+                    .into_iter()
+                    .find(|b| b.session_id == session_id);
+
+                if let Some(bookmark) = bookmark {
+                    let nm_ref = self.find_node_manager(&bookmark.node_id).await?;
+                    nm_ref
+                        .ask(&crate::agent::remote::DestroyRemoteSession {
+                            session_id: session_id.to_string(),
+                        })
+                        .await
+                        .map_err(|e| {
+                            Error::from(crate::error::AgentError::RemoteActor(e.to_string()))
+                        })?;
+                }
+
+                let mut registry = self.registry.lock().await;
+                registry
+                    .detach_remote_session_preserve_bookmark(session_id)
+                    .await;
+            }
+        } else {
+            let removed = {
+                let mut registry = self.registry.lock().await;
+                registry.remove(session_id)
+            };
+            if let Some(session_ref) = removed {
+                let _ = session_ref.shutdown().await;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // ── Model registry convenience ────────────────────────────────────────────
@@ -1585,21 +1684,7 @@ impl SendAgent for LocalAgentHandle {
     #[tracing::instrument(name = "acp.cancel", skip_all, fields(session_id = %notif.session_id))]
     async fn cancel(&self, notif: CancelNotification) -> Result<(), Error> {
         let session_id = notif.session_id.to_string();
-
-        let session_ref = {
-            let registry = self.registry.lock().await;
-            registry.get(&session_id).cloned()
-        };
-
-        if let Some(session_ref) = session_ref {
-            let _ = session_ref.cancel().await;
-        } else {
-            log::warn!(
-                "Cancel requested for session {} but not found in registry",
-                session_id
-            );
-        }
-        Ok(())
+        self.stop_session(&session_id).await
     }
 
     #[tracing::instrument(name = "acp.load_session", skip_all, fields(session_id = %req.session_id))]
@@ -2278,7 +2363,7 @@ mod tests {
     async fn test_cancel_unknown_session_is_noop() {
         let f = HandleFixture::new().await;
         let notif = CancelNotification::new(SessionId::from("no-such-session".to_string()));
-        // Should not return an error — cancel for unknown sessions is a no-op
+        // Should not return an error — stop for unknown sessions is a no-op
         let result = SendAgent::cancel(&f.handle, notif).await;
         assert!(result.is_ok());
     }

--- a/crates/agent/src/agent/handle.rs
+++ b/crates/agent/src/agent/handle.rs
@@ -1356,7 +1356,15 @@ impl LocalAgentHandle {
             .get_runtime_status()
             .await
             .unwrap_or(SessionRuntimeStatus::Running);
-        if matches!(status, SessionRuntimeStatus::Idle) {
+        if matches!(
+            status,
+            SessionRuntimeStatus::Idle | SessionRuntimeStatus::CancelRequested
+        ) {
+            tracing::debug!(
+                "Session {} stop: status={:?}, graceful shutdown — returning without force-stop",
+                session_id,
+                status
+            );
             return Ok(());
         }
 

--- a/crates/agent/src/agent/messages.rs
+++ b/crates/agent/src/agent/messages.rs
@@ -37,6 +37,14 @@ pub struct Prompt {
 #[derive(Serialize, Deserialize)]
 pub struct Cancel;
 
+/// High-level runtime state for stop/resume orchestration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionRuntimeStatus {
+    Idle,
+    Running,
+    CancelRequested,
+}
+
 /// Internal message sent by the spawned prompt task when it finishes.
 ///
 /// Carries the prompt generation that completed so the actor can ignore stale
@@ -144,6 +152,10 @@ pub struct ClearDeniedTools;
 /// Get session limits from configured middleware.
 #[derive(Serialize, Deserialize)]
 pub struct GetSessionLimits;
+
+/// Query the current runtime status for stop/resume orchestration.
+#[derive(Serialize, Deserialize)]
+pub struct GetRuntimeStatus;
 
 /// Get current LLM config for this session.
 #[derive(Serialize, Deserialize)]

--- a/crates/agent/src/agent/remote/actor_ref.rs
+++ b/crates/agent/src/agent/remote/actor_ref.rs
@@ -263,6 +263,9 @@ impl SessionActorRef {
     }
 
     /// Fork this session at a specific message boundary.
+    ///
+    /// Remote forks now go through `RemoteNodeManager` so only local sessions expose
+    /// this direct session-actor lifecycle operation.
     pub async fn fork_at_message(&self, message_id: String) -> Result<String, AgentError> {
         match self {
             Self::Local(actor_ref) => actor_ref
@@ -271,10 +274,9 @@ impl SessionActorRef {
                 .map_err(|e| AgentError::RemoteActor(e.to_string())),
 
             #[cfg(feature = "remote")]
-            Self::Remote { actor_ref, .. } => actor_ref
-                .ask(&messages::ForkAtMessage { message_id })
-                .await
-                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+            Self::Remote { .. } => Err(AgentError::Internal(
+                "remote fork must be routed through RemoteNodeManager".to_string(),
+            )),
         }
     }
 

--- a/crates/agent/src/agent/remote/actor_ref.rs
+++ b/crates/agent/src/agent/remote/actor_ref.rs
@@ -391,6 +391,22 @@ impl SessionActorRef {
         }
     }
 
+    /// Query current runtime status for stop orchestration.
+    pub async fn get_runtime_status(&self) -> Result<messages::SessionRuntimeStatus, AgentError> {
+        match self {
+            Self::Local(actor_ref) => actor_ref
+                .ask(messages::GetRuntimeStatus)
+                .await
+                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+
+            #[cfg(feature = "remote")]
+            Self::Remote { actor_ref, .. } => actor_ref
+                .ask(&messages::GetRuntimeStatus)
+                .await
+                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+        }
+    }
+
     /// Set the client bridge for SessionUpdate notifications (local only).
     ///
     /// This is a no-op for remote sessions — the bridge is a local channel

--- a/crates/agent/src/agent/remote/integration_tests.rs
+++ b/crates/agent/src/agent/remote/integration_tests.rs
@@ -186,12 +186,16 @@ mod node_manager_extended_tests {
 #[cfg(all(test, feature = "remote"))]
 mod remote_session_lifecycle_integration_tests {
     use crate::agent::core::AgentMode;
+    use crate::agent::messages::GetMode;
     use crate::agent::remote::SessionActorRef;
     use crate::agent::remote::node_manager::{
-        CreateRemoteSession, DestroyRemoteSession, GetNodeInfo, ListRemoteSessions,
+        CreateRemoteSession, DestroyRemoteSession, ForkRemoteSession, GetNodeInfo,
+        ListRemoteSessions,
     };
     use crate::agent::remote::test_helpers::fixtures::{TwoNodeFixture, get_test_mesh};
     use crate::agent::session_actor::SessionActor;
+    use crate::model::{AgentMessage, MessagePart};
+    use querymt::chat::ChatRole;
     use std::future::Future;
     use std::time::Duration;
     use uuid::Uuid;
@@ -231,7 +235,7 @@ mod remote_session_lifecycle_integration_tests {
             !resp.session_id.is_empty(),
             "session_id should not be empty"
         );
-        assert!(resp.actor_id > 0, "actor_id should be positive");
+        assert!(resp.created_at >= 0, "created_at should be populated");
 
         // Verify via Beta's local list.
         let sessions = within_timeout("ListRemoteSessions on beta", async {
@@ -356,6 +360,93 @@ mod remote_session_lifecycle_integration_tests {
             beta_ref
                 .ask(&DestroyRemoteSession {
                     session_id: r2.session_id,
+                })
+                .await
+        })
+        .await;
+        f.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_fork_remote_session_returns_attachable_child_without_lookup() {
+        let test_id = Uuid::now_v7().to_string();
+        let f = TwoNodeFixture::new(&test_id).await;
+        let mesh = get_test_mesh().await;
+
+        let beta_ref = within_timeout(
+            "lookup beta node manager",
+            mesh.lookup_actor::<crate::agent::remote::RemoteNodeManager>(&f.beta.dht_name),
+        )
+        .await
+        .expect("lookup")
+        .expect("not found");
+
+        let parent = within_timeout("create parent", async {
+            beta_ref.ask(&CreateRemoteSession { cwd: None }).await
+        })
+        .await
+        .expect("create parent");
+
+        let message_id = Uuid::new_v4().to_string();
+        f.beta
+            .config
+            .provider
+            .history_store()
+            .add_message(
+                &parent.session_id,
+                AgentMessage {
+                    id: message_id.clone(),
+                    session_id: parent.session_id.clone(),
+                    role: ChatRole::User,
+                    parts: vec![MessagePart::Text {
+                        content: "fork this point".to_string(),
+                    }],
+                    created_at: time::OffsetDateTime::now_utc().unix_timestamp(),
+                    parent_message_id: None,
+                    source_provider: None,
+                    source_model: None,
+                },
+            )
+            .await
+            .expect("insert parent message");
+
+        let child = within_timeout("fork child", async {
+            beta_ref
+                .ask(&ForkRemoteSession {
+                    source_session_id: parent.session_id.clone(),
+                    message_id: message_id.clone(),
+                })
+                .await
+        })
+        .await
+        .expect("fork child");
+
+        assert_ne!(child.session_id, parent.session_id);
+        let mode = child
+            .session_ref
+            .ask(&GetMode)
+            .await
+            .expect("forked child should be directly usable");
+        assert_eq!(mode, AgentMode::Build);
+
+        let sessions: Vec<_> =
+            within_timeout("list", async { beta_ref.ask(&ListRemoteSessions).await })
+                .await
+                .expect("list");
+        assert!(sessions.iter().any(|s| s.session_id == child.session_id));
+
+        let _ = within_timeout("destroy parent", async {
+            beta_ref
+                .ask(&DestroyRemoteSession {
+                    session_id: parent.session_id,
+                })
+                .await
+        })
+        .await;
+        let _ = within_timeout("destroy child", async {
+            beta_ref
+                .ask(&DestroyRemoteSession {
+                    session_id: child.session_id,
                 })
                 .await
         })

--- a/crates/agent/src/agent/remote/integration_tests.rs
+++ b/crates/agent/src/agent/remote/integration_tests.rs
@@ -188,6 +188,7 @@ mod remote_session_lifecycle_integration_tests {
     use crate::agent::core::AgentMode;
     use crate::agent::messages::GetMode;
     use crate::agent::remote::SessionActorRef;
+    use crate::agent::remote::node_manager::SessionHandoff;
     use crate::agent::remote::node_manager::{
         CreateRemoteSession, DestroyRemoteSession, ForkRemoteSession, GetNodeInfo,
         ListRemoteSessions,
@@ -422,8 +423,16 @@ mod remote_session_lifecycle_integration_tests {
         .expect("fork child");
 
         assert_ne!(child.session_id, parent.session_id);
-        let mode = child
-            .session_ref
+        let session_ref = match child.handoff {
+            SessionHandoff::DirectRemote { session_ref } => session_ref,
+            SessionHandoff::LookupOnly => {
+                panic!("expected direct handoff in integration mesh test")
+            }
+            SessionHandoff::NoAttachPath => {
+                panic!("expected attachable handoff in integration mesh test")
+            }
+        };
+        let mode = session_ref
             .ask(&GetMode)
             .await
             .expect("forked child should be directly usable");

--- a/crates/agent/src/agent/remote/mesh_provider.rs
+++ b/crates/agent/src/agent/remote/mesh_provider.rs
@@ -32,7 +32,7 @@ use querymt::LLMProvider;
 use querymt::chat::{ChatMessage, ChatProvider, StreamChunk, Tool};
 use querymt::completion::{CompletionProvider, CompletionRequest, CompletionResponse};
 use querymt::embedding::EmbeddingProvider;
-use querymt::error::LLMError;
+use querymt::error::{LLMError, LLMErrorPayload, TransportErrorKind};
 use std::pin::Pin;
 use std::time::Instant;
 use tokio::sync::mpsc;
@@ -167,12 +167,10 @@ impl ChatProvider for MeshChatProvider {
         };
 
         // ask() flattens Result<Result<T,E>, RemoteSendError> into Result<T, RemoteSendError<E>>
-        let chat_response = host_ref.ask(&request).await.map_err(|e| {
-            LLMError::ProviderError(format!(
-                "MeshChatProvider: remote call to '{}' failed: {}",
-                self.target_dht_name, e
-            ))
-        })?;
+        let chat_response = host_ref
+            .ask(&request)
+            .await
+            .map_err(remote_send_error_to_llm_error_with_handler)?;
 
         log::debug!(
             "MeshChatProvider: non-streaming response from {} ({}/{})",
@@ -258,12 +256,10 @@ impl ChatProvider for MeshChatProvider {
             params: self.params.clone(),
         };
 
-        host_ref.tell(&stream_request).send().map_err(|e| {
-            LLMError::ProviderError(format!(
-                "MeshChatProvider: failed to send stream request to '{}': {}",
-                self.target_dht_name, e
-            ))
-        })?;
+        host_ref
+            .tell(&stream_request)
+            .send()
+            .map_err(remote_send_error_to_llm_error_no_handler)?;
 
         log::debug!(
             "MeshChatProvider: streaming request sent to {} ({}/{})",
@@ -306,10 +302,13 @@ impl ChatProvider for MeshChatProvider {
                         let remaining = reconnect_grace.saturating_sub(elapsed);
                         if remaining.is_zero() {
                             return Some((
-                                Err(LLMError::ProviderError(format!(
-                                    "MeshChatProvider: reconnect grace expired after {:?}",
-                                    reconnect_grace,
-                                ))),
+                                Err(LLMError::Transport {
+                                    kind: TransportErrorKind::Timeout,
+                                    message: format!(
+                                        "reconnect grace expired after {:?}",
+                                        reconnect_grace,
+                                    ),
+                                }),
                                 (raw_stream, disconnected_since, chunk_index),
                             ));
                         }
@@ -317,10 +316,13 @@ impl ChatProvider for MeshChatProvider {
                             Ok(item) => item,
                             Err(_) => {
                                 return Some((
-                                    Err(LLMError::ProviderError(format!(
-                                        "MeshChatProvider: reconnect grace expired after {:?}",
-                                        reconnect_grace,
-                                    ))),
+                                    Err(LLMError::Transport {
+                                        kind: TransportErrorKind::Timeout,
+                                        message: format!(
+                                            "reconnect grace expired after {:?}",
+                                            reconnect_grace,
+                                        ),
+                                    }),
                                     (raw_stream, disconnected_since, chunk_index),
                                 ));
                             }
@@ -347,11 +349,8 @@ impl ChatProvider for MeshChatProvider {
                             );
                             Some((Ok(chunk), (raw_stream, None, chunk_index)))
                         }
-                        Some(StreamRelayMessage::ProviderError { message }) => Some((
-                            Err(LLMError::ProviderError(format!(
-                                "MeshChatProvider: {}",
-                                message,
-                            ))),
+                        Some(StreamRelayMessage::ProviderError { error }) => Some((
+                            Err(LLMError::from_payload(error)),
                             (raw_stream, disconnected_since, chunk_index),
                         )),
                         Some(StreamRelayMessage::TransportDisconnected { reason }) => {
@@ -378,11 +377,8 @@ impl ChatProvider for MeshChatProvider {
                                 (raw_stream, None, chunk_index),
                             ))
                         }
-                        Some(StreamRelayMessage::TransportFailed { reason }) => Some((
-                            Err(LLMError::ProviderError(format!(
-                                "MeshChatProvider: transport failed: {}",
-                                reason,
-                            ))),
+                        Some(StreamRelayMessage::TransportFailed { error }) => Some((
+                            Err(LLMError::from_payload(error)),
                             (raw_stream, disconnected_since, chunk_index),
                         )),
                         None => {
@@ -391,10 +387,13 @@ impl ChatProvider for MeshChatProvider {
                                 .is_some_and(|peer_id| mesh.is_peer_alive(peer_id));
                             if disconnected_since.is_some() || !peer_alive {
                                 Some((
-                                    Err(LLMError::ProviderError(format!(
-                                        "MeshChatProvider: stream receiver closed (peer_alive={})",
-                                        peer_alive,
-                                    ))),
+                                    Err(LLMError::Transport {
+                                        kind: TransportErrorKind::ConnectionClosed,
+                                        message: format!(
+                                            "stream receiver closed (peer_alive={})",
+                                            peer_alive,
+                                        ),
+                                    }),
                                     (raw_stream, disconnected_since, chunk_index),
                                 ))
                             } else {
@@ -435,6 +434,93 @@ impl EmbeddingProvider for MeshChatProvider {
 // ── LLMProvider ───────────────────────────────────────────────────────────────
 
 impl LLMProvider for MeshChatProvider {}
+
+fn remote_send_error_base<E>(error: kameo::error::RemoteSendError<E>) -> Result<LLMError, E> {
+    use kameo::error::RemoteSendError;
+
+    match error {
+        RemoteSendError::ActorNotRunning | RemoteSendError::ActorStopped => {
+            Ok(LLMError::Transport {
+                kind: TransportErrorKind::ConnectionClosed,
+                message: "remote actor not running".to_string(),
+            })
+        }
+        RemoteSendError::UnknownActor { .. } | RemoteSendError::UnknownMessage { .. } => {
+            Ok(LLMError::Transport {
+                kind: TransportErrorKind::ConnectionClosed,
+                message: "remote actor unavailable".to_string(),
+            })
+        }
+        RemoteSendError::BadActorType => {
+            Ok(LLMError::ProviderError("bad remote actor type".to_string()))
+        }
+        RemoteSendError::MailboxFull => Ok(LLMError::Transport {
+            kind: TransportErrorKind::Other,
+            message: "remote mailbox full".to_string(),
+        }),
+        RemoteSendError::ReplyTimeout | RemoteSendError::NetworkTimeout => {
+            Ok(LLMError::Transport {
+                kind: TransportErrorKind::Timeout,
+                message: "network timeout".to_string(),
+            })
+        }
+        RemoteSendError::DialFailure => Ok(LLMError::Transport {
+            kind: TransportErrorKind::ConnectionRefused,
+            message: "dial failure".to_string(),
+        }),
+        RemoteSendError::ConnectionClosed => Ok(LLMError::Transport {
+            kind: TransportErrorKind::ConnectionClosed,
+            message: "connection closed".to_string(),
+        }),
+        RemoteSendError::UnsupportedProtocols => Ok(LLMError::ProviderError(
+            "remote protocol unsupported".to_string(),
+        )),
+        RemoteSendError::SerializeMessage(err)
+        | RemoteSendError::DeserializeMessage(err)
+        | RemoteSendError::SerializeReply(err)
+        | RemoteSendError::SerializeHandlerError(err)
+        | RemoteSendError::DeserializeHandlerError(err) => Ok(LLMError::ProviderError(err)),
+        RemoteSendError::SwarmNotBootstrapped => Ok(LLMError::Transport {
+            kind: TransportErrorKind::Other,
+            message: "swarm not bootstrapped".to_string(),
+        }),
+        RemoteSendError::Io(Some(err)) => Ok(LLMError::from(err)),
+        RemoteSendError::Io(None) => Ok(LLMError::Transport {
+            kind: TransportErrorKind::Other,
+            message: "remote IO failure".to_string(),
+        }),
+        RemoteSendError::HandlerError(err) => Err(err),
+    }
+}
+
+fn remote_send_error_to_llm_error_with_handler(
+    error: kameo::error::RemoteSendError<crate::error::AgentError>,
+) -> LLMError {
+    match remote_send_error_base(error) {
+        Ok(err) => err,
+        Err(agent_error) => decode_remote_handler_error(agent_error),
+    }
+}
+
+fn remote_send_error_to_llm_error_no_handler(
+    error: kameo::error::RemoteSendError<kameo::error::Infallible>,
+) -> LLMError {
+    match remote_send_error_base(error) {
+        Ok(err) => err,
+        Err(never) => match never {},
+    }
+}
+
+fn decode_remote_handler_error(agent_error: crate::error::AgentError) -> LLMError {
+    match agent_error {
+        crate::error::AgentError::ProviderChat { reason, .. } => {
+            serde_json::from_str::<LLMErrorPayload>(&reason)
+                .map(LLMError::from_payload)
+                .unwrap_or_else(|_| LLMError::ProviderError(reason))
+        }
+        other => LLMError::ProviderError(other.to_string()),
+    }
+}
 
 // ── find_provider_on_mesh ─────────────────────────────────────────────────────
 

--- a/crates/agent/src/agent/remote/mesh_provider.rs
+++ b/crates/agent/src/agent/remote/mesh_provider.rs
@@ -335,18 +335,30 @@ impl ChatProvider for MeshChatProvider {
                         Some(StreamRelayMessage::Chunk(chunk)) => {
                             chunk_index += 1;
                             let elapsed_ms = stream_start.elapsed().as_millis();
-                            let is_done = matches!(&chunk, StreamChunk::Done { .. });
-                            tracing::trace!(
-                                target: "remote::mesh_provider::stream",
-                                provider = %provider_for_stream,
-                                model = %model_for_stream,
-                                target_node = %target_for_stream,
-                                stream_rx = %stream_rx_name_for_log,
-                                chunk_index,
-                                elapsed_ms,
-                                is_done,
-                                "stream chunk received"
-                            );
+                            if let StreamChunk::Done { finish_reason } = &chunk {
+                                tracing::debug!(
+                                    target: "remote::mesh_provider::stream",
+                                    provider = %provider_for_stream,
+                                    model = %model_for_stream,
+                                    target_node = %target_for_stream,
+                                    stream_rx = %stream_rx_name_for_log,
+                                    chunk_index,
+                                    elapsed_ms,
+                                    finish_reason = ?finish_reason,
+                                    "stream done received from remote provider"
+                                );
+                            } else {
+                                tracing::trace!(
+                                    target: "remote::mesh_provider::stream",
+                                    provider = %provider_for_stream,
+                                    model = %model_for_stream,
+                                    target_node = %target_for_stream,
+                                    stream_rx = %stream_rx_name_for_log,
+                                    chunk_index,
+                                    elapsed_ms,
+                                    "stream chunk received"
+                                );
+                            }
                             Some((Ok(chunk), (raw_stream, None, chunk_index)))
                         }
                         Some(StreamRelayMessage::ProviderError { error }) => Some((

--- a/crates/agent/src/agent/remote/mod.rs
+++ b/crates/agent/src/agent/remote/mod.rs
@@ -101,7 +101,7 @@ pub use node_manager::{AvailableModel, NodeInfo, RemoteSessionInfo};
 pub use node_manager::{
     CreateRemoteSession, CreateRemoteSessionResponse, DestroyRemoteSession, ForkRemoteSession,
     ForkRemoteSessionResponse, GetNodeInfo, ListAvailableModels, ListRemoteSessions,
-    RemoteNodeManager,
+    RemoteNodeManager, ResumeRemoteSession,
 };
 #[cfg(feature = "remote")]
 pub use provider_host::{

--- a/crates/agent/src/agent/remote/mod.rs
+++ b/crates/agent/src/agent/remote/mod.rs
@@ -99,8 +99,9 @@ pub use node_id::NodeId;
 pub use node_manager::{AvailableModel, NodeInfo, RemoteSessionInfo};
 #[cfg(feature = "remote")]
 pub use node_manager::{
-    CreateRemoteSession, CreateRemoteSessionResponse, DestroyRemoteSession, GetNodeInfo,
-    ListAvailableModels, ListRemoteSessions, RemoteNodeManager,
+    CreateRemoteSession, CreateRemoteSessionResponse, DestroyRemoteSession, ForkRemoteSession,
+    ForkRemoteSessionResponse, GetNodeInfo, ListAvailableModels, ListRemoteSessions,
+    RemoteNodeManager,
 };
 #[cfg(feature = "remote")]
 pub use provider_host::{

--- a/crates/agent/src/agent/remote/node_manager.rs
+++ b/crates/agent/src/agent/remote/node_manager.rs
@@ -614,6 +614,8 @@ mod remote_impl {
             _msg: ListRemoteSessions,
             _ctx: &mut Context<Self, Self::Reply>,
         ) -> Self::Reply {
+            use crate::agent::messages::SessionRuntimeStatus;
+
             let registry = self.registry.lock().await;
             let session_ids = registry.session_ids();
 
@@ -653,16 +655,37 @@ mod remote_impl {
                     _ => session_name,
                 };
 
-                let actor_id = registry
-                    .get(&sid)
-                    .and_then(|r| match r {
-                        crate::agent::remote::SessionActorRef::Local(ar) => {
-                            Some(ar.id().sequence_id())
+                let session_ref = registry.get(&sid).cloned();
+                let actor_id = match session_ref.as_ref() {
+                    Some(crate::agent::remote::SessionActorRef::Local(ar)) => ar.id().sequence_id(),
+                    #[cfg(feature = "remote")]
+                    Some(crate::agent::remote::SessionActorRef::Remote { .. }) | None => 0,
+                    #[cfg(not(feature = "remote"))]
+                    None => 0,
+                };
+                let runtime_state = match session_ref {
+                    Some(session_ref) => match tokio::time::timeout(
+                        std::time::Duration::from_millis(200),
+                        session_ref.get_runtime_status(),
+                    )
+                    .await
+                    {
+                        Ok(Ok(SessionRuntimeStatus::Idle)) => Some("idle".to_string()),
+                        Ok(Ok(
+                            SessionRuntimeStatus::Running | SessionRuntimeStatus::CancelRequested,
+                        )) => Some("busy".to_string()),
+                        Ok(Err(e)) => {
+                            log::debug!(
+                                "RemoteNodeManager: failed to query runtime status for {}: {}",
+                                sid,
+                                e
+                            );
+                            Some("active".to_string())
                         }
-                        #[cfg(feature = "remote")]
-                        crate::agent::remote::SessionActorRef::Remote { .. } => None,
-                    })
-                    .unwrap_or(0);
+                        Err(_) => Some("active".to_string()),
+                    },
+                    None => Some("active".to_string()),
+                };
 
                 infos.push(RemoteSessionInfo {
                     session_id: sid,
@@ -671,7 +694,7 @@ mod remote_impl {
                     created_at,
                     title,
                     peer_label: hostname.clone(),
-                    runtime_state: Some("active".to_string()),
+                    runtime_state,
                 });
             }
 

--- a/crates/agent/src/agent/remote/node_manager.rs
+++ b/crates/agent/src/agent/remote/node_manager.rs
@@ -57,7 +57,8 @@ pub struct AvailableModel {
 #[cfg(feature = "remote")]
 pub use remote_impl::{
     AdmissionRequest, AdmissionResponse, CreateRemoteSession, CreateRemoteSessionResponse,
-    DestroyRemoteSession, GetNodeInfo, ListAvailableModels, ListRemoteSessions, RemoteNodeManager,
+    DestroyRemoteSession, ForkRemoteSession, ForkRemoteSessionResponse, GetNodeInfo,
+    ListAvailableModels, ListRemoteSessions, RemoteNodeManager,
 };
 
 #[cfg(feature = "remote")]
@@ -94,10 +95,33 @@ mod remote_impl {
     /// Response from `CreateRemoteSession`.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct CreateRemoteSessionResponse {
-        /// The new session's public ID
+        /// The new session's public ID.
         pub session_id: String,
-        /// The `SessionActor`'s kameo ActorId (raw u64 for serialization)
-        pub actor_id: u64,
+        /// Direct reference to the spawned remote session actor.
+        pub session_ref: kameo::actor::RemoteActorRef<SessionActor>,
+        /// Working directory on the remote machine, if known.
+        pub cwd: Option<String>,
+        /// Session title/name, if known.
+        pub title: Option<String>,
+        /// Unix timestamp when the session was created.
+        pub created_at: i64,
+    }
+
+    /// Fork an existing session on this node at a specific message boundary.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ForkRemoteSession {
+        pub source_session_id: String,
+        pub message_id: String,
+    }
+
+    /// Response from `ForkRemoteSession`.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ForkRemoteSessionResponse {
+        pub session_id: String,
+        pub session_ref: kameo::actor::RemoteActorRef<SessionActor>,
+        pub cwd: Option<String>,
+        pub title: Option<String>,
+        pub created_at: i64,
     }
 
     /// List sessions active on this node.
@@ -215,6 +239,158 @@ mod remote_impl {
             self.node_name = Some(name);
             self
         }
+
+        async fn materialize_remote_session(
+            &mut self,
+            session_id: String,
+            cwd_path: Option<PathBuf>,
+            cwd: Option<String>,
+            title: Option<String>,
+            created_at: i64,
+        ) -> Result<kameo::actor::RemoteActorRef<SessionActor>, AgentError> {
+            // Remote lifecycle RPCs return a live capability directly; DHT registration
+            // remains best-effort background discoverability for later reconnects.
+            let runtime = SessionRuntime::new(
+                cwd_path.clone(),
+                HashMap::new(),
+                crate::agent::core::McpToolState::empty(),
+            );
+
+            let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
+                .with_mesh(self.mesh.clone());
+            let actor_ref = SessionActor::spawn(actor);
+            let actor_id_raw = actor_ref.id().sequence_id();
+
+            tracing::Span::current()
+                .record("session_id", &session_id)
+                .record("actor_id", actor_id_raw);
+
+            if let Some(ref mesh) = self.mesh {
+                let dht_name = crate::agent::remote::dht_name::session(&session_id);
+                let reg_span = tracing::info_span!(
+                    "remote.node_manager.dht_register_session",
+                    session_id = %session_id,
+                    dht_name = %dht_name,
+                );
+                let reg_timeout = std::time::Duration::from_secs(2);
+                match tokio::time::timeout(
+                    reg_timeout,
+                    mesh.register_actor(actor_ref.clone(), dht_name.clone())
+                        .instrument(reg_span),
+                )
+                .await
+                {
+                    Ok(()) => {}
+                    Err(_) => {
+                        log::warn!(
+                            "RemoteNodeManager: timed out registering session {} as '{}' in DHT after {:?}; continuing with direct ref handoff",
+                            session_id,
+                            dht_name,
+                            reg_timeout
+                        );
+                    }
+                }
+            } else {
+                log::debug!(
+                    "RemoteNodeManager: no mesh, skipping DHT registration for session {}",
+                    session_id
+                );
+            }
+
+            {
+                let mut registry = self.registry.lock().await;
+                registry.insert(session_id.clone(), actor_ref.clone());
+            }
+
+            self.session_meta
+                .insert(session_id.clone(), (created_at, cwd.clone()));
+
+            if let Err(e) = self
+                .config
+                .emit_event_persisted(&session_id, crate::events::AgentEventKind::SessionCreated)
+                .await
+            {
+                log::warn!(
+                    "RemoteNodeManager: failed to emit SessionCreated for {}: {}",
+                    session_id,
+                    e
+                );
+            }
+
+            if let Ok(Some(llm_config)) = self
+                .config
+                .provider
+                .history_store()
+                .get_session_llm_config(&session_id)
+                .await
+            {
+                let context_limit =
+                    crate::model_info::get_model_info(&llm_config.provider, &llm_config.model)
+                        .and_then(|m| m.context_limit());
+                self.config.emit_event(
+                    &session_id,
+                    crate::events::AgentEventKind::ProviderChanged {
+                        provider: llm_config.provider.clone(),
+                        model: llm_config.model.clone(),
+                        config_id: llm_config.id,
+                        context_limit,
+                        provider_node_id: None,
+                    },
+                );
+            }
+
+            if let Some(ref cwd_path) = cwd_path {
+                if cwd_path.exists() {
+                    let manager_actor = self.config.workspace_manager_actor.clone();
+                    let runtime_clone = runtime.clone();
+                    let cwd_owned = cwd_path.clone();
+                    let config_clone = self.config.clone();
+                    let session_id_for_index = session_id.clone();
+                    let index_span = tracing::info_span!(
+                        "remote.node_manager.init_workspace_index",
+                        session_id = %session_id,
+                        cwd = %cwd_owned.display(),
+                    );
+                    tokio::spawn(
+                        async move {
+                            let root = crate::index::resolve_workspace_root(&cwd_owned);
+                            match manager_actor
+                                .ask(crate::index::GetOrCreate { root: root.clone() })
+                                .await
+                            {
+                                Ok(handle) => {
+                                    let _ = runtime_clone.workspace_handle.set(handle);
+                                    config_clone.emit_event(
+                                        &session_id_for_index,
+                                        crate::events::AgentEventKind::WorkspaceIndexReady {
+                                            workspace_root: root.display().to_string(),
+                                        },
+                                    );
+                                }
+                                Err(e) => {
+                                    log::warn!("Failed to initialize workspace index: {}", e)
+                                }
+                            }
+                        }
+                        .instrument(index_span),
+                    );
+                } else {
+                    log::debug!(
+                        "RemoteNodeManager: cwd {:?} does not exist on this node, skipping workspace index",
+                        cwd_path
+                    );
+                }
+            }
+
+            log::info!(
+                "RemoteNodeManager: materialized session {} (actor_id={}, title={:?})",
+                session_id,
+                actor_id_raw,
+                title
+            );
+
+            Ok(actor_ref.into_remote_ref().await)
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -258,7 +434,6 @@ mod remote_impl {
         ) -> Self::Reply {
             let cwd_path: Option<PathBuf> = msg.cwd.as_ref().map(PathBuf::from);
 
-            // Validate cwd if provided
             if let Some(ref path) = cwd_path
                 && !path.is_absolute()
             {
@@ -268,180 +443,131 @@ mod remote_impl {
                 )));
             }
 
-            // Create session via provider
             let session_context = self
                 .config
                 .provider
                 .create_session(
                     cwd_path.clone(),
-                    None, // no parent
+                    None,
                     &self.config.execution_config_snapshot(),
                 )
                 .await
                 .map_err(|e| AgentError::Internal(e.to_string()))?;
 
-            let session_id = session_context.session().public_id.clone();
+            let session = session_context.session();
+            let session_id = session.public_id.clone();
+            let title = session.name.clone();
+            let created_at = session
+                .created_at
+                .map(|ts| ts.unix_timestamp())
+                .unwrap_or_else(|| {
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0)
+                });
 
-            // Build a minimal runtime (no MCP for now — remote MCP is future work)
-            let runtime = SessionRuntime::new(
-                cwd_path.clone(),
-                HashMap::new(), // mcp_services
-                crate::agent::core::McpToolState::empty(),
-            );
-
-            // Spawn the session actor, giving it access to the mesh handle so its
-            // SubscribeEvents handler can do DHT lookups without a global flag.
-            let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
-                .with_mesh(self.mesh.clone());
-            let actor_ref = SessionActor::spawn(actor);
-
-            let actor_id_raw = actor_ref.id().sequence_id();
-            tracing::Span::current()
-                .record("session_id", &session_id)
-                .record("actor_id", actor_id_raw);
-
-            // Register in REMOTE_REGISTRY + Kademlia DHT so remote peers can
-            // address the session actor by name.
-            if let Some(ref mesh) = self.mesh {
-                let dht_name = crate::agent::remote::dht_name::session(&session_id);
-                let reg_span = tracing::info_span!(
-                    "remote.node_manager.dht_register_session",
-                    session_id = %session_id,
-                    dht_name = %dht_name,
-                );
-                let reg_timeout = std::time::Duration::from_secs(2);
-                match tokio::time::timeout(
-                    reg_timeout,
-                    mesh.register_actor(actor_ref.clone(), dht_name.clone())
-                        .instrument(reg_span),
+            let session_ref = self
+                .materialize_remote_session(
+                    session_id.clone(),
+                    cwd_path,
+                    msg.cwd.clone(),
+                    title.clone(),
+                    created_at,
                 )
-                .await
-                {
-                    Ok(()) => {}
-                    Err(_) => {
-                        log::warn!(
-                            "RemoteNodeManager: timed out registering session {} as '{}' in DHT after {:?}; continuing with local registry",
-                            session_id,
-                            dht_name,
-                            reg_timeout
-                        );
-                    }
-                }
-            } else {
-                log::debug!(
-                    "RemoteNodeManager: no mesh, skipping DHT registration for session {}",
-                    session_id
-                );
-            }
-
-            // Insert into local registry
-            {
-                let mut registry = self.registry.lock().await;
-                registry.insert(session_id.clone(), actor_ref);
-            }
-
-            // Track metadata
-            let created_at = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
-            self.session_meta
-                .insert(session_id.clone(), (created_at, msg.cwd.clone()));
-
-            // Emit SessionCreated event — awaited so it is published to the fanout
-            // before ProviderChanged is spawned, giving subscribers a deterministic
-            // ordering guarantee (important for tests and for UI correctness).
-            if let Err(e) = self
-                .config
-                .emit_event_persisted(&session_id, crate::events::AgentEventKind::SessionCreated)
-                .await
-            {
-                log::warn!(
-                    "RemoteNodeManager: failed to emit SessionCreated for {}: {}",
-                    session_id,
-                    e
-                );
-            }
-
-            // Emit ProviderChanged so the UI knows which model is active and
-            // so prompt execution can find the LLM config (parity with
-            // SessionRegistry::new_session).
-            if let Ok(Some(llm_config)) = self
-                .config
-                .provider
-                .history_store()
-                .get_session_llm_config(&session_id)
-                .await
-            {
-                let context_limit =
-                    crate::model_info::get_model_info(&llm_config.provider, &llm_config.model)
-                        .and_then(|m| m.context_limit());
-                self.config.emit_event(
-                    &session_id,
-                    crate::events::AgentEventKind::ProviderChanged {
-                        provider: llm_config.provider.clone(),
-                        model: llm_config.model.clone(),
-                        config_id: llm_config.id,
-                        context_limit,
-                        provider_node_id: None,
-                    },
-                );
-            }
-
-            // Background: initialize workspace index (only if the path exists on this node)
-            if let Some(ref cwd_path) = cwd_path {
-                if cwd_path.exists() {
-                    let manager_actor = self.config.workspace_manager_actor.clone();
-                    let runtime_clone = runtime.clone();
-                    let cwd_owned = cwd_path.clone();
-                    let config_clone = self.config.clone();
-                    let session_id_for_index = session_id.clone();
-                    let index_span = tracing::info_span!(
-                        "remote.node_manager.init_workspace_index",
-                        session_id = %session_id,
-                        cwd = %cwd_owned.display(),
-                    );
-                    tokio::spawn(
-                        async move {
-                            let root = crate::index::resolve_workspace_root(&cwd_owned);
-                            match manager_actor
-                                .ask(crate::index::GetOrCreate { root: root.clone() })
-                                .await
-                            {
-                                Ok(handle) => {
-                                    let _ = runtime_clone.workspace_handle.set(handle);
-                                    // Emit event so the local UI (via EventForwarder →
-                                    // EventRelayActor → local EventBus) learns the index
-                                    // is ready and can push FileIndex without polling.
-                                    config_clone.emit_event(
-                                        &session_id_for_index,
-                                        crate::events::AgentEventKind::WorkspaceIndexReady {
-                                            workspace_root: root.display().to_string(),
-                                        },
-                                    );
-                                }
-                                Err(e) => log::warn!("Failed to initialize workspace index: {}", e),
-                            }
-                        }
-                        .instrument(index_span),
-                    );
-                } else {
-                    log::debug!(
-                        "RemoteNodeManager: cwd {:?} does not exist on this node, skipping workspace index",
-                        cwd_path
-                    );
-                }
-            }
-
-            log::info!(
-                "RemoteNodeManager: created session {} (actor_id={})",
-                session_id,
-                actor_id_raw
-            );
+                .await?;
 
             Ok(CreateRemoteSessionResponse {
                 session_id,
-                actor_id: actor_id_raw,
+                session_ref,
+                cwd: msg.cwd,
+                title,
+                created_at,
+            })
+        }
+    }
+
+    impl Message<ForkRemoteSession> for RemoteNodeManager {
+        type Reply = Result<ForkRemoteSessionResponse, AgentError>;
+
+        #[tracing::instrument(
+            name = "remote.node_manager.fork_session",
+            skip(self, _ctx),
+            fields(
+                source_session_id = %msg.source_session_id,
+                message_id = %msg.message_id,
+                session_id = tracing::field::Empty,
+                actor_id = tracing::field::Empty,
+            )
+        )]
+        async fn handle(
+            &mut self,
+            msg: ForkRemoteSession,
+            _ctx: &mut Context<Self, Self::Reply>,
+        ) -> Self::Reply {
+            let session = self
+                .config
+                .provider
+                .history_store()
+                .get_session(&msg.source_session_id)
+                .await
+                .map_err(|e| AgentError::Internal(e.to_string()))?
+                .ok_or_else(|| AgentError::SessionNotFound {
+                    session_id: msg.source_session_id.clone(),
+                })?;
+
+            let forked_session_id = self
+                .config
+                .provider
+                .history_store()
+                .fork_session(
+                    &msg.source_session_id,
+                    &msg.message_id,
+                    crate::session::domain::ForkOrigin::User,
+                )
+                .await
+                .map_err(|e| AgentError::Internal(e.to_string()))?;
+
+            let forked_session = self
+                .config
+                .provider
+                .history_store()
+                .get_session(&forked_session_id)
+                .await
+                .map_err(|e| AgentError::Internal(e.to_string()))?
+                .ok_or_else(|| AgentError::SessionNotFound {
+                    session_id: forked_session_id.clone(),
+                })?;
+
+            let cwd_path = forked_session.cwd.clone();
+            let cwd = cwd_path.as_ref().map(|path| path.display().to_string());
+            let title = forked_session.name.clone().or(session.name.clone());
+            let created_at = forked_session
+                .created_at
+                .map(|ts| ts.unix_timestamp())
+                .unwrap_or_else(|| {
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0)
+                });
+
+            let session_ref = self
+                .materialize_remote_session(
+                    forked_session_id.clone(),
+                    cwd_path,
+                    cwd.clone(),
+                    title.clone(),
+                    created_at,
+                )
+                .await?;
+
+            Ok(ForkRemoteSessionResponse {
+                session_id: forked_session_id,
+                session_ref,
+                cwd,
+                title,
+                created_at,
             })
         }
     }
@@ -859,6 +985,11 @@ mod remote_impl {
         CreateRemoteSession,
         "querymt::CreateRemoteSession",
         REG_CREATE_REMOTE_SESSION
+    );
+    remote_node_msg_impl!(
+        ForkRemoteSession,
+        "querymt::ForkRemoteSession",
+        REG_FORK_REMOTE_SESSION
     );
     remote_node_msg_impl!(
         ListRemoteSessions,

--- a/crates/agent/src/agent/remote/node_manager.rs
+++ b/crates/agent/src/agent/remote/node_manager.rs
@@ -58,21 +58,20 @@ pub struct AvailableModel {
 pub use remote_impl::{
     AdmissionRequest, AdmissionResponse, CreateRemoteSession, CreateRemoteSessionResponse,
     DestroyRemoteSession, ForkRemoteSession, ForkRemoteSessionResponse, GetNodeInfo,
-    ListAvailableModels, ListRemoteSessions, RemoteNodeManager,
+    ListAvailableModels, ListRemoteSessions, RemoteNodeManager, SessionHandoff,
 };
 
 #[cfg(feature = "remote")]
 mod remote_impl {
     use super::{AvailableModel, NodeInfo, RemoteSessionInfo};
     use crate::agent::agent_config::AgentConfig;
-    use crate::agent::core::SessionRuntime;
     use crate::agent::remote::NodeId;
     use crate::agent::remote::mesh::MeshHandle;
     use crate::agent::session_actor::SessionActor;
-    use crate::agent::session_registry::SessionRegistry;
+    use crate::agent::session_registry::{SessionMaterializationOptions, SessionRegistry};
     use crate::error::AgentError;
+    use futures_util::FutureExt;
     use kameo::Actor;
-    use kameo::actor::Spawn;
     use kameo::message::{Context, Message};
     use kameo::remote::_internal;
     use serde::{Deserialize, Serialize};
@@ -92,13 +91,40 @@ mod remote_impl {
         pub cwd: Option<String>,
     }
 
+    /// Wire-safe handoff returned from remote create/fork lifecycle RPCs.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub enum SessionHandoff {
+        /// Immediate direct capability for the newly materialized session.
+        DirectRemote {
+            session_ref: kameo::actor::RemoteActorRef<SessionActor>,
+        },
+        /// No direct capability was available, but the caller can attach via lookup.
+        LookupOnly,
+        /// The session was created, but this environment cannot provide any remote attach path.
+        NoAttachPath,
+    }
+
+    impl SessionHandoff {
+        pub fn direct(session_ref: kameo::actor::RemoteActorRef<SessionActor>) -> Self {
+            Self::DirectRemote { session_ref }
+        }
+
+        pub fn lookup_only() -> Self {
+            Self::LookupOnly
+        }
+
+        pub fn no_attach_path() -> Self {
+            Self::NoAttachPath
+        }
+    }
+
     /// Response from `CreateRemoteSession`.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct CreateRemoteSessionResponse {
         /// The new session's public ID.
         pub session_id: String,
-        /// Direct reference to the spawned remote session actor.
-        pub session_ref: kameo::actor::RemoteActorRef<SessionActor>,
+        /// Wire-safe handoff for immediate attach or lookup fallback.
+        pub handoff: SessionHandoff,
         /// Working directory on the remote machine, if known.
         pub cwd: Option<String>,
         /// Session title/name, if known.
@@ -118,7 +144,7 @@ mod remote_impl {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct ForkRemoteSessionResponse {
         pub session_id: String,
-        pub session_ref: kameo::actor::RemoteActorRef<SessionActor>,
+        pub handoff: SessionHandoff,
         pub cwd: Option<String>,
         pub title: Option<String>,
         pub created_at: i64,
@@ -247,60 +273,31 @@ mod remote_impl {
             cwd: Option<String>,
             title: Option<String>,
             created_at: i64,
-        ) -> Result<kameo::actor::RemoteActorRef<SessionActor>, AgentError> {
-            // Remote lifecycle RPCs return a live capability directly; DHT registration
-            // remains best-effort background discoverability for later reconnects.
-            let runtime = SessionRuntime::new(
-                cwd_path.clone(),
-                HashMap::new(),
-                crate::agent::core::McpToolState::empty(),
-            );
-
-            let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
-                .with_mesh(self.mesh.clone());
-            let actor_ref = SessionActor::spawn(actor);
+        ) -> Result<SessionHandoff, AgentError> {
+            let materialization = {
+                let mut registry = self.registry.lock().await;
+                registry.set_mesh(self.mesh.clone());
+                registry
+                    .materialize_session_actor(
+                        session_id.clone(),
+                        cwd_path.clone(),
+                        &[],
+                        false,
+                        SessionMaterializationOptions {
+                            attach_mesh_handle: true,
+                            register_in_dht: true,
+                        },
+                    )
+                    .await
+                    .map_err(|e| AgentError::Internal(e.to_string()))?
+            };
+            let actor_ref = materialization.actor_ref;
+            let runtime = materialization.runtime;
             let actor_id_raw = actor_ref.id().sequence_id();
 
             tracing::Span::current()
                 .record("session_id", &session_id)
                 .record("actor_id", actor_id_raw);
-
-            if let Some(ref mesh) = self.mesh {
-                let dht_name = crate::agent::remote::dht_name::session(&session_id);
-                let reg_span = tracing::info_span!(
-                    "remote.node_manager.dht_register_session",
-                    session_id = %session_id,
-                    dht_name = %dht_name,
-                );
-                let reg_timeout = std::time::Duration::from_secs(2);
-                match tokio::time::timeout(
-                    reg_timeout,
-                    mesh.register_actor(actor_ref.clone(), dht_name.clone())
-                        .instrument(reg_span),
-                )
-                .await
-                {
-                    Ok(()) => {}
-                    Err(_) => {
-                        log::warn!(
-                            "RemoteNodeManager: timed out registering session {} as '{}' in DHT after {:?}; continuing with direct ref handoff",
-                            session_id,
-                            dht_name,
-                            reg_timeout
-                        );
-                    }
-                }
-            } else {
-                log::debug!(
-                    "RemoteNodeManager: no mesh, skipping DHT registration for session {}",
-                    session_id
-                );
-            }
-
-            {
-                let mut registry = self.registry.lock().await;
-                registry.insert(session_id.clone(), actor_ref.clone());
-            }
 
             self.session_meta
                 .insert(session_id.clone(), (created_at, cwd.clone()));
@@ -382,6 +379,29 @@ mod remote_impl {
                 }
             }
 
+            let handoff = match std::panic::AssertUnwindSafe(async {
+                actor_ref.into_remote_ref().await
+            })
+            .catch_unwind()
+            .await
+            {
+                Ok(remote_ref) => SessionHandoff::direct(remote_ref),
+                Err(_) if self.mesh.is_some() => {
+                    log::warn!(
+                        "RemoteNodeManager: direct remote export unavailable for session {}; returning lookup-only handoff",
+                        session_id
+                    );
+                    SessionHandoff::lookup_only()
+                }
+                Err(_) => {
+                    log::warn!(
+                        "RemoteNodeManager: direct remote export unavailable for session {} and no mesh is active; returning no-attach-path handoff",
+                        session_id
+                    );
+                    SessionHandoff::no_attach_path()
+                }
+            };
+
             log::info!(
                 "RemoteNodeManager: materialized session {} (actor_id={}, title={:?})",
                 session_id,
@@ -389,7 +409,7 @@ mod remote_impl {
                 title
             );
 
-            Ok(actor_ref.into_remote_ref().await)
+            Ok(handoff)
         }
     }
 
@@ -467,7 +487,7 @@ mod remote_impl {
                         .unwrap_or(0)
                 });
 
-            let session_ref = self
+            let handoff = self
                 .materialize_remote_session(
                     session_id.clone(),
                     cwd_path,
@@ -479,7 +499,7 @@ mod remote_impl {
 
             Ok(CreateRemoteSessionResponse {
                 session_id,
-                session_ref,
+                handoff,
                 cwd: msg.cwd,
                 title,
                 created_at,
@@ -552,7 +572,7 @@ mod remote_impl {
                         .unwrap_or(0)
                 });
 
-            let session_ref = self
+            let handoff = self
                 .materialize_remote_session(
                     forked_session_id.clone(),
                     cwd_path,
@@ -564,7 +584,7 @@ mod remote_impl {
 
             Ok(ForkRemoteSessionResponse {
                 session_id: forked_session_id,
-                session_ref,
+                handoff,
                 cwd,
                 title,
                 created_at,

--- a/crates/agent/src/agent/remote/node_manager.rs
+++ b/crates/agent/src/agent/remote/node_manager.rs
@@ -624,7 +624,7 @@ mod remote_impl {
             for sid in session_ids {
                 // Prefer metadata from session_meta (for remotely-created sessions),
                 // but fall back to querying the session store for locally-created sessions.
-                let (created_at, cwd, title) = if let Some((ts, meta_cwd)) =
+                let (created_at, cwd, session_name) = if let Some((ts, meta_cwd)) =
                     self.session_meta.get(&sid)
                 {
                     (*ts, meta_cwd.clone(), None)
@@ -633,11 +633,24 @@ mod remote_impl {
                         Ok(Some(session)) => {
                             let ts = session.created_at.map(|t| t.unix_timestamp()).unwrap_or(0);
                             let cwd = session.cwd.map(|p| p.display().to_string());
-                            let title = session.name.clone();
-                            (ts, cwd, title)
+                            let session_name = session.name.clone();
+                            (ts, cwd, session_name)
                         }
                         _ => (0, None, None),
                     }
+                };
+
+                // Match local session-list title behavior: use the initial intent summary
+                // (truncated) as the display title, then fall back to session.name.
+                let title = match store.get_initial_intent_snapshot(&sid).await {
+                    Ok(Some(snapshot)) => {
+                        if snapshot.summary.len() > 80 {
+                            Some(format!("{}...", &snapshot.summary[..77]))
+                        } else {
+                            Some(snapshot.summary)
+                        }
+                    }
+                    _ => session_name,
                 };
 
                 let actor_id = registry

--- a/crates/agent/src/agent/remote/node_manager.rs
+++ b/crates/agent/src/agent/remote/node_manager.rs
@@ -30,6 +30,8 @@ pub struct RemoteSessionInfo {
     pub title: Option<String>,
     /// Human-readable label of the peer that owns this session
     pub peer_label: String,
+    /// High-level runtime lifecycle state for UI summaries.
+    pub runtime_state: Option<String>,
 }
 
 /// Metadata about a remote node.
@@ -58,7 +60,8 @@ pub struct AvailableModel {
 pub use remote_impl::{
     AdmissionRequest, AdmissionResponse, CreateRemoteSession, CreateRemoteSessionResponse,
     DestroyRemoteSession, ForkRemoteSession, ForkRemoteSessionResponse, GetNodeInfo,
-    ListAvailableModels, ListRemoteSessions, RemoteNodeManager, SessionHandoff,
+    ListAvailableModels, ListRemoteSessions, RemoteNodeManager, ResumeRemoteSession,
+    SessionHandoff,
 };
 
 #[cfg(feature = "remote")]
@@ -161,6 +164,12 @@ mod remote_impl {
     /// Destroy (shutdown) a session on this node.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct DestroyRemoteSession {
+        pub session_id: String,
+    }
+
+    /// Re-materialize a persisted session on this node.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ResumeRemoteSession {
         pub session_id: String,
     }
 
@@ -649,6 +658,7 @@ mod remote_impl {
                     created_at,
                     title,
                     peer_label: hostname.clone(),
+                    runtime_state: Some("active".to_string()),
                 });
             }
 
@@ -706,8 +716,10 @@ mod remote_impl {
                     mesh.deregister_actor(&dht_name);
                 }
 
-                self.session_meta.remove(&msg.session_id);
-                log::info!("RemoteNodeManager: destroyed session {}", msg.session_id);
+                log::info!(
+                    "RemoteNodeManager: destroyed runtime for session {}",
+                    msg.session_id
+                );
                 Ok(())
             } else {
                 tracing::Span::current().record("found", false);
@@ -715,6 +727,63 @@ mod remote_impl {
                     session_id: msg.session_id.clone(),
                 })
             }
+        }
+    }
+
+    impl Message<ResumeRemoteSession> for RemoteNodeManager {
+        type Reply = Result<CreateRemoteSessionResponse, AgentError>;
+
+        #[tracing::instrument(
+            name = "remote.node_manager.resume_session",
+            skip(self, _ctx),
+            fields(session_id = %msg.session_id)
+        )]
+        async fn handle(
+            &mut self,
+            msg: ResumeRemoteSession,
+            _ctx: &mut Context<Self, Self::Reply>,
+        ) -> Self::Reply {
+            let session = self
+                .config
+                .provider
+                .history_store()
+                .get_session(&msg.session_id)
+                .await
+                .map_err(|e| AgentError::Internal(e.to_string()))?
+                .ok_or_else(|| AgentError::SessionNotFound {
+                    session_id: msg.session_id.clone(),
+                })?;
+
+            let cwd_path = session.cwd.clone();
+            let cwd = cwd_path.as_ref().map(|p| p.display().to_string());
+            let title = session.name.clone();
+            let created_at = session
+                .created_at
+                .map(|ts| ts.unix_timestamp())
+                .unwrap_or_else(|| {
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0)
+                });
+
+            let handoff = self
+                .materialize_remote_session(
+                    msg.session_id.clone(),
+                    cwd_path,
+                    cwd.clone(),
+                    title.clone(),
+                    created_at,
+                )
+                .await?;
+
+            Ok(CreateRemoteSessionResponse {
+                session_id: msg.session_id,
+                handoff,
+                cwd,
+                title,
+                created_at,
+            })
         }
     }
 
@@ -1020,6 +1089,11 @@ mod remote_impl {
         DestroyRemoteSession,
         "querymt::DestroyRemoteSession",
         REG_DESTROY_REMOTE_SESSION
+    );
+    remote_node_msg_impl!(
+        ResumeRemoteSession,
+        "querymt::ResumeRemoteSession",
+        REG_RESUME_REMOTE_SESSION
     );
     remote_node_msg_impl!(GetNodeInfo, "querymt::GetNodeInfo", REG_GET_NODE_INFO);
     remote_node_msg_impl!(

--- a/crates/agent/src/agent/remote/provider_host.rs
+++ b/crates/agent/src/agent/remote/provider_host.rs
@@ -559,9 +559,25 @@ impl Message<ProviderStreamRequest> for ProviderHostActor {
                             error: e.to_payload(),
                         },
                     };
-                    let is_done = matches!(message, StreamRelayMessage::Chunk(StreamChunk::Done { .. }))
+                    let finish_reason = match &message {
+                        StreamRelayMessage::Chunk(StreamChunk::Done { finish_reason }) => Some(*finish_reason),
+                        _ => None,
+                    };
+                    let is_done = finish_reason.is_some()
                         || matches!(message, StreamRelayMessage::ProviderError { .. });
                     buffered.push_back(message);
+
+                    if let Some(reason) = finish_reason {
+                        tracing::debug!(
+                            target: "remote::provider_host::stream",
+                            provider = %provider_name,
+                            model = %model,
+                            receiver_name = %receiver_name,
+                            finish_reason = ?reason,
+                            chunk_index = chunk_count,
+                            "stream done from upstream provider"
+                        );
+                    }
 
                     loop {
                         if disconnected_since.is_some() {

--- a/crates/agent/src/agent/remote/provider_host.rs
+++ b/crates/agent/src/agent/remote/provider_host.rs
@@ -19,6 +19,7 @@ use querymt::LLMProvider;
 use querymt::ToolCall;
 use querymt::Usage;
 use querymt::chat::{ChatMessage, ChatResponse, FinishReason, StreamChunk, Tool};
+use querymt::error::LLMErrorPayload;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::fmt;
@@ -94,13 +95,13 @@ pub enum StreamRelayMessage {
     /// Normal streamed chunk from the upstream provider.
     Chunk(StreamChunk),
     /// Provider/model error produced by the upstream stream.
-    ProviderError { message: String },
+    ProviderError { error: LLMErrorPayload },
     /// The transport path to the requesting node disappeared but may recover.
     TransportDisconnected { reason: String },
     /// Delivery has resumed after a temporary transport disconnect.
     TransportReconnected { buffered_chunks: usize },
     /// The stream failed permanently because reconnect grace expired.
-    TransportFailed { reason: String },
+    TransportFailed { error: LLMErrorPayload },
 }
 
 /// Thin wrapper around a stream relay/control payload.
@@ -431,7 +432,7 @@ impl Message<ProviderChatRequest> for ProviderHostActor {
             .await
             .map_err(|e| AgentError::ProviderChat {
                 operation: "chat_with_tools".to_string(),
-                reason: e.to_string(),
+                reason: serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
             })?;
 
         let tool_calls = response.tool_calls().unwrap_or_default();
@@ -495,7 +496,7 @@ impl Message<ProviderStreamRequest> for ProviderHostActor {
             .await
             .map_err(|e| AgentError::ProviderChat {
                 operation: "chat_stream_with_tools".to_string(),
-                reason: e.to_string(),
+                reason: serde_json::to_string(&e.to_payload()).unwrap_or_else(|_| e.to_string()),
             })?;
 
         // Look up the StreamReceiverActor on the requesting node.
@@ -555,7 +556,7 @@ impl Message<ProviderStreamRequest> for ProviderHostActor {
                     let message = match chunk_result {
                         Ok(chunk) => StreamRelayMessage::Chunk(chunk),
                         Err(e) => StreamRelayMessage::ProviderError {
-                            message: e.to_string(),
+                            error: e.to_payload(),
                         },
                     };
                     let is_done = matches!(message, StreamRelayMessage::Chunk(StreamChunk::Done { .. }))
@@ -588,10 +589,14 @@ impl Message<ProviderStreamRequest> for ProviderHostActor {
                                         let _ = receiver_ref
                                             .tell(&StreamChunkRelay {
                                                 message: StreamRelayMessage::TransportFailed {
-                                                    reason: format!(
-                                                        "reconnect grace expired after {:?}",
-                                                        reconnect_grace,
-                                                    ),
+                                                    error: querymt::error::LLMError::Transport {
+                                                        kind: querymt::error::TransportErrorKind::Timeout,
+                                                        message: format!(
+                                                            "reconnect grace expired after {:?}",
+                                                            reconnect_grace,
+                                                        ),
+                                                    }
+                                                    .to_payload(),
                                                 },
                                             })
                                             .send();

--- a/crates/agent/src/agent/remote/provider_host_tests.rs
+++ b/crates/agent/src/agent/remote/provider_host_tests.rs
@@ -323,13 +323,18 @@ mod provider_host_tests {
     fn test_stream_chunk_relay_err_roundtrip() {
         let relay = StreamChunkRelay {
             message: StreamRelayMessage::ProviderError {
-                message: "oops".to_string(),
+                error: querymt::error::LLMError::ProviderError("oops".to_string()).to_payload(),
             },
         };
         let json = serde_json::to_string(&relay).expect("serialize");
         let back: StreamChunkRelay = serde_json::from_str(&json).expect("deserialize");
         match back.message {
-            StreamRelayMessage::ProviderError { message } => assert_eq!(message, "oops"),
+            StreamRelayMessage::ProviderError { error } => {
+                assert_eq!(
+                    querymt::error::LLMError::from_payload(error).to_string(),
+                    "LLM Provider Error: oops"
+                )
+            }
             other => panic!("expected ProviderError, got {:?}", other),
         }
     }
@@ -448,7 +453,7 @@ mod provider_host_tests {
 
         let error_relay = StreamChunkRelay {
             message: StreamRelayMessage::ProviderError {
-                message: "boom".to_string(),
+                error: querymt::error::LLMError::ProviderError("boom".to_string()).to_payload(),
             },
         };
 
@@ -461,7 +466,12 @@ mod provider_host_tests {
 
         let received = rx.try_recv().expect("should have received error chunk");
         match received {
-            StreamRelayMessage::ProviderError { message } => assert_eq!(message, "boom"),
+            StreamRelayMessage::ProviderError { error } => {
+                assert_eq!(
+                    querymt::error::LLMError::from_payload(error).to_string(),
+                    "LLM Provider Error: boom"
+                )
+            }
             other => panic!("expected ProviderError, got {:?}", other),
         }
 

--- a/crates/agent/src/agent/remote/provider_host_tests.rs
+++ b/crates/agent/src/agent/remote/provider_host_tests.rs
@@ -409,7 +409,7 @@ mod provider_host_tests {
 
         let done_relay = StreamChunkRelay {
             message: StreamRelayMessage::Chunk(StreamChunk::Done {
-                stop_reason: "end_turn".to_string(),
+                finish_reason: querymt::chat::FinishReason::Stop,
             }),
         };
 

--- a/crates/agent/src/agent/remote/remote_actor_impl.rs
+++ b/crates/agent/src/agent/remote/remote_actor_impl.rs
@@ -114,11 +114,6 @@ remote_msg_impl!(messages::GetMode, "querymt::GetMode", REG_GET_MODE);
 remote_msg_impl!(messages::Undo, "querymt::Undo", REG_UNDO);
 remote_msg_impl!(messages::Redo, "querymt::Redo", REG_REDO);
 remote_msg_impl!(
-    messages::ForkAtMessage,
-    "querymt::ForkAtMessage",
-    REG_FORK_AT_MESSAGE
-);
-remote_msg_impl!(
     messages::SetSessionModel,
     "querymt::SetSessionModel",
     REG_SET_SESSION_MODEL

--- a/crates/agent/src/agent/remote/remote_actor_impl.rs
+++ b/crates/agent/src/agent/remote/remote_actor_impl.rs
@@ -135,6 +135,11 @@ remote_msg_impl!(
     REG_GET_SESSION_LIMITS
 );
 remote_msg_impl!(
+    messages::GetRuntimeStatus,
+    "querymt::GetRuntimeStatus",
+    REG_GET_RUNTIME_STATUS
+);
+remote_msg_impl!(
     messages::SetProvider,
     "querymt::SetProvider",
     REG_SET_PROVIDER

--- a/crates/agent/src/agent/remote/remote_agent_stub_tests.rs
+++ b/crates/agent/src/agent/remote/remote_agent_stub_tests.rs
@@ -43,6 +43,49 @@ mod remote_agent_stub_tests {
         // No panic is the key assertion — both Ok and Err are acceptable outcomes.
     }
 
+    #[tokio::test]
+    async fn test_handle_new_session_returns_live_session_via_direct_ref_handoff() {
+        let test_id = Uuid::now_v7().to_string();
+        let _nm = MeshNodeManagerFixture::new("direct-ref", &test_id).await;
+
+        let mesh = get_test_mesh().await;
+        let handle = make_handle(&format!("direct-ref-{test_id}"), mesh);
+
+        let response = _nm
+            .actor_ref
+            .ask(crate::agent::remote::CreateRemoteSession {
+                cwd: Some("/tmp".to_string()),
+            })
+            .await
+            .expect("direct create_remote_session RPC should succeed");
+
+        let mode = response
+            .session_ref
+            .ask(&crate::agent::messages::GetMode)
+            .await
+            .expect("directly handed off remote ref should be immediately usable");
+
+        let wrapped = crate::agent::remote::SessionActorRef::remote(
+            response.session_ref.clone(),
+            format!("direct-ref-{test_id}"),
+        );
+        handle
+            .cache_session_for_test(response.session_id.clone(), wrapped)
+            .await;
+
+        let cancel_result = handle
+            .cancel(CancelNotification::new(response.session_id.clone()))
+            .await;
+
+        assert_eq!(response.session_id.len(), 36);
+        let _ = mode;
+        assert!(
+            cancel_result.is_ok(),
+            "session returned via direct ref handoff should support handle operations: {:?}",
+            cancel_result.err()
+        );
+    }
+
     // ── C.2 — prompt errors without a live peer ──────────────────────────────
 
     #[tokio::test]

--- a/crates/agent/src/agent/remote/remote_agent_stub_tests.rs
+++ b/crates/agent/src/agent/remote/remote_agent_stub_tests.rs
@@ -10,6 +10,7 @@
 #[allow(clippy::module_inception)]
 mod remote_agent_stub_tests {
     use crate::agent::handle::AgentHandle;
+    use crate::agent::remote::node_manager::SessionHandoff;
     use crate::agent::remote::remote_handle::RemoteAgentHandle;
     use crate::agent::remote::test_helpers::fixtures::{MeshNodeManagerFixture, get_test_mesh};
     use agent_client_protocol::schema::{CancelNotification, NewSessionRequest, SessionId};
@@ -59,14 +60,23 @@ mod remote_agent_stub_tests {
             .await
             .expect("direct create_remote_session RPC should succeed");
 
-        let mode = response
-            .session_ref
+        let session_ref = match response.handoff.clone() {
+            SessionHandoff::DirectRemote { session_ref } => session_ref,
+            SessionHandoff::LookupOnly => {
+                panic!("expected direct handoff in direct-ref test")
+            }
+            SessionHandoff::NoAttachPath => {
+                panic!("expected attachable handoff in direct-ref test")
+            }
+        };
+
+        let mode = session_ref
             .ask(&crate::agent::messages::GetMode)
             .await
             .expect("directly handed off remote ref should be immediately usable");
 
         let wrapped = crate::agent::remote::SessionActorRef::remote(
-            response.session_ref.clone(),
+            session_ref,
             format!("direct-ref-{test_id}"),
         );
         handle

--- a/crates/agent/src/agent/remote/remote_handle.rs
+++ b/crates/agent/src/agent/remote/remote_handle.rs
@@ -45,11 +45,19 @@ impl RemoteAgentHandle {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) async fn cache_session_for_test(
+        &self,
+        session_id: String,
+        session_ref: SessionActorRef,
+    ) {
+        self.sessions.lock().await.insert(session_id, session_ref);
+    }
+
     /// Create a remote session and return `(session_id, SessionActorRef)`.
     ///
     /// Looks up the remote `RemoteNodeManager` via DHT, sends
-    /// `CreateRemoteSession`, and resolves the `SessionActorRef` by
-    /// DHT name lookup.
+    /// `CreateRemoteSession`, and uses the returned direct session ref.
     #[tracing::instrument(
         name = "delegation.remote.create_session",
         skip(self, cwd),
@@ -66,7 +74,6 @@ impl RemoteAgentHandle {
         cwd: Option<String>,
     ) -> Result<(String, SessionActorRef), Error> {
         use crate::agent::remote::{CreateRemoteSession, RemoteNodeManager};
-        use crate::agent::session_actor::SessionActor;
         use crate::error::AgentError;
 
         let span = tracing::Span::current();
@@ -102,30 +109,8 @@ impl RemoteAgentHandle {
 
         let session_id = resp.session_id.clone();
         span.record("session_id", session_id.as_str());
-        let dht_name = crate::agent::remote::dht_name::session(&session_id);
 
-        let t2 = std::time::Instant::now();
-        let remote_session_ref = self
-            .mesh
-            .lookup_actor::<SessionActor>(dht_name.clone())
-            .await
-            .map_err(|e| {
-                Error::from(AgentError::SwarmLookupFailed {
-                    key: dht_name.clone(),
-                    reason: e.to_string(),
-                })
-            })?
-            .ok_or_else(|| {
-                Error::from(AgentError::RemoteSessionNotFound {
-                    details: format!(
-                        "session {} (actor_id={}) not found in DHT under '{}'",
-                        session_id, resp.actor_id, dht_name
-                    ),
-                })
-            })?;
-        span.record("dht_lookup_session_ms", t2.elapsed().as_millis() as u64);
-
-        let session_ref = SessionActorRef::remote(remote_session_ref, self.peer_label.clone());
+        let session_ref = SessionActorRef::remote(resp.session_ref, self.peer_label.clone());
 
         // Store the session ref for future prompt/cancel calls.
         self.sessions

--- a/crates/agent/src/agent/remote/remote_handle.rs
+++ b/crates/agent/src/agent/remote/remote_handle.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
 
 use super::mesh::MeshHandle;
+use super::node_manager::SessionHandoff;
 
 /// A handle for interacting with a remote agent via the kameo mesh.
 ///
@@ -110,7 +111,63 @@ impl RemoteAgentHandle {
         let session_id = resp.session_id.clone();
         span.record("session_id", session_id.as_str());
 
-        let session_ref = SessionActorRef::remote(resp.session_ref, self.peer_label.clone());
+        let session_ref = match resp.handoff {
+            SessionHandoff::DirectRemote { session_ref } => {
+                SessionActorRef::remote(session_ref, self.peer_label.clone())
+            }
+            SessionHandoff::LookupOnly => {
+                let dht_name = crate::agent::remote::dht_name::session(&session_id);
+                let lookup_backoff_ms: [u64; 4] = [0, 120, 300, 700];
+                let mut remote_ref = None;
+                let mut last_error = None;
+
+                for delay_ms in lookup_backoff_ms {
+                    if delay_ms > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    }
+
+                    match self
+                        .mesh
+                        .lookup_actor_no_retry::<crate::agent::session_actor::SessionActor>(
+                            dht_name.clone(),
+                        )
+                        .await
+                    {
+                        Ok(Some(found)) => {
+                            remote_ref = Some(found);
+                            break;
+                        }
+                        Ok(None) => {}
+                        Err(e) => last_error = Some(e.to_string()),
+                    }
+                }
+
+                let remote_ref = remote_ref.ok_or_else(|| {
+                    if let Some(reason) = last_error {
+                        Error::from(AgentError::SwarmLookupFailed {
+                            key: dht_name.clone(),
+                            reason,
+                        })
+                    } else {
+                        Error::from(AgentError::RemoteSessionNotFound {
+                            details: format!(
+                                "remote session {} created but not yet discoverable via lookup",
+                                session_id
+                            ),
+                        })
+                    }
+                })?;
+                SessionActorRef::remote(remote_ref, self.peer_label.clone())
+            }
+            SessionHandoff::NoAttachPath => {
+                return Err(Error::from(AgentError::RemoteSessionNotFound {
+                    details: format!(
+                        "remote session {} was created but the remote node cannot provide a direct or lookup attach path",
+                        session_id
+                    ),
+                }));
+            }
+        };
 
         // Store the session ref for future prompt/cancel calls.
         self.sessions

--- a/crates/agent/src/agent/remote/test_helpers.rs
+++ b/crates/agent/src/agent/remote/test_helpers.rs
@@ -244,7 +244,7 @@ pub(crate) mod fixtures {
             let chunks = vec![
                 Ok(StreamChunk::Text(text)),
                 Ok(StreamChunk::Done {
-                    stop_reason: "end_turn".to_string(),
+                    finish_reason: querymt::chat::FinishReason::Stop,
                 }),
             ];
             Ok(Box::pin(stream::iter(chunks)))

--- a/crates/agent/src/agent/remote/tests.rs
+++ b/crates/agent/src/agent/remote/tests.rs
@@ -506,7 +506,7 @@ mod node_manager_tests {
     use crate::agent::messages::GetMode;
     use crate::agent::remote::node_manager::{
         CreateRemoteSession, DestroyRemoteSession, ForkRemoteSession, GetNodeInfo,
-        ListRemoteSessions, RemoteNodeManager, SessionHandoff,
+        ListRemoteSessions, RemoteNodeManager, ResumeRemoteSession, SessionHandoff,
     };
     use crate::agent::remote::test_helpers::fixtures::get_test_mesh;
     use crate::model::{AgentMessage, MessagePart};
@@ -680,7 +680,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_destroy_session() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
+        let (nm_ref, config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let resp = nm_ref
             .ask(CreateRemoteSession { cwd: None })
@@ -696,6 +696,16 @@ mod node_manager_tests {
 
         let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
         assert!(sessions.is_empty());
+        assert!(
+            config
+                .provider
+                .history_store()
+                .get_session(&resp.session_id)
+                .await
+                .expect("session lookup")
+                .is_some(),
+            "destroy should remove only the runtime, not persisted history"
+        );
     }
 
     #[tokio::test]
@@ -812,6 +822,36 @@ mod node_manager_tests {
         let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, resp2.session_id);
+    }
+
+    #[tokio::test]
+    async fn test_resume_destroyed_session() {
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
+
+        let resp = nm_ref
+            .ask(CreateRemoteSession { cwd: None })
+            .await
+            .expect("create");
+
+        nm_ref
+            .ask(DestroyRemoteSession {
+                session_id: resp.session_id.clone(),
+            })
+            .await
+            .expect("destroy");
+
+        let resumed = nm_ref
+            .ask(ResumeRemoteSession {
+                session_id: resp.session_id.clone(),
+            })
+            .await
+            .expect("resume");
+
+        assert_eq!(resumed.session_id, resp.session_id);
+
+        let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, resp.session_id);
     }
 
     #[tokio::test]

--- a/crates/agent/src/agent/remote/tests.rs
+++ b/crates/agent/src/agent/remote/tests.rs
@@ -503,14 +503,18 @@ mod event_forwarder_stub {
 #[cfg(feature = "remote")]
 mod node_manager_tests {
     use super::*;
+    use crate::agent::messages::GetMode;
     use crate::agent::remote::node_manager::{
-        CreateRemoteSession, DestroyRemoteSession, GetNodeInfo, ListRemoteSessions,
-        RemoteNodeManager,
+        CreateRemoteSession, DestroyRemoteSession, ForkRemoteSession, GetNodeInfo,
+        ListRemoteSessions, RemoteNodeManager,
     };
     use crate::agent::remote::test_helpers::fixtures::get_test_mesh;
+    use crate::model::{AgentMessage, MessagePart};
     use kameo::actor::{ActorRef, Spawn};
     use kameo::error::SendError;
+    use querymt::chat::ChatRole;
     use tokio::sync::Mutex;
+    use uuid::Uuid;
 
     /// Spawn a `RemoteNodeManager` actor without mesh and return its `ActorRef`.
     async fn spawn_test_node_manager_no_mesh()
@@ -535,7 +539,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_create_session_no_cwd() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let resp = nm_ref
             .ask(CreateRemoteSession { cwd: None })
@@ -546,12 +550,12 @@ mod node_manager_tests {
             !resp.session_id.is_empty(),
             "session_id should not be empty"
         );
-        assert!(resp.actor_id > 0, "actor_id should be positive");
+        assert!(resp.created_at >= 0, "created_at should be populated");
     }
 
     #[tokio::test]
     async fn test_create_session_valid_cwd() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
         let cwd_dir = TempDir::new().unwrap();
 
         let resp = nm_ref
@@ -566,7 +570,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_create_session_nonexistent_cwd() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let resp = nm_ref
             .ask(CreateRemoteSession {
@@ -580,7 +584,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_create_session_relative_cwd_rejected() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let result = nm_ref
             .ask(CreateRemoteSession {
@@ -603,7 +607,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_list_sessions_empty() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let sessions = nm_ref
             .ask(ListRemoteSessions)
@@ -615,7 +619,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_list_sessions_after_create() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let resp = nm_ref
             .ask(CreateRemoteSession { cwd: None })
@@ -631,7 +635,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_create_multiple_sessions() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let mut session_ids = Vec::new();
         for _ in 0..3 {
@@ -654,7 +658,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_destroy_session() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let resp = nm_ref
             .ask(CreateRemoteSession { cwd: None })
@@ -674,7 +678,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_destroy_nonexistent_session() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         let result = nm_ref
             .ask(DestroyRemoteSession {
@@ -740,7 +744,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_create_session_cwd_tracked_in_list() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
         let cwd_dir = TempDir::new().unwrap();
         let cwd_str = cwd_dir.path().to_string_lossy().to_string();
 
@@ -760,7 +764,7 @@ mod node_manager_tests {
 
     #[tokio::test]
     async fn test_destroy_then_create_reuses_slot() {
-        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+        let (nm_ref, _config, _td) = spawn_test_node_manager_with_mesh().await;
 
         // Create + destroy
         let resp1 = nm_ref
@@ -786,6 +790,52 @@ mod node_manager_tests {
         let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, resp2.session_id);
+    }
+
+    #[tokio::test]
+    async fn test_fork_remote_session_returns_live_child_ref() {
+        let (nm_ref, config, _td) = spawn_test_node_manager_with_mesh().await;
+
+        let parent = nm_ref
+            .ask(CreateRemoteSession { cwd: None })
+            .await
+            .expect("create parent");
+
+        let message_id = Uuid::new_v4().to_string();
+        config
+            .provider
+            .history_store()
+            .add_message(
+                &parent.session_id,
+                AgentMessage {
+                    id: message_id.clone(),
+                    session_id: parent.session_id.clone(),
+                    role: ChatRole::User,
+                    parts: vec![MessagePart::Text {
+                        content: "fork here".to_string(),
+                    }],
+                    created_at: time::OffsetDateTime::now_utc().unix_timestamp(),
+                    parent_message_id: None,
+                    source_provider: None,
+                    source_model: None,
+                },
+            )
+            .await
+            .expect("insert parent message");
+
+        let resp = nm_ref
+            .ask(ForkRemoteSession {
+                source_session_id: parent.session_id.clone(),
+                message_id,
+            })
+            .await
+            .expect("fork child");
+
+        assert_ne!(resp.session_id, parent.session_id);
+        assert!(resp.session_ref.ask(&GetMode).await.is_ok());
+
+        let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
+        assert!(sessions.iter().any(|s| s.session_id == resp.session_id));
     }
 }
 

--- a/crates/agent/src/agent/remote/tests.rs
+++ b/crates/agent/src/agent/remote/tests.rs
@@ -506,7 +506,7 @@ mod node_manager_tests {
     use crate::agent::messages::GetMode;
     use crate::agent::remote::node_manager::{
         CreateRemoteSession, DestroyRemoteSession, ForkRemoteSession, GetNodeInfo,
-        ListRemoteSessions, RemoteNodeManager,
+        ListRemoteSessions, RemoteNodeManager, SessionHandoff,
     };
     use crate::agent::remote::test_helpers::fixtures::get_test_mesh;
     use crate::model::{AgentMessage, MessagePart};
@@ -551,6 +551,28 @@ mod node_manager_tests {
             "session_id should not be empty"
         );
         assert!(resp.created_at >= 0, "created_at should be populated");
+        assert!(matches!(resp.handoff, SessionHandoff::DirectRemote { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_create_session_no_mesh_never_claims_lookup_fallback() {
+        let (nm_ref, _config, _td) = spawn_test_node_manager_no_mesh().await;
+
+        let resp = nm_ref
+            .ask(CreateRemoteSession { cwd: None })
+            .await
+            .expect("create session without mesh should succeed");
+
+        assert!(
+            matches!(
+                resp.handoff,
+                SessionHandoff::DirectRemote { .. } | SessionHandoff::NoAttachPath
+            ),
+            "no-mesh environments must not advertise lookup-only handoff"
+        );
+
+        let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
+        assert!(sessions.iter().any(|s| s.session_id == resp.session_id));
     }
 
     #[tokio::test]
@@ -832,7 +854,12 @@ mod node_manager_tests {
             .expect("fork child");
 
         assert_ne!(resp.session_id, parent.session_id);
-        assert!(resp.session_ref.ask(&GetMode).await.is_ok());
+        let session_ref = match resp.handoff {
+            SessionHandoff::DirectRemote { session_ref } => session_ref,
+            SessionHandoff::LookupOnly => panic!("expected direct handoff in mesh test"),
+            SessionHandoff::NoAttachPath => panic!("expected attachable handoff in mesh test"),
+        };
+        assert!(session_ref.ask(&GetMode).await.is_ok());
 
         let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
         assert!(sessions.iter().any(|s| s.session_id == resp.session_id));

--- a/crates/agent/src/agent/remote/tests.rs
+++ b/crates/agent/src/agent/remote/tests.rs
@@ -510,6 +510,7 @@ mod node_manager_tests {
     };
     use crate::agent::remote::test_helpers::fixtures::get_test_mesh;
     use crate::model::{AgentMessage, MessagePart};
+    use crate::session::domain::IntentSnapshot;
     use kameo::actor::{ActorRef, Spawn};
     use kameo::error::SendError;
     use querymt::chat::ChatRole;
@@ -653,6 +654,47 @@ mod node_manager_tests {
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, resp.session_id);
         assert!(!sessions[0].peer_label.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions_uses_initial_intent_snapshot_as_title() {
+        let (nm_ref, config, _td) = spawn_test_node_manager_with_mesh().await;
+
+        let resp = nm_ref
+            .ask(CreateRemoteSession { cwd: None })
+            .await
+            .expect("create");
+
+        let session = config
+            .provider
+            .history_store()
+            .get_session(&resp.session_id)
+            .await
+            .expect("session lookup")
+            .expect("created session should exist");
+
+        config
+            .provider
+            .history_store()
+            .create_intent_snapshot(IntentSnapshot {
+                id: 0,
+                session_id: session.id,
+                task_id: None,
+                summary: "Remote title from snapshot".to_string(),
+                constraints: None,
+                next_step_hint: None,
+                created_at: time::OffsetDateTime::now_utc(),
+            })
+            .await
+            .expect("create intent snapshot");
+
+        let sessions = nm_ref.ask(ListRemoteSessions).await.expect("list");
+        let listed = sessions
+            .iter()
+            .find(|s| s.session_id == resp.session_id)
+            .expect("created session should be listed");
+
+        assert_eq!(listed.title.as_deref(), Some("Remote title from snapshot"));
     }
 
     #[tokio::test]

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -1418,10 +1418,10 @@ impl Message<Prompt> for SessionActor {
                 })
                 .await
             {
-                warn!(
-                    "Failed to send PromptFinished message to actor: {:?}. \
-                     Session may remain in 'busy' state until next prompt resets it.",
-                    e
+                debug!(
+                    "Failed to send PromptFinished message to actor ({}): {:?}. \
+                     Actor may have been shutdown — next prompt will reset via generation guard.",
+                    session_id, e
                 );
             } else {
                 debug!("Session {}: PromptFinished sent successfully", session_id);
@@ -2135,6 +2135,37 @@ mod tests {
             .await
             .expect("ask GetRuntimeStatus");
 
+        assert_eq!(status, SessionRuntimeStatus::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_get_runtime_status_cancel_requested_when_prompt_running_and_cancelled() {
+        let f = ActorFixture::new().await;
+
+        // Simulate prompt_running=true and token cancelled (the state after Cancel
+        // is received while a prompt execution task is still in flight).
+        f.actor_ref
+            .tell(PromptFinished { generation: 0 })
+            .await
+            .expect("tell PromptFinished");
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // Now set prompt_running=true and cancel the token
+        f.actor_ref.tell(Cancel).await.expect("tell Cancel");
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // We can't directly set prompt_running from outside, but we can verify
+        // the status logic: when prompt_running=false and token is cancelled,
+        // status should be Idle (not CancelRequested) because there's no running
+        // prompt to cancel.
+        let status = f
+            .actor_ref
+            .ask(GetRuntimeStatus)
+            .await
+            .expect("ask GetRuntimeStatus");
+
+        // prompt_running is false (no prompt was sent), so status is Idle
+        // even though the token was cancelled.
         assert_eq!(status, SessionRuntimeStatus::Idle);
     }
 

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -820,6 +820,25 @@ impl Message<GetSessionLimits> for SessionActor {
     }
 }
 
+impl Message<GetRuntimeStatus> for SessionActor {
+    type Reply = Result<SessionRuntimeStatus, kameo::error::Infallible>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetRuntimeStatus,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let status = if !self.prompt_running {
+            SessionRuntimeStatus::Idle
+        } else if self.turn_state.token.is_cancelled() {
+            SessionRuntimeStatus::CancelRequested
+        } else {
+            SessionRuntimeStatus::Running
+        };
+        Ok(status)
+    }
+}
+
 impl Message<GetLlmConfig> for SessionActor {
     type Reply = Result<Option<LLMConfig>, AgentError>;
 
@@ -2089,6 +2108,34 @@ mod tests {
             }
         }
         assert!(found_cancel, "Expected Cancelled event on event fanout");
+    }
+
+    #[tokio::test]
+    async fn test_get_runtime_status_idle_when_not_running() {
+        let f = ActorFixture::new().await;
+
+        let status = f
+            .actor_ref
+            .ask(GetRuntimeStatus)
+            .await
+            .expect("ask GetRuntimeStatus");
+
+        assert_eq!(status, SessionRuntimeStatus::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_get_runtime_status_remains_idle_after_cancel_without_running_prompt() {
+        let f = ActorFixture::new().await;
+
+        f.actor_ref.tell(Cancel).await.expect("tell Cancel");
+
+        let status = f
+            .actor_ref
+            .ask(GetRuntimeStatus)
+            .await
+            .expect("ask GetRuntimeStatus");
+
+        assert_eq!(status, SessionRuntimeStatus::Idle);
     }
 
     #[tokio::test]

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -1593,12 +1593,15 @@ async fn execute_prompt_detached(
     );
 
     // Acquire execution permit (blocking with timeout)
-    let _permit = match tokio::time::timeout(
-        std::time::Duration::from_millis(100),
-        runtime.execution_permit.acquire(),
-    )
-    .await
-    {
+    let _permit = match tokio::select! {
+        permit = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            runtime.execution_permit.acquire(),
+        ) => permit,
+        _ = cancel_token.cancelled() => {
+            return Ok(PromptResponse::new(StopReason::Cancelled));
+        }
+    } {
         Ok(Ok(permit)) => permit,
         Ok(Err(_)) => return Err(AgentError::SessionSemaphoreClosed),
         Err(_) => {
@@ -1613,7 +1616,12 @@ async fn execute_prompt_detached(
                 },
             );
             let timeout_duration = std::time::Duration::from_secs(config.execution_timeout_secs);
-            match tokio::time::timeout(timeout_duration, runtime.execution_permit.acquire()).await {
+            match tokio::select! {
+                permit = tokio::time::timeout(timeout_duration, runtime.execution_permit.acquire()) => permit,
+                _ = cancel_token.cancelled() => {
+                    return Ok(PromptResponse::new(StopReason::Cancelled));
+                }
+            } {
                 Ok(Ok(permit)) => permit,
                 Ok(Err(_)) => return Err(AgentError::SessionSemaphoreClosed),
                 Err(_) => {

--- a/crates/agent/src/agent/session_registry.rs
+++ b/crates/agent/src/agent/session_registry.rs
@@ -454,17 +454,12 @@ impl SessionRegistry {
         session_ref
     }
 
-    /// Detach a remote session: send `UnsubscribeEvents` to stop the remote
-    /// `EventForwarder`, then remove the session from the registry.
-    ///
-    /// This is the counterpart to [`attach_remote_session`](Self::attach_remote_session).
-    /// Call this instead of bare `remove()` for remote sessions so the
-    /// forwarder task on the remote node is properly cleaned up.
-    ///
-    /// For local sessions (or if the session is not in the registry) this
-    /// falls back to a plain `remove()`.
     #[cfg(feature = "remote")]
-    pub async fn detach_remote_session(&mut self, session_id: &str) -> Option<SessionActorRef> {
+    async fn detach_remote_session_inner(
+        &mut self,
+        session_id: &str,
+        preserve_bookmark: bool,
+    ) -> Option<SessionActorRef> {
         // Send UnsubscribeEvents before removing so the remote forwarder is aborted.
         if let (Some(session_ref), Some((relay_id, relay_dht_name))) = (
             self.sessions.get(session_id),
@@ -503,18 +498,43 @@ impl SessionRegistry {
             }
         }
 
-        // Remove the persisted bookmark.
-        let store = self.config.provider.history_store();
-        let sid = session_id.to_string();
-        tokio::spawn(async move {
-            if let Err(e) = store.remove_remote_session_bookmark(&sid).await {
-                log::warn!("Failed to remove remote session bookmark {}: {}", sid, e);
-            }
-        });
+        if !preserve_bookmark {
+            let store = self.config.provider.history_store();
+            let sid = session_id.to_string();
+            tokio::spawn(async move {
+                if let Err(e) = store.remove_remote_session_bookmark(&sid).await {
+                    log::warn!("Failed to remove remote session bookmark {}: {}", sid, e);
+                }
+            });
+        }
 
         self.relay_actor_ids.remove(session_id);
         self.local_actor_refs.remove(session_id);
         self.sessions.remove(session_id)
+    }
+
+    /// Detach a remote session: send `UnsubscribeEvents` to stop the remote
+    /// `EventForwarder`, then remove the session from the registry.
+    ///
+    /// This is the counterpart to [`attach_remote_session`](Self::attach_remote_session).
+    /// Call this instead of bare `remove()` for remote sessions so the
+    /// forwarder task on the remote node is properly cleaned up.
+    ///
+    /// For local sessions (or if the session is not in the registry) this
+    /// falls back to a plain `remove()`.
+    #[cfg(feature = "remote")]
+    pub async fn detach_remote_session(&mut self, session_id: &str) -> Option<SessionActorRef> {
+        self.detach_remote_session_inner(session_id, false).await
+    }
+
+    /// Remove a remote session runtime from local tracking but keep its bookmark
+    /// so the stopped session remains visible and resumable.
+    #[cfg(feature = "remote")]
+    pub async fn detach_remote_session_preserve_bookmark(
+        &mut self,
+        session_id: &str,
+    ) -> Option<SessionActorRef> {
+        self.detach_remote_session_inner(session_id, true).await
     }
 
     /// Create a new session: build runtime, spawn SessionActor, return session_id.

--- a/crates/agent/src/agent/session_registry.rs
+++ b/crates/agent/src/agent/session_registry.rs
@@ -13,8 +13,9 @@ use agent_client_protocol::schema::{
     NewSessionResponse, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOption, SessionInfo, SessionMode, SessionModeState,
 };
-use kameo::actor::Spawn;
+use kameo::actor::{ActorRef, Spawn};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 fn all_session_modes() -> Vec<SessionMode> {
@@ -76,10 +77,22 @@ pub(crate) fn config_options(
     ]
 }
 
+/// Controls how a materialized session actor is integrated with remote infra.
+pub struct SessionMaterializationOptions {
+    pub attach_mesh_handle: bool,
+    pub register_in_dht: bool,
+}
+
 /// Manages session actors. Lives on the server layer.
+pub struct SessionMaterialization {
+    pub actor_ref: ActorRef<SessionActor>,
+    pub runtime: Arc<SessionRuntime>,
+}
+
 pub struct SessionRegistry {
     pub config: Arc<AgentConfig>,
     sessions: HashMap<String, SessionActorRef>,
+    local_actor_refs: HashMap<String, ActorRef<SessionActor>>,
     /// Tracks the `(relay_actor_id, relay_dht_name)` spawned for each remote
     /// session so that `detach_remote_session` can send `UnsubscribeEvents`
     /// with both values.
@@ -100,6 +113,7 @@ impl SessionRegistry {
         Self {
             config,
             sessions: HashMap::new(),
+            local_actor_refs: HashMap::new(),
             #[cfg(feature = "remote")]
             relay_actor_ids: HashMap::new(),
             #[cfg(feature = "remote")]
@@ -127,15 +141,13 @@ impl SessionRegistry {
     pub fn set_mesh(&mut self, mesh: Option<crate::agent::remote::MeshHandle>) {
         // Register all existing local sessions in DHT so remote peers can attach.
         if let Some(ref mesh) = mesh {
-            for (session_id, session_ref) in &self.sessions {
-                if let SessionActorRef::Local(ar) = session_ref {
-                    let dht_name = crate::agent::remote::dht_name::session(session_id);
-                    let mesh = mesh.clone();
-                    let ar = ar.clone();
-                    tokio::spawn(async move {
-                        mesh.register_actor(ar, dht_name).await;
-                    });
-                }
+            for (session_id, actor_ref) in &self.local_actor_refs {
+                let dht_name = crate::agent::remote::dht_name::session(session_id);
+                let mesh = mesh.clone();
+                let actor_ref = actor_ref.clone();
+                tokio::spawn(async move {
+                    mesh.register_actor(actor_ref, dht_name).await;
+                });
             }
         }
         self.mesh = mesh;
@@ -182,7 +194,87 @@ impl SessionRegistry {
     /// Accepts anything that converts into a `SessionActorRef`, including
     /// a bare `ActorRef<SessionActor>` (via the `From` impl).
     pub fn insert(&mut self, session_id: String, actor_ref: impl Into<SessionActorRef>) {
-        self.sessions.insert(session_id, actor_ref.into());
+        self.sessions.insert(session_id.clone(), actor_ref.into());
+        self.local_actor_refs.remove(&session_id);
+    }
+
+    pub fn local_actor_ref(&self, session_id: &str) -> Option<&ActorRef<SessionActor>> {
+        self.local_actor_refs.get(session_id)
+    }
+
+    pub async fn materialize_session_actor(
+        &mut self,
+        session_id: String,
+        cwd: Option<PathBuf>,
+        mcp_servers: &[McpServer],
+        initialize_fork: bool,
+        options: SessionMaterializationOptions,
+    ) -> Result<SessionMaterialization, Error> {
+        let merged_mcp = self.merged_mcp_servers(mcp_servers);
+        let tool_state = crate::agent::core::McpToolState::empty();
+        let mcp_services = crate::agent::protocol::build_mcp_state(
+            &merged_mcp,
+            self.config.pending_elicitations(),
+            self.config.event_sink.clone(),
+            session_id.clone(),
+            &crate::agent::mcp::agent_implementation(),
+            tool_state.clone(),
+        )
+        .await?;
+
+        if initialize_fork {
+            crate::session::runtime::SessionForkHelper::initialize_fork(
+                self.config.provider.history_store(),
+                &session_id,
+            )
+            .await
+            .map_err(|e| Error::internal_error().data(e.to_string()))?;
+        }
+
+        let runtime = SessionRuntime::new(cwd.clone(), mcp_services, tool_state);
+        #[cfg(feature = "remote")]
+        let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
+            .with_mesh(if options.attach_mesh_handle {
+                self.mesh.clone()
+            } else {
+                None
+            });
+        #[cfg(not(feature = "remote"))]
+        let actor = {
+            let _ = &options;
+            SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
+        };
+        let actor_ref = SessionActor::spawn(actor);
+        let session_ref = SessionActorRef::from(actor_ref.clone());
+
+        if let Some(ref bridge) = self.bridge
+            && let Err(e) = session_ref.set_bridge(bridge.clone()).await
+        {
+            log::warn!(
+                "Session {}: failed to set bridge on session actor: {}",
+                session_id,
+                e
+            );
+        }
+
+        self.sessions
+            .insert(session_id.clone(), session_ref.clone());
+        self.local_actor_refs
+            .insert(session_id.clone(), actor_ref.clone());
+
+        #[cfg(feature = "remote")]
+        if options.register_in_dht
+            && let Some(ref mesh) = self.mesh
+        {
+            let dht_name = crate::agent::remote::dht_name::session(&session_id);
+            let mesh = mesh.clone();
+            let actor_ref = actor_ref.clone();
+            tokio::spawn(async move {
+                mesh.register_actor(actor_ref, dht_name).await;
+            });
+        }
+
+        Ok(SessionMaterialization { actor_ref, runtime })
     }
 
     /// Remove a session actor from the registry.
@@ -195,6 +287,7 @@ impl SessionRegistry {
             let session_dht_name = crate::agent::remote::dht_name::session(session_id);
             mesh.deregister_actor(&session_dht_name);
         }
+        self.local_actor_refs.remove(session_id);
         self.sessions.remove(session_id)
     }
 
@@ -420,6 +513,7 @@ impl SessionRegistry {
         });
 
         self.relay_actor_ids.remove(session_id);
+        self.local_actor_refs.remove(session_id);
         self.sessions.remove(session_id)
     }
 
@@ -458,60 +552,19 @@ impl SessionRegistry {
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
         let session_id = session_context.session().public_id.clone();
 
-        // Build MCP state: merge config-level MCP servers with any client-supplied ones.
-        let merged_mcp = self.merged_mcp_servers(&req.mcp_servers);
-        let tool_state = crate::agent::core::McpToolState::empty();
-        let mcp_services = crate::agent::protocol::build_mcp_state(
-            &merged_mcp,
-            self.config.pending_elicitations(),
-            self.config.event_sink.clone(),
-            session_id.clone(),
-            &crate::agent::mcp::agent_implementation(),
-            tool_state.clone(),
-        )
-        .await?;
-
-        // Initialize fork if parent_session_id was provided
-        if parent_session_id.is_some() {
-            crate::session::runtime::SessionForkHelper::initialize_fork(
-                self.config.provider.history_store(),
-                &session_id,
+        let materialization = self
+            .materialize_session_actor(
+                session_id.clone(),
+                cwd.clone(),
+                &req.mcp_servers,
+                parent_session_id.is_some(),
+                SessionMaterializationOptions {
+                    attach_mesh_handle: true,
+                    register_in_dht: true,
+                },
             )
-            .await
-            .map_err(|e| Error::internal_error().data(e.to_string()))?;
-        }
-
-        let runtime = SessionRuntime::new(cwd.clone(), mcp_services, tool_state);
-
-        // Spawn the session actor
-        let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone());
-        let actor_ref = SessionActor::spawn(actor);
-        let session_ref: SessionActorRef = actor_ref.clone().into();
-
-        // Propagate client bridge so the session can send notifications and
-        // tools like `language_query` can access the client's language server.
-        if let Some(ref bridge) = self.bridge
-            && let Err(e) = session_ref.set_bridge(bridge.clone()).await
-        {
-            log::warn!(
-                "Session {}: failed to set bridge on new session actor: {}",
-                session_id,
-                e
-            );
-        }
-
-        self.sessions.insert(session_id.clone(), session_ref);
-
-        // Register in DHT so remote peers can discover and attach to this session.
-        #[cfg(feature = "remote")]
-        if let Some(ref mesh) = self.mesh {
-            let dht_name = crate::agent::remote::dht_name::session(&session_id);
-            let mesh = mesh.clone();
-            let ar = actor_ref.clone();
-            tokio::spawn(async move {
-                mesh.register_actor(ar, dht_name).await;
-            });
-        }
+            .await?;
+        let runtime = materialization.runtime;
 
         self.config
             .emit_event(&session_id, crate::events::AgentEventKind::SessionCreated);
@@ -628,47 +681,18 @@ impl SessionRegistry {
             Some(req.cwd.clone())
         };
 
-        let merged_mcp = self.merged_mcp_servers(&req.mcp_servers);
-        let tool_state = crate::agent::core::McpToolState::empty();
-        let mcp_services = crate::agent::protocol::build_mcp_state(
-            &merged_mcp,
-            self.config.pending_elicitations(),
-            self.config.event_sink.clone(),
-            session_id.clone(),
-            &crate::agent::mcp::agent_implementation(),
-            tool_state.clone(),
-        )
-        .await?;
-
-        let runtime = SessionRuntime::new(cwd, mcp_services, tool_state);
-
-        let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime);
-        let actor_ref = SessionActor::spawn(actor);
-        let session_ref: SessionActorRef = actor_ref.clone().into();
-
-        // Propagate client bridge (same as new_session)
-        if let Some(ref bridge) = self.bridge
-            && let Err(e) = session_ref.set_bridge(bridge.clone()).await
-        {
-            log::warn!(
-                "Session {}: failed to set bridge on loaded session actor: {}",
-                session_id,
-                e
-            );
-        }
-
-        self.sessions.insert(session_id.clone(), session_ref);
-
-        // Register in DHT so remote peers can discover and attach to this session.
-        #[cfg(feature = "remote")]
-        if let Some(ref mesh) = self.mesh {
-            let dht_name = crate::agent::remote::dht_name::session(&session_id);
-            let mesh = mesh.clone();
-            let ar = actor_ref.clone();
-            tokio::spawn(async move {
-                mesh.register_actor(ar, dht_name).await;
-            });
-        }
+        let _materialization = self
+            .materialize_session_actor(
+                session_id.clone(),
+                cwd,
+                &req.mcp_servers,
+                false,
+                SessionMaterializationOptions {
+                    attach_mesh_handle: true,
+                    register_in_dht: true,
+                },
+            )
+            .await?;
 
         // Stream full history to client
         // TODO: Implement full-fidelity history streaming with SessionUpdate notifications
@@ -799,47 +823,18 @@ impl SessionRegistry {
             Some(req.cwd.clone())
         };
 
-        let merged_mcp = self.merged_mcp_servers(&req.mcp_servers);
-        let tool_state = crate::agent::core::McpToolState::empty();
-        let mcp_services = crate::agent::protocol::build_mcp_state(
-            &merged_mcp,
-            self.config.pending_elicitations(),
-            self.config.event_sink.clone(),
-            session_id.clone(),
-            &crate::agent::mcp::agent_implementation(),
-            tool_state.clone(),
-        )
-        .await?;
-
-        let runtime = SessionRuntime::new(cwd, mcp_services, tool_state);
-
-        let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime);
-        let actor_ref = SessionActor::spawn(actor);
-        let session_ref: SessionActorRef = actor_ref.clone().into();
-
-        // Propagate client bridge (same as new_session)
-        if let Some(ref bridge) = self.bridge
-            && let Err(e) = session_ref.set_bridge(bridge.clone()).await
-        {
-            log::warn!(
-                "Session {}: failed to set bridge on resumed session actor: {}",
-                session_id,
-                e
-            );
-        }
-
-        self.sessions.insert(session_id.clone(), session_ref);
-
-        // Register in DHT so remote peers can discover and attach to this session.
-        #[cfg(feature = "remote")]
-        if let Some(ref mesh) = self.mesh {
-            let dht_name = crate::agent::remote::dht_name::session(&session_id);
-            let mesh = mesh.clone();
-            let ar = actor_ref.clone();
-            tokio::spawn(async move {
-                mesh.register_actor(ar, dht_name).await;
-            });
-        }
+        let _materialization = self
+            .materialize_session_actor(
+                session_id.clone(),
+                cwd,
+                &req.mcp_servers,
+                false,
+                SessionMaterializationOptions {
+                    attach_mesh_handle: true,
+                    register_in_dht: true,
+                },
+            )
+            .await?;
 
         self.config
             .emit_event(&session_id, crate::events::AgentEventKind::SessionCreated);

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -223,6 +223,9 @@ pub const DEFAULT_RATE_LIMIT_WAIT_SECS: u64 = 60;
 /// Default backoff multiplier for rate limiting
 pub const DEFAULT_RATE_LIMIT_BACKOFF_MULTIPLIER: f64 = 2.0;
 
+/// Default max retries for mid-stream transport failures
+pub const DEFAULT_STREAM_MAX_RETRIES: usize = 1;
+
 fn default_rate_limit_max_retries() -> usize {
     DEFAULT_RATE_LIMIT_MAX_RETRIES
 }
@@ -233,6 +236,10 @@ fn default_rate_limit_wait_secs() -> u64 {
 
 fn default_rate_limit_backoff_multiplier() -> f64 {
     DEFAULT_RATE_LIMIT_BACKOFF_MULTIPLIER
+}
+
+fn default_stream_max_retries() -> usize {
+    DEFAULT_STREAM_MAX_RETRIES
 }
 
 /// Configuration for rate limit retry behavior
@@ -251,6 +258,11 @@ pub struct RateLimitConfig {
     /// Wait time increases exponentially: default_wait_secs * multiplier^(attempt-1)
     #[serde(default = "default_rate_limit_backoff_multiplier")]
     pub backoff_multiplier: f64,
+
+    /// Max retries for mid-stream transport failures (default: 1).
+    /// On each retry, accumulated text is discarded and the stream is re-created.
+    #[serde(default = "default_stream_max_retries")]
+    pub max_stream_retries: usize,
 }
 
 impl Default for RateLimitConfig {
@@ -259,6 +271,7 @@ impl Default for RateLimitConfig {
             max_retries: DEFAULT_RATE_LIMIT_MAX_RETRIES,
             default_wait_secs: DEFAULT_RATE_LIMIT_WAIT_SECS,
             backoff_multiplier: DEFAULT_RATE_LIMIT_BACKOFF_MULTIPLIER,
+            max_stream_retries: DEFAULT_STREAM_MAX_RETRIES,
         }
     }
 }

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -253,6 +253,7 @@ pub enum AgentEventKind {
     },
     SessionStopRequested,
     SessionForceStopped {
+        #[typeshare(serialized_as = "number")]
         escalated_after_ms: u64,
         reason: String,
     },

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -251,6 +251,11 @@ pub enum AgentEventKind {
         /// Reason for queueing (e.g., "waiting for previous operation to complete")
         reason: String,
     },
+    SessionStopRequested,
+    SessionForceStopped {
+        escalated_after_ms: u64,
+        reason: String,
+    },
     Cancelled,
     Error {
         message: String,
@@ -930,6 +935,21 @@ mod tests {
     fn classify_cancelled_is_durable() {
         assert_eq!(
             classify_durability(&AgentEventKind::Cancelled),
+            Durability::Durable
+        );
+    }
+
+    #[test]
+    fn classify_stop_events_are_durable() {
+        assert_eq!(
+            classify_durability(&AgentEventKind::SessionStopRequested),
+            Durability::Durable
+        );
+        assert_eq!(
+            classify_durability(&AgentEventKind::SessionForceStopped {
+                escalated_after_ms: 3000,
+                reason: "timeout".into(),
+            }),
             Durability::Durable
         );
     }

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -179,6 +179,20 @@ pub enum AgentEventKind {
         #[serde(skip_serializing_if = "Option::is_none")]
         message_id: Option<String>,
     },
+    /// Ephemeral signal emitted when mid-stream transport error is detected.
+    /// Accumulated text is discarded and a new stream is being created.
+    StreamRecovering {
+        /// Human-readable error message that triggered the retry
+        message: String,
+        /// Current attempt (1-indexed)
+        #[typeshare(serialized_as = "number")]
+        attempt: u32,
+        /// Maximum attempts
+        #[typeshare(serialized_as = "number")]
+        max_attempts: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message_id: Option<String>,
+    },
     LlmRequestStart {
         message_count: u32,
     },
@@ -653,6 +667,7 @@ pub fn classify_durability(kind: &AgentEventKind) -> Durability {
         AgentEventKind::AssistantThinkingDelta { .. } => Durability::Ephemeral,
         AgentEventKind::RemoteStreamDisconnected { .. } => Durability::Ephemeral,
         AgentEventKind::RemoteStreamReconnected { .. } => Durability::Ephemeral,
+        AgentEventKind::StreamRecovering { .. } => Durability::Ephemeral,
 
         // Everything else is durable by default.
         _ => Durability::Durable,

--- a/crates/agent/src/session/compaction.rs
+++ b/crates/agent/src/session/compaction.rs
@@ -320,11 +320,10 @@ impl SessionCompaction {
 /// with the previous request.  Retrying just queues additional inference work,
 /// wasting compute and potentially causing cascading timeouts.
 ///
-/// Detection relies on the string representation produced by
-/// `MeshChatProvider::chat_with_tools` when kameo's `RemoteSendError` is
-/// formatted:
-///   - `"network timeout"` — clean `OutboundFailure::Timeout`
-///   - `"Eof {"` — CBOR decode truncation when the timeout fires mid-read
+/// Detection matches on the typed `LLMError::Transport { kind: Timeout, .. }`
+/// variant which is produced by `MeshChatProvider::chat_with_tools` when
+/// kameo's `RemoteSendError::Timeout` fires, or when a mesh stream's
+/// reconnect grace period expires.
 fn is_mesh_timeout_error(e: &querymt::error::LLMError) -> bool {
     matches!(
         e,

--- a/crates/agent/src/session/compaction.rs
+++ b/crates/agent/src/session/compaction.rs
@@ -326,8 +326,13 @@ impl SessionCompaction {
 ///   - `"network timeout"` — clean `OutboundFailure::Timeout`
 ///   - `"Eof {"` — CBOR decode truncation when the timeout fires mid-read
 fn is_mesh_timeout_error(e: &querymt::error::LLMError) -> bool {
-    let msg = e.to_string();
-    msg.contains("network timeout") || msg.contains("Eof {")
+    matches!(
+        e,
+        querymt::error::LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::Timeout,
+            ..
+        }
+    )
 }
 
 /// Filter messages to return only the "effective" history after the last compaction.
@@ -1128,11 +1133,10 @@ mod tests {
 
     #[test]
     fn test_mesh_timeout_network_timeout() {
-        let err = LLMError::ProviderError(
-            "MeshChatProvider: remote call to 'provider_host::peer::12D3KooW...' \
-             failed: network timeout"
-                .to_string(),
-        );
+        let err = LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::Timeout,
+            message: "network timeout".to_string(),
+        };
         assert!(
             is_mesh_timeout_error(&err),
             "network timeout should be detected as mesh timeout"
@@ -1141,11 +1145,10 @@ mod tests {
 
     #[test]
     fn test_mesh_timeout_eof_error() {
-        let err = LLMError::ProviderError(
-            "MeshChatProvider: remote call to 'provider_host::peer::12D3KooW...' \
-             failed: Eof { name: \"enum\", expect: Small(1) }"
-                .to_string(),
-        );
+        let err = LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::Timeout,
+            message: "Eof { name: \"enum\", expect: Small(1) }".to_string(),
+        };
         assert!(
             is_mesh_timeout_error(&err),
             "Eof decode error should be detected as mesh timeout"
@@ -1154,11 +1157,10 @@ mod tests {
 
     #[test]
     fn test_mesh_timeout_dial_failure_is_not_timeout() {
-        let err = LLMError::ProviderError(
-            "MeshChatProvider: remote call to 'provider_host::peer::12D3KooW...' \
-             failed: dial failure"
-                .to_string(),
-        );
+        let err = LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::ConnectionRefused,
+            message: "dial failure".to_string(),
+        };
         assert!(
             !is_mesh_timeout_error(&err),
             "dial failure should NOT be classified as mesh timeout"
@@ -1176,9 +1178,10 @@ mod tests {
 
     #[test]
     fn test_mesh_timeout_connection_closed_is_not_timeout() {
-        let err = LLMError::ProviderError(
-            "MeshChatProvider: remote call to '...' failed: connection closed".to_string(),
-        );
+        let err = LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::ConnectionClosed,
+            message: "connection closed".to_string(),
+        };
         assert!(
             !is_mesh_timeout_error(&err),
             "connection closed should NOT be classified as mesh timeout"
@@ -1192,9 +1195,10 @@ mod tests {
 
         // Simulate a mesh timeout on the first attempt — should NOT retry.
         let mock = MockCompactionProvider::new(vec![
-            Err(LLMError::ProviderError(
-                "MeshChatProvider: remote call to '...' failed: network timeout".to_string(),
-            )),
+            Err(LLMError::Transport {
+                kind: querymt::error::TransportErrorKind::Timeout,
+                message: "network timeout".to_string(),
+            }),
             // This second response should never be reached.
             Ok("should not be used".to_string()),
         ]);

--- a/crates/agent/src/session/projection.rs
+++ b/crates/agent/src/session/projection.rs
@@ -175,6 +175,30 @@ pub trait ViewStore: Send + Sync {
         filter: Option<SessionListFilter>,
     ) -> SessionResult<SessionListView>;
 
+    /// Browse workspace groups with preview sessions.
+    async fn browse_session_groups(
+        &self,
+        cursor: Option<String>,
+        group_limit: usize,
+        session_limit_per_group: usize,
+    ) -> SessionResult<(Vec<SessionGroup>, Option<String>, usize)>;
+
+    /// Page sessions for one workspace group.
+    async fn list_group_sessions(
+        &self,
+        cwd: Option<String>,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> SessionResult<(SessionGroup, usize)>;
+
+    /// Search all sessions via FTS5 (DB-wide, not limited to loaded pages).
+    async fn search_sessions(
+        &self,
+        query: String,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> SessionResult<(Vec<SessionGroup>, Option<String>, usize)>;
+
     /// Export session as ATIF (Agent Trajectory Interchange Format)
     async fn get_atif(
         &self,
@@ -326,6 +350,8 @@ pub struct SessionGroup {
     pub sessions: Vec<SessionListItem>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub latest_activity: Option<OffsetDateTime>,
+    pub total_count: Option<usize>,
+    pub next_cursor: Option<String>,
 }
 
 /// Session list view with grouping
@@ -335,6 +361,14 @@ pub struct SessionListView {
     pub total_count: usize,
     #[serde(with = "time::serde::rfc3339")]
     pub generated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionGroupTotal {
+    pub cwd: Option<String>,
+    pub total_count: usize,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub latest_activity: Option<OffsetDateTime>,
 }
 
 /// Recent model usage entry from event history

--- a/crates/agent/src/session/repo_intent.rs
+++ b/crates/agent/src/session/repo_intent.rs
@@ -92,6 +92,24 @@ impl IntentRepository for SqliteIntentRepository {
                 "INSERT INTO intent_snapshots (session_id, task_id, summary, constraints, next_step_hint, created_at) VALUES (?, ?, ?, ?, ?, ?)",
                 params![session_id, task_id, summary, constraints, next_step_hint, created_at_str],
             )?;
+
+            // Refresh the session's FTS row so the title (derived from the
+            // earliest intent_snapshot summary) stays searchable. We only
+            // need to do this when this is the first snapshot for the session,
+            // but checking is more expensive than just always refreshing.
+            conn.execute(
+                r#"INSERT INTO sessions_fts(sessions_fts, rowid) VALUES ('delete', ?1)"#,
+                params![session_id],
+            ).ok(); // ignore — FTS table may not exist yet during early migrations
+
+            conn.execute(
+                r#"INSERT INTO sessions_fts(rowid, public_id, name, cwd, title)
+                   SELECT s.id, s.public_id, COALESCE(s.name, ''), COALESCE(s.cwd, ''),
+                          COALESCE((SELECT i.summary FROM intent_snapshots i WHERE i.session_id = s.id ORDER BY i.id ASC LIMIT 1), '')
+                   FROM sessions s WHERE s.id = ?1"#,
+                params![session_id],
+            ).ok();
+
             Ok(())
         })
         .await

--- a/crates/agent/src/session/schema.rs
+++ b/crates/agent/src/session/schema.rs
@@ -41,6 +41,46 @@ pub fn init_schema(conn: &mut Connection) -> Result<(), rusqlite::Error> {
 
         CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_public_id ON sessions(public_id);
         CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
+        CREATE INDEX IF NOT EXISTS idx_sessions_cwd_updated ON sessions(cwd, updated_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at DESC);
+
+        -- Full-text session search index (all sessions, not just loaded pages).
+        -- The 'title' column is populated from intent_snapshots.summary so that
+        -- session titles are searchable even though the title is derived data.
+        -- Standalone FTS5 table — contentless, so delete/rebuild commands work
+        -- without requiring a content table with matching columns.
+        CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
+            public_id,
+            name,
+            cwd,
+            title,
+            content='',
+            tokenize='porter unicode61'
+        );
+
+        CREATE TRIGGER IF NOT EXISTS sessions_ai AFTER INSERT ON sessions BEGIN
+            INSERT INTO sessions_fts(rowid, public_id, name, cwd, title)
+            VALUES (
+                new.id,
+                new.public_id,
+                COALESCE(new.name, ''),
+                COALESCE(new.cwd, ''),
+                COALESCE((SELECT i.summary FROM intent_snapshots i WHERE i.session_id = new.id ORDER BY i.id ASC LIMIT 1), '')
+            );
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS sessions_au AFTER UPDATE ON sessions BEGIN
+            INSERT INTO sessions_fts(sessions_fts, rowid) VALUES ('delete', old.id);
+            INSERT INTO sessions_fts(rowid, public_id, name, cwd, title)
+            VALUES (
+                new.id, new.public_id, COALESCE(new.name, ''), COALESCE(new.cwd, ''),
+                COALESCE((SELECT i.summary FROM intent_snapshots i WHERE i.session_id = new.id ORDER BY i.id ASC LIMIT 1), '')
+            );
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS sessions_ad AFTER DELETE ON sessions BEGIN
+            INSERT INTO sessions_fts(sessions_fts, rowid) VALUES ('delete', old.id);
+        END;
 
         -- Tasks - referenced externally in UIs/APIs
         CREATE TABLE IF NOT EXISTS tasks (

--- a/crates/agent/src/session/sqlite_storage/migrations.rs
+++ b/crates/agent/src/session/sqlite_storage/migrations.rs
@@ -44,6 +44,10 @@ pub(super) const MIGRATIONS: &[Migration] = &[
         version: "0008_remote_session_bookmarks",
         apply: migration_0008_remote_session_bookmarks,
     },
+    Migration {
+        version: "0009_sessions_browse_and_search_indexes",
+        apply: migration_0009_sessions_browse_and_search_indexes,
+    },
 ];
 
 pub(super) fn apply_migrations(conn: &mut Connection) -> Result<(), rusqlite::Error> {
@@ -353,5 +357,62 @@ fn migration_0008_remote_session_bookmarks(conn: &mut Connection) -> Result<(), 
             );
         "#,
     )?;
+    Ok(())
+}
+
+fn migration_0009_sessions_browse_and_search_indexes(
+    conn: &mut Connection,
+) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        r#"
+            CREATE INDEX IF NOT EXISTS idx_sessions_cwd_updated ON sessions(cwd, updated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at DESC);
+
+            DROP TRIGGER IF EXISTS sessions_ai;
+            DROP TRIGGER IF EXISTS sessions_au;
+            DROP TRIGGER IF EXISTS sessions_ad;
+            DROP TABLE IF EXISTS sessions_fts;
+
+            CREATE VIRTUAL TABLE sessions_fts USING fts5(
+                public_id,
+                name,
+                cwd,
+                title,
+                content='',
+                tokenize='porter unicode61'
+            );
+
+            CREATE TRIGGER sessions_ai AFTER INSERT ON sessions BEGIN
+                INSERT INTO sessions_fts(rowid, public_id, name, cwd, title)
+                VALUES (
+                    new.id,
+                    new.public_id,
+                    COALESCE(new.name, ''),
+                    COALESCE(new.cwd, ''),
+                    COALESCE((SELECT i.summary FROM intent_snapshots i WHERE i.session_id = new.id ORDER BY i.id ASC LIMIT 1), '')
+                );
+            END;
+
+            CREATE TRIGGER sessions_au AFTER UPDATE ON sessions BEGIN
+                INSERT INTO sessions_fts(sessions_fts, rowid) VALUES ('delete', old.id);
+                INSERT INTO sessions_fts(rowid, public_id, name, cwd, title)
+                VALUES (
+                    new.id, new.public_id, COALESCE(new.name, ''), COALESCE(new.cwd, ''),
+                    COALESCE((SELECT i.summary FROM intent_snapshots i WHERE i.session_id = new.id ORDER BY i.id ASC LIMIT 1), '')
+                );
+            END;
+
+            CREATE TRIGGER sessions_ad AFTER DELETE ON sessions BEGIN
+                INSERT INTO sessions_fts(sessions_fts, rowid) VALUES ('delete', old.id);
+            END;
+
+            INSERT INTO sessions_fts(rowid, public_id, name, cwd, title)
+            SELECT s.id, s.public_id, COALESCE(s.name, ''), COALESCE(s.cwd, ''),
+                   COALESCE((SELECT i.summary FROM intent_snapshots i
+                             WHERE i.session_id = s.id ORDER BY i.id ASC LIMIT 1), '')
+            FROM sessions s;
+        "#,
+    )?;
+
     Ok(())
 }

--- a/crates/agent/src/session/sqlite_storage/view_store.rs
+++ b/crates/agent/src/session/sqlite_storage/view_store.rs
@@ -22,6 +22,7 @@ use crate::session::repository::{
     ProgressRepository, SessionRepository, TaskRepository,
 };
 use crate::session::store::Session;
+use rusqlite::params;
 
 use super::SqliteStorage;
 
@@ -250,9 +251,13 @@ impl ViewStore for SqliteStorage {
         // Extract SQL-level limit from filter before moving into the closure.
         // A limit without a filter expression can be pushed straight into SQL,
         // avoiding deserializing rows we'll discard anyway.
-        let sql_limit: Option<usize> = filter
-            .as_ref()
-            .and_then(|f| if f.filter.is_none() { f.limit } else { None });
+        let sql_limit: Option<usize> = filter.as_ref().and_then(|f| {
+            if f.filter.is_none() && f.offset.unwrap_or(0) == 0 {
+                f.limit
+            } else {
+                None
+            }
+        });
 
         let raw_rows: Vec<RawRow> = self
             .run_blocking(move |conn| {
@@ -357,6 +362,7 @@ impl ViewStore for SqliteStorage {
         // Apply in-memory filter/limit (filter_expr needs the full Session struct;
         // convert only the subset we need to evaluate the predicate).
         let mut raw_rows = raw_rows;
+        let mut total_count = session_count_before_filter;
         if let Some(filter_spec) = filter {
             if let Some(filter_expr) = filter_spec.filter {
                 // Build minimal Session values for predicate evaluation.
@@ -396,13 +402,17 @@ impl ViewStore for SqliteStorage {
                     evaluate_session_filter(&session, &filter_expr)
                 });
             }
+            total_count = raw_rows.len();
+            let offset = filter_spec.offset.unwrap_or(0);
+            if offset > 0 {
+                raw_rows = raw_rows.into_iter().skip(offset).collect();
+            }
             if let Some(limit) = filter_spec.limit {
                 raw_rows.truncate(limit);
             }
         }
 
         let filter_ms = filter_started.elapsed().as_millis() as u64;
-        let total_count = raw_rows.len();
 
         // Build session list items
         let title_lookup_started = Instant::now();
@@ -514,6 +524,8 @@ impl ViewStore for SqliteStorage {
                     cwd,
                     sessions,
                     latest_activity,
+                    total_count: None,
+                    next_cursor: None,
                 }
             })
             .collect();
@@ -555,6 +567,537 @@ impl ViewStore for SqliteStorage {
             total_count,
             generated_at: OffsetDateTime::now_utc(),
         })
+    }
+
+    async fn browse_session_groups(
+        &self,
+        cursor: Option<String>,
+        group_limit: usize,
+        session_limit_per_group: usize,
+    ) -> SessionResult<(Vec<SessionGroup>, Option<String>, usize)> {
+        let group_offset = cursor
+            .as_deref()
+            .and_then(|c| c.parse::<usize>().ok())
+            .unwrap_or(0);
+        let group_limit = group_limit.clamp(1, 100);
+        let preview_limit = session_limit_per_group.clamp(1, 100);
+
+        self.run_blocking(move |conn| {
+            let total_sessions: usize =
+                conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| {
+                    row.get::<_, i64>(0).map(|v| v as usize)
+                })?;
+
+            let mut summary_stmt = conn.prepare(
+                r#"
+                SELECT
+                    cwd,
+                    COUNT(*) as total_count,
+                    MAX(updated_at) as latest_activity
+                FROM sessions
+                GROUP BY cwd
+                ORDER BY (cwd IS NOT NULL), MAX(updated_at) DESC
+                LIMIT ?1 OFFSET ?2
+                "#,
+            )?;
+
+            let summaries = summary_stmt
+                .query_map(params![group_limit as i64, group_offset as i64], |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, i64>(1)? as usize,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let total_groups: usize = conn.query_row(
+                "SELECT COUNT(DISTINCT COALESCE(cwd, '__none__')) FROM sessions",
+                [],
+                |row| row.get::<_, i64>(0).map(|v| v as usize),
+            )?;
+
+            let mut groups = Vec::with_capacity(summaries.len());
+            for (cwd, total_count, latest_raw) in summaries {
+                let latest_activity = latest_raw.and_then(|v| {
+                    time::OffsetDateTime::parse(&v, &time::format_description::well_known::Rfc3339)
+                        .ok()
+                });
+
+                let mut session_stmt = if cwd.is_some() {
+                    conn.prepare(
+                        r#"
+                        SELECT
+                            s.public_id,
+                            s.name,
+                            s.cwd,
+                            s.created_at,
+                            s.updated_at,
+                            p.public_id,
+                            s.fork_origin,
+                            s.session_kind,
+                            EXISTS(SELECT 1 FROM sessions c WHERE c.parent_session_id = s.id),
+                            i.summary
+                        FROM sessions s
+                        LEFT JOIN sessions p ON p.id = s.parent_session_id
+                        LEFT JOIN intent_snapshots i
+                            ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
+                        WHERE s.cwd = ?1
+                        ORDER BY s.updated_at DESC
+                        LIMIT ?2
+                        "#,
+                    )?
+                } else {
+                    conn.prepare(
+                        r#"
+                        SELECT
+                            s.public_id,
+                            s.name,
+                            s.cwd,
+                            s.created_at,
+                            s.updated_at,
+                            p.public_id,
+                            s.fork_origin,
+                            s.session_kind,
+                            EXISTS(SELECT 1 FROM sessions c WHERE c.parent_session_id = s.id),
+                            i.summary
+                        FROM sessions s
+                        LEFT JOIN sessions p ON p.id = s.parent_session_id
+                        LEFT JOIN intent_snapshots i
+                            ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
+                        WHERE s.cwd IS NULL
+                        ORDER BY s.updated_at DESC
+                        LIMIT ?1
+                        "#,
+                    )?
+                };
+
+                let sessions = if let Some(ref cwd_value) = cwd {
+                    session_stmt
+                        .query_map(params![cwd_value, preview_limit as i64], |row| {
+                            Ok(SessionListItem {
+                                session_id: row.get(0)?,
+                                name: row.get(1)?,
+                                cwd: row.get(2)?,
+                                title: row.get::<_, Option<String>>(9)?.map(|summary| {
+                                    if summary.len() > 80 {
+                                        format!("{}...", &summary[..77])
+                                    } else {
+                                        summary
+                                    }
+                                }),
+                                created_at: row.get::<_, Option<String>>(3)?.and_then(|s| {
+                                    time::OffsetDateTime::parse(
+                                        &s,
+                                        &time::format_description::well_known::Rfc3339,
+                                    )
+                                    .ok()
+                                }),
+                                updated_at: row.get::<_, Option<String>>(4)?.and_then(|s| {
+                                    time::OffsetDateTime::parse(
+                                        &s,
+                                        &time::format_description::well_known::Rfc3339,
+                                    )
+                                    .ok()
+                                }),
+                                parent_session_id: row.get(5)?,
+                                fork_origin: row.get(6)?,
+                                session_kind: row.get(7)?,
+                                has_children: row.get::<_, i64>(8)? != 0,
+                            })
+                        })?
+                        .collect::<Result<Vec<_>, _>>()?
+                } else {
+                    session_stmt
+                        .query_map(params![preview_limit as i64], |row| {
+                            Ok(SessionListItem {
+                                session_id: row.get(0)?,
+                                name: row.get(1)?,
+                                cwd: row.get(2)?,
+                                title: row.get::<_, Option<String>>(9)?.map(|summary| {
+                                    if summary.len() > 80 {
+                                        format!("{}...", &summary[..77])
+                                    } else {
+                                        summary
+                                    }
+                                }),
+                                created_at: row.get::<_, Option<String>>(3)?.and_then(|s| {
+                                    time::OffsetDateTime::parse(
+                                        &s,
+                                        &time::format_description::well_known::Rfc3339,
+                                    )
+                                    .ok()
+                                }),
+                                updated_at: row.get::<_, Option<String>>(4)?.and_then(|s| {
+                                    time::OffsetDateTime::parse(
+                                        &s,
+                                        &time::format_description::well_known::Rfc3339,
+                                    )
+                                    .ok()
+                                }),
+                                parent_session_id: row.get(5)?,
+                                fork_origin: row.get(6)?,
+                                session_kind: row.get(7)?,
+                                has_children: row.get::<_, i64>(8)? != 0,
+                            })
+                        })?
+                        .collect::<Result<Vec<_>, _>>()?
+                };
+
+                let next_cursor = if sessions.len() < total_count {
+                    Some(sessions.len().to_string())
+                } else {
+                    None
+                };
+
+                groups.push(SessionGroup {
+                    cwd,
+                    sessions,
+                    latest_activity,
+                    total_count: Some(total_count),
+                    next_cursor,
+                });
+            }
+
+            let next_group_cursor = if group_offset + groups.len() < total_groups {
+                Some((group_offset + groups.len()).to_string())
+            } else {
+                None
+            };
+
+            Ok((groups, next_group_cursor, total_sessions))
+        })
+        .await
+    }
+
+    async fn list_group_sessions(
+        &self,
+        cwd: Option<String>,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> SessionResult<(SessionGroup, usize)> {
+        let offset = cursor
+            .as_deref()
+            .and_then(|c| c.parse::<usize>().ok())
+            .unwrap_or(0);
+        let limit = limit.clamp(1, 200);
+
+        self.run_blocking(move |conn| {
+            let total_count: usize = if let Some(ref cwd_value) = cwd {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM sessions WHERE cwd = ?1",
+                    params![cwd_value],
+                    |row| row.get::<_, i64>(0).map(|v| v as usize),
+                )?
+            } else {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM sessions WHERE cwd IS NULL",
+                    [],
+                    |row| row.get::<_, i64>(0).map(|v| v as usize),
+                )?
+            };
+
+            let latest_raw: Option<String> = if let Some(ref cwd_value) = cwd {
+                conn.query_row(
+                    "SELECT MAX(updated_at) FROM sessions WHERE cwd = ?1",
+                    params![cwd_value],
+                    |row| row.get(0),
+                )?
+            } else {
+                conn.query_row(
+                    "SELECT MAX(updated_at) FROM sessions WHERE cwd IS NULL",
+                    [],
+                    |row| row.get(0),
+                )?
+            };
+
+            let latest_activity = latest_raw.and_then(|v| {
+                time::OffsetDateTime::parse(&v, &time::format_description::well_known::Rfc3339).ok()
+            });
+
+            let mut session_stmt = if cwd.is_some() {
+                conn.prepare(
+                    r#"
+                    SELECT
+                        s.public_id,
+                        s.name,
+                        s.cwd,
+                        s.created_at,
+                        s.updated_at,
+                        p.public_id,
+                        s.fork_origin,
+                        s.session_kind,
+                        EXISTS(SELECT 1 FROM sessions c WHERE c.parent_session_id = s.id),
+                        i.summary
+                    FROM sessions s
+                    LEFT JOIN sessions p ON p.id = s.parent_session_id
+                    LEFT JOIN intent_snapshots i
+                        ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
+                    WHERE s.cwd = ?1
+                    ORDER BY s.updated_at DESC
+                    LIMIT ?2 OFFSET ?3
+                    "#,
+                )?
+            } else {
+                conn.prepare(
+                    r#"
+                    SELECT
+                        s.public_id,
+                        s.name,
+                        s.cwd,
+                        s.created_at,
+                        s.updated_at,
+                        p.public_id,
+                        s.fork_origin,
+                        s.session_kind,
+                        EXISTS(SELECT 1 FROM sessions c WHERE c.parent_session_id = s.id),
+                        i.summary
+                    FROM sessions s
+                    LEFT JOIN sessions p ON p.id = s.parent_session_id
+                    LEFT JOIN intent_snapshots i
+                        ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
+                    WHERE s.cwd IS NULL
+                    ORDER BY s.updated_at DESC
+                    LIMIT ?1 OFFSET ?2
+                    "#,
+                )?
+            };
+
+            let sessions = if let Some(ref cwd_value) = cwd {
+                session_stmt
+                    .query_map(params![cwd_value, limit as i64, offset as i64], |row| {
+                        Ok(SessionListItem {
+                            session_id: row.get(0)?,
+                            name: row.get(1)?,
+                            cwd: row.get(2)?,
+                            title: row.get::<_, Option<String>>(9)?.map(|summary| {
+                                if summary.len() > 80 {
+                                    format!("{}...", &summary[..77])
+                                } else {
+                                    summary
+                                }
+                            }),
+                            created_at: row.get::<_, Option<String>>(3)?.and_then(|s| {
+                                time::OffsetDateTime::parse(
+                                    &s,
+                                    &time::format_description::well_known::Rfc3339,
+                                )
+                                .ok()
+                            }),
+                            updated_at: row.get::<_, Option<String>>(4)?.and_then(|s| {
+                                time::OffsetDateTime::parse(
+                                    &s,
+                                    &time::format_description::well_known::Rfc3339,
+                                )
+                                .ok()
+                            }),
+                            parent_session_id: row.get(5)?,
+                            fork_origin: row.get(6)?,
+                            session_kind: row.get(7)?,
+                            has_children: row.get::<_, i64>(8)? != 0,
+                        })
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?
+            } else {
+                session_stmt
+                    .query_map(params![limit as i64, offset as i64], |row| {
+                        Ok(SessionListItem {
+                            session_id: row.get(0)?,
+                            name: row.get(1)?,
+                            cwd: row.get(2)?,
+                            title: row.get::<_, Option<String>>(9)?.map(|summary| {
+                                if summary.len() > 80 {
+                                    format!("{}...", &summary[..77])
+                                } else {
+                                    summary
+                                }
+                            }),
+                            created_at: row.get::<_, Option<String>>(3)?.and_then(|s| {
+                                time::OffsetDateTime::parse(
+                                    &s,
+                                    &time::format_description::well_known::Rfc3339,
+                                )
+                                .ok()
+                            }),
+                            updated_at: row.get::<_, Option<String>>(4)?.and_then(|s| {
+                                time::OffsetDateTime::parse(
+                                    &s,
+                                    &time::format_description::well_known::Rfc3339,
+                                )
+                                .ok()
+                            }),
+                            parent_session_id: row.get(5)?,
+                            fork_origin: row.get(6)?,
+                            session_kind: row.get(7)?,
+                            has_children: row.get::<_, i64>(8)? != 0,
+                        })
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+
+            let next_cursor = if offset + sessions.len() < total_count {
+                Some((offset + sessions.len()).to_string())
+            } else {
+                None
+            };
+
+            Ok((
+                SessionGroup {
+                    cwd,
+                    sessions,
+                    latest_activity,
+                    total_count: Some(total_count),
+                    next_cursor,
+                },
+                total_count,
+            ))
+        })
+        .await
+    }
+
+    async fn search_sessions(
+        &self,
+        query: String,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> SessionResult<(Vec<SessionGroup>, Option<String>, usize)> {
+        let offset = cursor
+            .as_deref()
+            .and_then(|c| c.parse::<usize>().ok())
+            .unwrap_or(0);
+        let limit = limit.clamp(1, 200);
+        let fts_query = build_session_fts_query(&query);
+        if fts_query.is_empty() {
+            return Ok((Vec::new(), None, 0));
+        }
+
+        self.run_blocking(move |conn| {
+            let total_count: usize = match conn.query_row(
+                "SELECT COUNT(*) FROM sessions_fts WHERE sessions_fts MATCH ?1",
+                params![fts_query.clone()],
+                |row| row.get::<_, i64>(0).map(|v| v as usize),
+            ) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Ok((Vec::new(), None, 0));
+                }
+            };
+
+            let mut group_counts_stmt = conn.prepare(
+                r#"
+                SELECT s.cwd, COUNT(*)
+                FROM sessions_fts f
+                JOIN sessions s ON s.id = f.rowid
+                WHERE sessions_fts MATCH ?1
+                GROUP BY s.cwd
+                "#,
+            )?;
+            let group_counts = group_counts_stmt
+                .query_map(params![fts_query.clone()], |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, i64>(1)? as usize,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            let group_counts_map: std::collections::HashMap<Option<String>, usize> =
+                group_counts.into_iter().collect();
+
+            let mut stmt = conn.prepare(
+                r#"
+                SELECT
+                    s.public_id,
+                    s.name,
+                    s.cwd,
+                    s.created_at,
+                    s.updated_at,
+                    p.public_id,
+                    s.fork_origin,
+                    s.session_kind,
+                    EXISTS(SELECT 1 FROM sessions c WHERE c.parent_session_id = s.id),
+                    i.summary
+                FROM sessions_fts f
+                JOIN sessions s ON s.id = f.rowid
+                LEFT JOIN sessions p ON p.id = s.parent_session_id
+                LEFT JOIN intent_snapshots i
+                    ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
+                WHERE sessions_fts MATCH ?1
+                ORDER BY bm25(sessions_fts), s.updated_at DESC
+                LIMIT ?2 OFFSET ?3
+                "#,
+            )?;
+
+            let items = stmt
+                .query_map(params![fts_query, limit as i64, offset as i64], |row| {
+                    Ok(SessionListItem {
+                        session_id: row.get(0)?,
+                        name: row.get(1)?,
+                        cwd: row.get(2)?,
+                        title: row.get::<_, Option<String>>(9)?.map(|summary| {
+                            if summary.len() > 80 {
+                                format!("{}...", &summary[..77])
+                            } else {
+                                summary
+                            }
+                        }),
+                        created_at: row.get::<_, Option<String>>(3)?.and_then(|s| {
+                            time::OffsetDateTime::parse(
+                                &s,
+                                &time::format_description::well_known::Rfc3339,
+                            )
+                            .ok()
+                        }),
+                        updated_at: row.get::<_, Option<String>>(4)?.and_then(|s| {
+                            time::OffsetDateTime::parse(
+                                &s,
+                                &time::format_description::well_known::Rfc3339,
+                            )
+                            .ok()
+                        }),
+                        parent_session_id: row.get(5)?,
+                        fork_origin: row.get(6)?,
+                        session_kind: row.get(7)?,
+                        has_children: row.get::<_, i64>(8)? != 0,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let mut by_cwd: std::collections::HashMap<Option<String>, Vec<SessionListItem>> =
+                std::collections::HashMap::new();
+            for item in items {
+                by_cwd.entry(item.cwd.clone()).or_default().push(item);
+            }
+
+            let mut groups: Vec<SessionGroup> = by_cwd
+                .into_iter()
+                .map(|(cwd, sessions)| {
+                    let latest_activity = sessions.iter().filter_map(|s| s.updated_at).max();
+                    SessionGroup {
+                        total_count: Some(*group_counts_map.get(&cwd).unwrap_or(&sessions.len())),
+                        next_cursor: None,
+                        cwd,
+                        sessions,
+                        latest_activity,
+                    }
+                })
+                .collect();
+
+            groups.sort_by(|a, b| match (&a.cwd, &b.cwd) {
+                (None, None) => std::cmp::Ordering::Equal,
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                (Some(_), Some(_)) => b.latest_activity.cmp(&a.latest_activity),
+            });
+
+            let next_cursor = if offset + limit < total_count {
+                Some((offset + limit).to_string())
+            } else {
+                None
+            };
+
+            Ok((groups, next_cursor, total_count))
+        })
+        .await
     }
 
     async fn get_atif(
@@ -664,6 +1207,16 @@ impl ViewStore for SqliteStorage {
 // ============================================================================
 
 /// Evaluate a filter expression against a session
+fn build_session_fts_query(input: &str) -> String {
+    let terms: Vec<String> = input
+        .split_whitespace()
+        .map(|t| t.replace('"', ""))
+        .filter(|t| !t.is_empty())
+        .map(|t| format!("\"{}\"*", t))
+        .collect();
+    terms.join(" AND ")
+}
+
 fn evaluate_session_filter(session: &Session, expr: &FilterExpr) -> bool {
     match expr {
         FilterExpr::Predicate(pred) => evaluate_predicate(session, pred),

--- a/crates/agent/src/ui/connection.rs
+++ b/crates/agent/src/ui/connection.rs
@@ -663,7 +663,10 @@ pub fn spawn_peer_event_watcher(state: ServerState, tx: mpsc::Sender<String>) {
 
                         // Refresh session list so the UI session picker updates
                         // with any newly-discoverable remote sessions (Bug 2 fix).
-                        super::handlers::handle_list_sessions(&state, &tx).await;
+                        super::handlers::handle_list_sessions(
+                            &state, &tx, None, None, None, None, None,
+                        )
+                        .await;
                     } else {
                         // Expired: push the updated (node-removed) list immediately.
                         let nodes = state.agent.list_remote_nodes().await;
@@ -743,7 +746,10 @@ pub fn spawn_peer_event_watcher(state: ServerState, tx: mpsc::Sender<String>) {
 
                         // Refresh session list so expired peer's sessions are
                         // removed from the UI (Bug 2 fix).
-                        super::handlers::handle_list_sessions(&state, &tx).await;
+                        super::handlers::handle_list_sessions(
+                            &state, &tx, None, None, None, None, None,
+                        )
+                        .await;
 
                         // Schedule a delayed re-check to catch any stale DHT
                         // records that resolved between the immediate push and

--- a/crates/agent/src/ui/handlers/mod.rs
+++ b/crates/agent/src/ui/handlers/mod.rs
@@ -29,7 +29,6 @@ pub use oauth::handle_disconnect_oauth;
 pub use oauth::handle_start_oauth_login;
 pub(crate) use oauth::stop_oauth_callback_listener_for_connection;
 pub use plugins::handle_update_plugins;
-pub(crate) use remote::attach_remote_session_via_lookup;
 pub use remote::handle_attach_remote_session;
 pub use remote::handle_create_mesh_invite;
 pub use remote::handle_create_remote_session;

--- a/crates/agent/src/ui/handlers/mod.rs
+++ b/crates/agent/src/ui/handlers/mod.rs
@@ -86,7 +86,7 @@ pub async fn handle_ui_message(
             send_state(state, conn_id, tx).await;
             let send_state_ms = started.elapsed().as_millis() as u64;
 
-            handle_list_sessions(state, tx).await;
+            handle_list_sessions(state, tx, None, None, None, None, None).await;
             audio::handle_audio_capabilities(state, tx).await;
             tracing::info!(
                 target: "querymt_agent::ui::handlers",
@@ -140,7 +140,7 @@ pub async fn handle_ui_message(
                 let _ = send_error(tx, err).await;
             }
 
-            handle_list_sessions(state, tx).await;
+            handle_list_sessions(state, tx, None, None, None, None, None).await;
         }
         UiClientMessage::Prompt { prompt } => {
             let has_user_text = prompt.iter().any(|block| match block {
@@ -163,11 +163,17 @@ pub async fn handle_ui_message(
                     log::error!("prompt_for_mode failed: {}", err);
                     let _ = super::connection::send_error(&tx, err).await;
                 }
-                handle_list_sessions(&state, &tx).await;
+                handle_list_sessions(&state, &tx, None, None, None, None, None).await;
             });
         }
-        UiClientMessage::ListSessions => {
-            handle_list_sessions(state, tx).await;
+        UiClientMessage::ListSessions {
+            mode,
+            cursor,
+            limit,
+            cwd,
+            query,
+        } => {
+            handle_list_sessions(state, tx, mode, cursor, limit, cwd, query).await;
         }
         UiClientMessage::LoadSession { session_id } => {
             handle_load_session(state, conn_id, &session_id, tx).await;

--- a/crates/agent/src/ui/handlers/mod.rs
+++ b/crates/agent/src/ui/handlers/mod.rs
@@ -59,6 +59,8 @@ pub use session_ops::handle_set_reasoning_effort;
 pub use session_ops::handle_subscribe_session;
 pub use session_ops::handle_undo;
 pub use session_ops::handle_unsubscribe_session;
+#[cfg(all(test, feature = "remote"))]
+pub(crate) use session_ops::refresh_attached_remote_summary;
 
 use super::ServerState;
 use super::connection::{send_error, send_state};

--- a/crates/agent/src/ui/handlers/remote.rs
+++ b/crates/agent/src/ui/handlers/remote.rs
@@ -14,6 +14,8 @@ use super::super::connection::{send_error, send_message};
 use super::super::messages::{MeshInviteInfo, UiServerMessage};
 use super::session_ops::handle_list_sessions;
 #[cfg(feature = "remote")]
+use crate::agent::remote::node_manager::SessionHandoff;
+#[cfg(feature = "remote")]
 use crate::agent::utils::u32_from_usize;
 #[cfg(feature = "remote")]
 use kameo::actor::RemoteActorRef;
@@ -135,7 +137,7 @@ pub async fn handle_create_remote_session(
                     conn_id,
                     node_id,
                     &session_id,
-                    resp.session_ref,
+                    resp.handoff,
                     cwd_path,
                     tx,
                 )
@@ -196,7 +198,7 @@ pub(crate) async fn finalize_remote_session_attach(
     conn_id: &str,
     node_id: &str,
     session_id: &str,
-    remote_ref: RemoteActorRef<crate::agent::session_actor::SessionActor>,
+    handoff: SessionHandoff,
     cwd: Option<PathBuf>,
     tx: &mpsc::Sender<String>,
 ) -> Result<(), String> {
@@ -208,6 +210,19 @@ pub(crate) async fn finalize_remote_session_attach(
         .find(|n| n.node_id.to_string() == node_id)
         .map(|n| n.hostname)
         .unwrap_or_else(|| node_id.to_string());
+
+    let remote_ref = match handoff {
+        SessionHandoff::DirectRemote { session_ref } => session_ref,
+        SessionHandoff::LookupOnly => {
+            lookup_remote_session_actor(state, node_id, session_id).await?
+        }
+        SessionHandoff::NoAttachPath => {
+            return Err(format!(
+                "Remote session '{}' was created on node '{}' but that node cannot provide a direct or lookup attach path",
+                session_id, node_id
+            ));
+        }
+    };
 
     let _session_actor_ref = state
         .agent
@@ -423,8 +438,16 @@ pub(crate) async fn attach_remote_session_via_lookup(
     session_id: &str,
     tx: &mpsc::Sender<String>,
 ) -> Result<(), String> {
-    let remote_ref = lookup_remote_session_actor(state, node_id, session_id).await?;
-    finalize_remote_session_attach(state, conn_id, node_id, session_id, remote_ref, None, tx).await
+    finalize_remote_session_attach(
+        state,
+        conn_id,
+        node_id,
+        session_id,
+        SessionHandoff::LookupOnly,
+        None,
+        tx,
+    )
+    .await
 }
 
 /// Attach an existing remote session to the local registry.

--- a/crates/agent/src/ui/handlers/remote.rs
+++ b/crates/agent/src/ui/handlers/remote.rs
@@ -438,7 +438,7 @@ pub(crate) async fn attach_remote_session_via_lookup(
     session_id: &str,
     tx: &mpsc::Sender<String>,
 ) -> Result<(), String> {
-    finalize_remote_session_attach(
+    match finalize_remote_session_attach(
         state,
         conn_id,
         node_id,
@@ -448,6 +448,33 @@ pub(crate) async fn attach_remote_session_via_lookup(
         tx,
     )
     .await
+    {
+        Ok(()) => Ok(()),
+        Err(lookup_err) => {
+            let nm_ref = state
+                .agent
+                .find_node_manager(node_id)
+                .await
+                .map_err(|e| e.to_string())?;
+            let resumed = state
+                .agent
+                .resume_remote_session(&nm_ref, session_id.to_string())
+                .await
+                .map_err(|e| e.to_string())?;
+
+            finalize_remote_session_attach(
+                state,
+                conn_id,
+                node_id,
+                session_id,
+                resumed.handoff,
+                resumed.cwd.map(PathBuf::from),
+                tx,
+            )
+            .await
+            .map_err(|resume_err| format!("{lookup_err}; resume failed: {resume_err}"))
+        }
+    }
 }
 
 /// Attach an existing remote session to the local registry.

--- a/crates/agent/src/ui/handlers/remote.rs
+++ b/crates/agent/src/ui/handlers/remote.rs
@@ -345,7 +345,7 @@ pub(crate) async fn finalize_remote_session_attach(
     .await;
 
     super::super::connection::send_state(state, conn_id, tx).await;
-    handle_list_sessions(state, tx).await;
+    handle_list_sessions(state, tx, None, None, None, None, None).await;
 
     log::info!(
         "handle_attach_remote_session: attached session {} from node_id '{}'",
@@ -536,7 +536,7 @@ pub async fn handle_dismiss_remote_session(
     }
 
     // 3. Refresh session list
-    handle_list_sessions(state, tx).await;
+    handle_list_sessions(state, tx, None, None, None, None, None).await;
 }
 
 /// Create a mesh invite token on the local node.

--- a/crates/agent/src/ui/handlers/remote.rs
+++ b/crates/agent/src/ui/handlers/remote.rs
@@ -17,6 +17,8 @@ use super::session_ops::handle_list_sessions;
 use crate::agent::utils::u32_from_usize;
 #[cfg(feature = "remote")]
 use kameo::actor::RemoteActorRef;
+#[cfg(feature = "remote")]
+use std::path::PathBuf;
 use tokio::sync::mpsc;
 
 /// List remote nodes discovered in the kameo mesh.
@@ -120,73 +122,42 @@ pub async fn handle_create_remote_session(
             }
         };
 
-        let peer_label = state
-            .agent
-            .list_remote_nodes()
-            .await
-            .into_iter()
-            .find(|n| n.node_id.to_string() == node_id)
-            .map(|n| n.hostname)
-            .unwrap_or_else(|| node_id.to_string());
-
         match state
             .agent
-            .create_remote_session(
-                &node_manager_ref,
-                node_id.to_string(),
-                peer_label,
-                cwd.map(|s| s.to_string()),
-            )
+            .create_remote_session(&node_manager_ref, cwd.map(|s| s.to_string()))
             .await
         {
-            Ok((session_id, _session_actor_ref)) => {
-                let agent_id = super::super::session::PRIMARY_AGENT_ID.to_string();
-
+            Ok(resp) => {
+                let session_id = resp.session_id.clone();
+                let cwd_path = resp.cwd.as_ref().map(PathBuf::from);
+                if let Err(err) = finalize_remote_session_attach(
+                    state,
+                    conn_id,
+                    node_id,
+                    &session_id,
+                    resp.session_ref,
+                    cwd_path,
+                    tx,
+                )
+                .await
                 {
-                    let mut connections = state.connections.lock().await;
-                    if let Some(conn) = connections.get_mut(conn_id) {
-                        conn.sessions.insert(agent_id.clone(), session_id.clone());
-                        conn.subscribed_sessions.insert(session_id.clone());
-                    }
-                }
-
-                {
-                    let mut agents = state.session_agents.lock().await;
-                    agents.insert(session_id.clone(), agent_id.clone());
-                }
-
-                if let Some(cwd_str) = cwd {
-                    let mut cwds = state.session_cwds.lock().await;
-                    cwds.insert(session_id.clone(), std::path::PathBuf::from(cwd_str));
+                    let _ = send_error(
+                        tx,
+                        format!("Failed to finalize remote session attach: {err}"),
+                    )
+                    .await;
+                    return;
                 }
 
                 let _ = send_message(
                     tx,
                     UiServerMessage::SessionCreated {
-                        agent_id,
+                        agent_id: super::super::session::PRIMARY_AGENT_ID.to_string(),
                         session_id: session_id.clone(),
                         request_id: request_id.map(|s| s.to_string()),
                     },
                 )
                 .await;
-
-                // Signal the UI that the workspace index is building.
-                // The UI will show "Loading files..." in the @ mention dropdown
-                // until WorkspaceIndexReady arrives via the event relay and the
-                // server pushes a FileIndex message reactively.
-                if cwd.is_some() {
-                    let _ = send_message(
-                        tx,
-                        UiServerMessage::WorkspaceIndexStatus {
-                            session_id: session_id.clone(),
-                            status: "building".to_string(),
-                            message: None,
-                        },
-                    )
-                    .await;
-                }
-
-                handle_list_sessions(state, tx).await;
 
                 log::info!(
                     "handle_create_remote_session: created session {} on node_id '{}'",
@@ -220,12 +191,13 @@ pub async fn handle_create_remote_session(
 }
 
 #[cfg(feature = "remote")]
-async fn finalize_remote_session_attach(
+pub(crate) async fn finalize_remote_session_attach(
     state: &ServerState,
     conn_id: &str,
     node_id: &str,
     session_id: &str,
     remote_ref: RemoteActorRef<crate::agent::session_actor::SessionActor>,
+    cwd: Option<PathBuf>,
     tx: &mpsc::Sender<String>,
 ) -> Result<(), String> {
     let peer_label = state
@@ -247,8 +219,6 @@ async fn finalize_remote_session_attach(
         )
         .await;
 
-    // Health-check the attached session before publishing SessionLoaded.
-    // This avoids rendering a session that cannot accept prompts.
     let attached_session_ref = {
         let registry = state.agent.registry.lock().await;
         registry.get(session_id).cloned()
@@ -282,12 +252,11 @@ async fn finalize_remote_session_attach(
         agents.insert(session_id.to_string(), agent_id.clone());
     }
 
-    if let Some(cwd_path) = state.default_cwd.clone() {
+    if let Some(cwd_path) = cwd {
         let mut cwds = state.session_cwds.lock().await;
         cwds.insert(session_id.to_string(), cwd_path);
     }
 
-    // Fetch remote event history so the UI can render the conversation.
     let remote_events = {
         let session_ref = {
             let registry = state.agent.registry.lock().await;
@@ -330,8 +299,6 @@ async fn finalize_remote_session_attach(
         generated_at: time::OffsetDateTime::now_utc(),
     };
 
-    // Seed connection cursor so the event forwarder won't drop events
-    // that arrive while we're still sending the SessionLoaded payload.
     {
         let mut connections = state.connections.lock().await;
         if let Some(conn) = connections.get_mut(conn_id) {
@@ -457,7 +424,7 @@ pub(crate) async fn attach_remote_session_via_lookup(
     tx: &mpsc::Sender<String>,
 ) -> Result<(), String> {
     let remote_ref = lookup_remote_session_actor(state, node_id, session_id).await?;
-    finalize_remote_session_attach(state, conn_id, node_id, session_id, remote_ref, tx).await
+    finalize_remote_session_attach(state, conn_id, node_id, session_id, remote_ref, None, tx).await
 }
 
 /// Attach an existing remote session to the local registry.

--- a/crates/agent/src/ui/handlers/session_ops.rs
+++ b/crates/agent/src/ui/handlers/session_ops.rs
@@ -70,60 +70,101 @@ pub(crate) fn refresh_attached_remote_summary(
         total_ms = tracing::field::Empty
     )
 )]
-pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>) {
+pub async fn handle_list_sessions(
+    state: &ServerState,
+    tx: &mpsc::Sender<String>,
+    mode: Option<String>,
+    cursor: Option<String>,
+    limit: Option<u32>,
+    cwd: Option<String>,
+    query: Option<String>,
+) {
     let started = Instant::now();
-    let view_started = Instant::now();
+    let page_limit = limit.unwrap_or(20).clamp(1, 200) as usize;
+    let mode = mode.unwrap_or_else(|| "browse".to_string());
+    let is_browse_first_page = mode == "browse" && cursor.is_none();
 
-    let view = match state
-        .view_store
-        .get_session_list_view(None)
-        .instrument(tracing::info_span!(
-            "ui.handle_list_sessions.get_session_list_view"
-        ))
-        .await
-    {
-        Ok(view) => view,
+    let to_ui_group = |g: crate::session::projection::SessionGroup| SessionGroup {
+        cwd: g.cwd,
+        latest_activity: g.latest_activity.and_then(|t| t.format(&Rfc3339).ok()),
+        total_count: Some(g.total_count.unwrap_or(g.sessions.len()) as u64),
+        next_cursor: g.next_cursor,
+        sessions: g
+            .sessions
+            .into_iter()
+            .map(|s| SessionSummary {
+                session_id: s.session_id,
+                name: s.name,
+                cwd: s.cwd,
+                title: s.title,
+                created_at: s.created_at.and_then(|t| t.format(&Rfc3339).ok()),
+                updated_at: s.updated_at.and_then(|t| t.format(&Rfc3339).ok()),
+                parent_session_id: s.parent_session_id,
+                fork_origin: s.fork_origin,
+                session_kind: s.session_kind,
+                has_children: s.has_children,
+                node: None,
+                node_id: None,
+                attached: None,
+                runtime_state: None,
+            })
+            .collect(),
+    };
+
+    let result = match mode.as_str() {
+        "group" => {
+            let cwd_value = match cwd.as_deref() {
+                Some("__none__") => None,
+                _ => cwd,
+            };
+            state
+                .view_store
+                .list_group_sessions(cwd_value, cursor, page_limit)
+                .await
+                .map(|(group, total)| {
+                    let next_cursor = group.next_cursor.clone();
+                    (vec![to_ui_group(group)], next_cursor, total)
+                })
+        }
+        "search" => {
+            let q = query.unwrap_or_default();
+            state
+                .view_store
+                .search_sessions(q, cursor, page_limit)
+                .await
+                .map(|(groups, next_cursor, total)| {
+                    (
+                        groups.into_iter().map(to_ui_group).collect(),
+                        next_cursor,
+                        total,
+                    )
+                })
+        }
+        _ => state
+            .view_store
+            .browse_session_groups(cursor, page_limit, 10)
+            .await
+            .map(|(groups, next_cursor, total)| {
+                (
+                    groups.into_iter().map(to_ui_group).collect(),
+                    next_cursor,
+                    total,
+                )
+            }),
+    };
+
+    let (mut groups, next_cursor, total_count) = match result {
+        Ok(v) => v,
         Err(e) => {
             let _ = send_error(tx, format!("Failed to list sessions: {}", e)).await;
             return;
         }
     };
 
-    let view_fetch_ms = view_started.elapsed().as_millis() as u64;
-    let local_group_count = view.groups.len();
-    let local_session_count: usize = view.groups.iter().map(|g| g.sessions.len()).sum();
+    let local_group_count = groups.len();
+    let local_session_count: usize = groups.iter().map(|g| g.sessions.len()).sum();
 
-    let mut groups: Vec<SessionGroup> = view
-        .groups
-        .into_iter()
-        .map(|g| SessionGroup {
-            cwd: g.cwd,
-            latest_activity: g.latest_activity.and_then(|t| t.format(&Rfc3339).ok()),
-            sessions: g
-                .sessions
-                .into_iter()
-                .map(|s| SessionSummary {
-                    session_id: s.session_id,
-                    name: s.name,
-                    cwd: s.cwd,
-                    title: s.title,
-                    created_at: s.created_at.and_then(|t| t.format(&Rfc3339).ok()),
-                    updated_at: s.updated_at.and_then(|t| t.format(&Rfc3339).ok()),
-                    parent_session_id: s.parent_session_id,
-                    fork_origin: s.fork_origin,
-                    session_kind: s.session_kind,
-                    has_children: s.has_children,
-                    node: None,     // local sessions have no node label
-                    node_id: None,  // not applicable for local sessions
-                    attached: None, // not applicable for local sessions
-                    runtime_state: None,
-                })
-                .collect(),
-        })
-        .collect();
-
-    // Append in-memory remote sessions (not persisted to the local view store).
-    // Group them by peer_label so each remote node gets its own collapsible group.
+    // Append in-memory remote sessions for browse first page only.
     #[cfg(feature = "remote")]
     let mut remote_group_count = 0usize;
     #[cfg(feature = "remote")]
@@ -135,7 +176,7 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
 
     let remote_merge_started = Instant::now();
     #[cfg(feature = "remote")]
-    {
+    if is_browse_first_page {
         async {
             // 1. Collect already-attached remote sessions from the registry.
             let attached_sessions: std::collections::HashSet<String>;
@@ -146,7 +187,6 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                 sessions
             };
 
-            // Collect per-node groups: node_label -> Vec<SessionSummary>
             let mut by_node: std::collections::HashMap<String, Vec<SessionSummary>> =
                 std::collections::HashMap::new();
             let bookmark_titles: std::collections::HashMap<String, String> = state
@@ -158,9 +198,6 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                 .filter_map(|bookmark| bookmark.title.map(|title| (bookmark.session_id, title)))
                 .collect();
 
-            // Build a peer_label -> node_id_str map from live remote nodes so we
-            // can populate SessionSummary::node_id for both attached and discovered
-            // sessions.  The frontend needs node_id to send attach_remote_session.
             let node_id_by_label: std::collections::HashMap<String, String> =
                 if state.agent.mesh().is_some() {
                     state
@@ -197,31 +234,19 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                             has_children: false,
                             node: Some(peer_label),
                             node_id,
-                            attached: Some(true), // in-memory remote sessions are attached
+                            attached: Some(true),
                             runtime_state: Some("active".to_string()),
                         });
                 }
             }
 
-            // 2. Query each live peer for their sessions and include
-            //    unattached ones so the UI can show "available" remote
-            //    sessions after restart (Bug 2 fix).
-            //    Peers are queried in parallel to avoid accumulating the
-            //    2-second timeout for each peer serially.
-            //
-            //    We also collect the set of session IDs confirmed to exist on
-            //    each peer so the bookmark reattach phase can skip DHT lookups
-            //    for sessions that the peer confirms no longer exist.
-
-            // peer_label -> set of session IDs confirmed on that peer.
-            // A peer that was queried successfully but returned no sessions
-            // will have an empty set (distinguishable from "not queried").
+            // 2. Query each live peer for their sessions and refresh metadata.
             let mut confirmed_peer_sessions: std::collections::HashMap<
                 String,
                 std::collections::HashSet<String>,
             > = std::collections::HashMap::new();
 
-            if state.agent.mesh().is_some() {
+            if state.agent.mesh().is_some() && !node_id_by_label.is_empty() {
                 let peer_futures: Vec<_> = node_id_by_label
                     .iter()
                     .map(|(peer_label, node_id_str)| {
@@ -240,42 +265,25 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                             .await
                             {
                                 Ok(Ok(s)) => s,
-                                Ok(Err(e)) => {
-                                    log::debug!(
-                                        "handle_list_sessions: failed to query sessions from {}: {}",
-                                        peer_label,
-                                        e.message
-                                    );
-                                    return None;
-                                }
-                                Err(_) => {
-                                    log::debug!(
-                                        "handle_list_sessions: timeout querying sessions from {}",
-                                        peer_label
-                                    );
-                                    return None;
-                                }
+                                Ok(Err(_)) | Err(_) => return None,
                             };
                             Some((peer_label, node_id_str, sessions))
                         }
                     })
                     .collect();
 
-                let peer_results =
-                    futures_util::future::join_all(peer_futures).await;
+                let peer_results = futures_util::future::join_all(peer_futures).await;
 
                 for result in peer_results.into_iter().flatten() {
                     let (peer_label, node_id_str, sessions) = result;
 
-                    // Record which sessions this peer confirmed as existing.
                     let confirmed_ids: std::collections::HashSet<String> =
                         sessions.iter().map(|s| s.session_id.clone()).collect();
-                    confirmed_peer_sessions.insert(peer_label.clone(), confirmed_ids);
+                    confirmed_peer_sessions
+                        .insert(peer_label.clone(), confirmed_ids);
 
                     for session_info in sessions {
                         if attached_sessions.contains(&session_info.session_id) {
-                            // Keep attached sessions in-place, but refresh metadata from the
-                            // authoritative remote node response when available.
                             let _ = refresh_attached_remote_summary(
                                 &mut by_node,
                                 &peer_label,
@@ -301,7 +309,7 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                 has_children: false,
                                 node: Some(peer_label.clone()),
                                 node_id: Some(node_id_str.clone()),
-                                attached: Some(false), // discovered but not attached
+                                attached: Some(false),
                                 runtime_state: session_info.runtime_state,
                             });
                     }
@@ -311,31 +319,16 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
             for (node_label, sessions) in by_node {
                 remote_group_count += 1;
                 remote_session_count += sessions.len();
-                // Use a synthetic cwd like "remote::<node>" so the group header
-                // is recognisable without requiring a real path.
                 groups.push(SessionGroup {
                     cwd: Some(format!("remote::{}", node_label)),
                     sessions,
                     latest_activity: None,
+                    total_count: None,
+                    next_cursor: None,
                 });
             }
 
-            // ── Lazy bookmark reattach ────────────────────────────────────
-            //
-            // Load persisted remote session bookmarks and attempt to re-attach
-            // sessions that are not yet in the registry.
-            //
-            // Optimisations over the previous sequential approach:
-            //   1. If the bookmark's peer was successfully queried and the
-            //      session ID is NOT in that peer's list → the session was
-            //      deleted on the remote side.  Skip the DHT lookup entirely
-            //      and auto-prune the stale bookmark.
-            //   2. Remaining reattach attempts run concurrently (join_all)
-            //      instead of sequentially, so N bookmarks take ~O(1) wall
-            //      time instead of O(N * 1.75 s).
-            //   3. Uses `reattach_from_bookmark_quick` (single DHT lookup,
-            //      no retries) to avoid 1.75 s backoff per stale bookmark.
-
+            // 3. Lazy bookmark reattach.
             if state.agent.mesh().is_some() {
                 match state.session_store.list_remote_session_bookmarks().await {
                     Ok(bookmarks) if !bookmarks.is_empty() => {
@@ -344,29 +337,20 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                             registry.session_ids().into_iter().collect()
                         };
 
-                        // Partition bookmarks into:
-                        //  - `stale`: peer is online and confirmed the session is gone
-                        //  - `to_reattach`: need a DHT lookup (peer offline or session
-                        //     might still exist)
-                        //  - already attached: skip
                         let mut stale_ids: Vec<String> = Vec::new();
                         let mut to_reattach: Vec<crate::session::store::RemoteSessionBookmark> =
                             Vec::new();
 
                         for bookmark in bookmarks {
                             if registry_ids.contains(&bookmark.session_id) {
-                                continue; // already attached
+                                continue;
                             }
 
-                            // Check if we successfully queried this bookmark's peer
-                            // and the session is NOT in the returned list.
                             if let Some(peer_sessions) =
                                 confirmed_peer_sessions.get(&bookmark.peer_label)
                                 && !peer_sessions.contains(&bookmark.session_id) {
-                                    // Peer is online, session confirmed gone → prune.
                                     log::info!(
-                                        "Auto-pruning stale bookmark {}: peer '{}' is online \
-                                         but session no longer exists",
+                                        "Auto-pruning stale bookmark {}: peer '{}' online but session gone",
                                         bookmark.session_id,
                                         bookmark.peer_label,
                                     );
@@ -377,7 +361,6 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                             to_reattach.push(bookmark);
                         }
 
-                        // Prune stale bookmarks in the background.
                         if !stale_ids.is_empty() {
                             let store = state.session_store.clone();
                             tokio::spawn(async move {
@@ -385,17 +368,12 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                     if let Err(e) =
                                         store.remove_remote_session_bookmark(&sid).await
                                     {
-                                        log::warn!(
-                                            "Failed to remove stale bookmark {}: {}",
-                                            sid,
-                                            e
-                                        );
+                                        log::warn!("Failed to remove stale bookmark {}: {}", sid, e);
                                     }
                                 }
                             });
                         }
 
-                        // Reattach remaining bookmarks concurrently.
                         if !to_reattach.is_empty() {
                             let reattach_futures: Vec<_> = to_reattach
                                 .into_iter()
@@ -408,36 +386,22 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                         )
                                         .await
                                         {
-                                            Ok(Ok(_)) => {
-                                                log::info!(
-                                                    "Reattached remote session {} from bookmark",
-                                                    bookmark.session_id
-                                                );
-                                                true
-                                            }
+                                            Ok(Ok(_)) => true,
                                             Ok(Err(e)) => {
                                                 log::debug!(
-                                                    "Failed to reattach bookmarked session {}: {}",
-                                                    bookmark.session_id,
-                                                    e
+                                                    "Failed to reattach bookmark {}: {}",
+                                                    bookmark.session_id, e
                                                 );
                                                 false
                                             }
-                                            Err(_) => {
-                                                log::debug!(
-                                                    "Reattach timed out for bookmarked session {}",
-                                                    bookmark.session_id
-                                                );
-                                                false
-                                            }
+                                            Err(_) => false,
                                         };
                                         (bookmark, reattached)
                                     }
                                 })
                                 .collect();
 
-                            let results =
-                                futures_util::future::join_all(reattach_futures).await;
+                            let results = futures_util::future::join_all(reattach_futures).await;
 
                             let mut bookmark_groups: std::collections::HashMap<
                                 String,
@@ -477,11 +441,7 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                     .find(|g| g.cwd.as_deref() == Some(group_cwd.as_str()))
                                 {
                                     let existing_ids: std::collections::HashSet<String> =
-                                        existing
-                                            .sessions
-                                            .iter()
-                                            .map(|s| s.session_id.clone())
-                                            .collect();
+                                        existing.sessions.iter().map(|s| s.session_id.clone()).collect();
                                     for s in sessions {
                                         if !existing_ids.contains(&s.session_id) {
                                             existing.sessions.push(s);
@@ -494,12 +454,14 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                         cwd: Some(group_cwd),
                                         sessions,
                                         latest_activity: None,
+                                        total_count: None,
+                                        next_cursor: None,
                                     });
                                 }
                             }
                         }
                     }
-                    Ok(_) => {} // no bookmarks
+                    Ok(_) => {}
                     Err(e) => {
                         log::warn!("Failed to load remote session bookmarks: {}", e);
                     }
@@ -510,6 +472,8 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
         .await;
     }
     let remote_merge_ms = remote_merge_started.elapsed().as_millis() as u64;
+    #[cfg(not(feature = "remote"))]
+    let remote_merge_ms = 0u64;
 
     let total_group_count = groups.len();
     let total_session_count: usize = groups.iter().map(|g| g.sessions.len()).sum();
@@ -521,11 +485,19 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
     span.record("remote_session_count", remote_session_count);
     span.record("total_group_count", total_group_count);
     span.record("total_session_count", total_session_count);
-    span.record("view_fetch_ms", view_fetch_ms);
+    span.record("view_fetch_ms", started.elapsed().as_millis() as u64);
     span.record("remote_merge_ms", remote_merge_ms);
     span.record("total_ms", started.elapsed().as_millis() as u64);
 
-    let _ = send_message(tx, UiServerMessage::SessionList { groups }).await;
+    let _ = send_message(
+        tx,
+        UiServerMessage::SessionList {
+            groups,
+            next_cursor,
+            total_count: total_count as u64,
+        },
+    )
+    .await;
 }
 
 /// Handle session loading request.
@@ -713,7 +685,7 @@ pub async fn handle_delete_session(
     }
 
     send_state(state, conn_id, tx).await;
-    handle_list_sessions(state, tx).await;
+    handle_list_sessions(state, tx, None, None, None, None, None).await;
 }
 
 pub(super) async fn ensure_session_loaded(
@@ -1220,7 +1192,7 @@ pub async fn handle_fork_session(
             }
 
             send_state(state, conn_id, tx).await;
-            handle_list_sessions(state, tx).await;
+            handle_list_sessions(state, tx, None, None, None, None, None).await;
 
             let _ = send_message(
                 tx,

--- a/crates/agent/src/ui/handlers/session_ops.rs
+++ b/crates/agent/src/ui/handlers/session_ops.rs
@@ -235,7 +235,7 @@ pub async fn handle_list_sessions(
                             node: Some(peer_label),
                             node_id,
                             attached: Some(true),
-                            runtime_state: Some("active".to_string()),
+                            runtime_state: None,
                         });
                 }
             }

--- a/crates/agent/src/ui/handlers/session_ops.rs
+++ b/crates/agent/src/ui/handlers/session_ops.rs
@@ -27,6 +27,31 @@ use time::format_description::well_known::Rfc3339;
 use tokio::sync::mpsc;
 use tracing::Instrument;
 
+#[cfg(feature = "remote")]
+pub(crate) fn refresh_attached_remote_summary(
+    by_node: &mut std::collections::HashMap<String, Vec<SessionSummary>>,
+    peer_label: &str,
+    node_id: &str,
+    session_info: &crate::agent::remote::RemoteSessionInfo,
+) -> bool {
+    let Some(existing) = by_node.get_mut(peer_label).and_then(|sessions| {
+        sessions
+            .iter_mut()
+            .find(|s| s.session_id == session_info.session_id)
+    }) else {
+        return false;
+    };
+
+    if session_info.title.is_some() {
+        existing.title = session_info.title.clone();
+        existing.name = session_info.title.clone();
+    }
+
+    existing.node_id = Some(node_id.to_string());
+    existing.runtime_state = session_info.runtime_state.clone();
+    true
+}
+
 // ── Session list / load ───────────────────────────────────────────────────────
 
 /// Handle session listing request.
@@ -248,8 +273,15 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                     confirmed_peer_sessions.insert(peer_label.clone(), confirmed_ids);
 
                     for session_info in sessions {
-                        // Skip sessions that are already attached.
                         if attached_sessions.contains(&session_info.session_id) {
+                            // Keep attached sessions in-place, but refresh metadata from the
+                            // authoritative remote node response when available.
+                            let _ = refresh_attached_remote_summary(
+                                &mut by_node,
+                                &peer_label,
+                                &node_id_str,
+                                &session_info,
+                            );
                             continue;
                         }
 

--- a/crates/agent/src/ui/handlers/session_ops.rs
+++ b/crates/agent/src/ui/handlers/session_ops.rs
@@ -8,7 +8,7 @@ use super::super::ServerState;
 use super::super::connection::{send_error, send_message, send_state, subscribe_to_file_index};
 use super::super::messages::{SessionGroup, SessionSummary, UiServerMessage};
 #[cfg(feature = "remote")]
-use super::attach_remote_session_via_lookup;
+use super::remote::finalize_remote_session_attach;
 
 use super::super::{cursor_from_events, session::PRIMARY_AGENT_ID};
 use crate::agent::core::AgentMode;
@@ -1013,12 +1013,11 @@ pub async fn handle_fork_session(
         let registry = state.agent.registry.lock().await;
         registry.get(&source_session_id).cloned()
     };
+
     #[cfg(feature = "remote")]
-    let source_remote_node_id = if source_session_ref
-        .as_ref()
-        .is_some_and(|session_ref| session_ref.is_remote())
+    if let Some(crate::agent::remote::SessionActorRef::Remote { .. }) = source_session_ref.as_ref()
     {
-        state
+        let source_remote_node_id = state
             .session_store
             .list_remote_session_bookmarks()
             .await
@@ -1028,33 +1027,63 @@ pub async fn handle_fork_session(
                     .into_iter()
                     .find(|bookmark| bookmark.session_id == source_session_id)
                     .map(|bookmark| bookmark.node_id)
-            })
-    } else {
-        None
-    };
+            });
 
-    let fork_result = if let Some(session_ref) = source_session_ref {
-        session_ref
-            .fork_at_message(message_id.to_string())
-            .await
-            .map_err(|err| err.to_string())
-    } else {
-        state
-            .session_store
-            .fork_session(&source_session_id, message_id, ForkOrigin::User)
-            .await
-            .map_err(|err| err.to_string())
-    };
+        let Some(node_id) = source_remote_node_id else {
+            let _ = send_message(
+                tx,
+                UiServerMessage::ForkResult {
+                    success: false,
+                    source_session_id: Some(source_session_id),
+                    forked_session_id: None,
+                    message: Some(
+                        "Remote source session is missing owner node metadata".to_string(),
+                    ),
+                },
+            )
+            .await;
+            return;
+        };
 
-    match fork_result {
-        Ok(forked_session_id) => {
-            #[cfg(feature = "remote")]
-            if let Some(node_id) = source_remote_node_id.clone() {
-                if let Err(err) = attach_remote_session_via_lookup(
+        let node_manager_ref = match state.agent.find_node_manager(&node_id).await {
+            Ok(r) => r,
+            Err(err) => {
+                let _ = send_message(
+                    tx,
+                    UiServerMessage::ForkResult {
+                        success: false,
+                        source_session_id: Some(source_session_id),
+                        forked_session_id: None,
+                        message: Some(format!(
+                            "Failed to resolve remote node manager: {}",
+                            err.message
+                        )),
+                    },
+                )
+                .await;
+                return;
+            }
+        };
+
+        match state
+            .agent
+            .fork_remote_session(
+                &node_manager_ref,
+                source_session_id.clone(),
+                message_id.to_string(),
+            )
+            .await
+        {
+            Ok(resp) => {
+                let forked_session_id = resp.session_id.clone();
+                let cwd = resp.cwd.as_ref().map(PathBuf::from);
+                if let Err(err) = finalize_remote_session_attach(
                     state,
                     conn_id,
                     &node_id,
                     &forked_session_id,
+                    resp.session_ref,
+                    cwd,
                     tx,
                 )
                 .await
@@ -1086,7 +1115,37 @@ pub async fn handle_fork_session(
                 .await;
                 return;
             }
+            Err(err) => {
+                let _ = send_message(
+                    tx,
+                    UiServerMessage::ForkResult {
+                        success: false,
+                        source_session_id: Some(source_session_id),
+                        forked_session_id: None,
+                        message: Some(format!("Failed to fork remote session: {}", err.message)),
+                    },
+                )
+                .await;
+                return;
+            }
+        }
+    }
 
+    let fork_result = if let Some(session_ref) = source_session_ref {
+        session_ref
+            .fork_at_message(message_id.to_string())
+            .await
+            .map_err(|err| err.to_string())
+    } else {
+        state
+            .session_store
+            .fork_session(&source_session_id, message_id, ForkOrigin::User)
+            .await
+            .map_err(|err| err.to_string())
+    };
+
+    match fork_result {
+        Ok(forked_session_id) => {
             if let Ok(Some(forked_session)) =
                 state.session_store.get_session(&forked_session_id).await
                 && let Some(cwd) = forked_session.cwd
@@ -1143,6 +1202,7 @@ pub async fn handle_fork_session(
             )
             .await;
         }
+
         Err(err) => {
             let _ = send_message(
                 tx,

--- a/crates/agent/src/ui/handlers/session_ops.rs
+++ b/crates/agent/src/ui/handlers/session_ops.rs
@@ -1082,7 +1082,7 @@ pub async fn handle_fork_session(
                     conn_id,
                     &node_id,
                     &forked_session_id,
-                    resp.session_ref,
+                    resp.handoff,
                     cwd,
                     tx,
                 )

--- a/crates/agent/src/ui/handlers/session_ops.rs
+++ b/crates/agent/src/ui/handlers/session_ops.rs
@@ -17,7 +17,7 @@ use crate::index::resolve_workspace_root;
 use crate::send_agent::SendAgent;
 use crate::session::domain::ForkOrigin;
 use crate::ui::mentions::{filter_index_for_cwd, filter_index_for_cwd_entries};
-use agent_client_protocol::schema::{CancelNotification, LoadSessionRequest, SessionId};
+use agent_client_protocol::schema::{LoadSessionRequest, SessionId};
 use querymt::chat::ReasoningEffort;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -91,6 +91,7 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                     node: None,     // local sessions have no node label
                     node_id: None,  // not applicable for local sessions
                     attached: None, // not applicable for local sessions
+                    runtime_state: None,
                 })
                 .collect(),
         })
@@ -172,6 +173,7 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                             node: Some(peer_label),
                             node_id,
                             attached: Some(true), // in-memory remote sessions are attached
+                            runtime_state: Some("active".to_string()),
                         });
                 }
             }
@@ -268,6 +270,7 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                 node: Some(peer_label.clone()),
                                 node_id: Some(node_id_str.clone()),
                                 attached: Some(false), // discovered but not attached
+                                runtime_state: session_info.runtime_state,
                             });
                     }
                 }
@@ -427,6 +430,11 @@ pub async fn handle_list_sessions(state: &ServerState, tx: &mpsc::Sender<String>
                                         node: Some(bookmark.peer_label),
                                         node_id: Some(bookmark.node_id),
                                         attached: Some(reattached),
+                                        runtime_state: Some(if reattached {
+                                            "active".to_string()
+                                        } else {
+                                            "stopped".to_string()
+                                        }),
                                     });
                             }
 
@@ -791,17 +799,8 @@ pub async fn handle_cancel_session(state: &ServerState, conn_id: &str, tx: &mpsc
         return;
     };
 
-    let agent_id = {
-        let agents = state.session_agents.lock().await;
-        agents.get(&session_id).cloned()
-    };
-    let agent = agent_id
-        .and_then(|id| super::super::session::agent_for_id(state, &id))
-        .unwrap_or_else(|| state.agent.clone() as Arc<dyn crate::agent::handle::AgentHandle>);
-
-    let notif = CancelNotification::new(session_id);
-    if let Err(e) = agent.cancel(notif).await {
-        let _ = send_error(tx, format!("Failed to cancel session: {}", e)).await;
+    if let Err(e) = state.agent.stop_session(&session_id).await {
+        let _ = send_error(tx, format!("Failed to stop session: {}", e)).await;
     }
 }
 

--- a/crates/agent/src/ui/messages.rs
+++ b/crates/agent/src/ui/messages.rs
@@ -151,6 +151,11 @@ pub struct SessionGroup {
     pub cwd: Option<String>,
     pub sessions: Vec<SessionSummary>,
     pub latest_activity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[typeshare(serialized_as = "number")]
+    pub total_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// Messages from UI client to server.
@@ -174,7 +179,23 @@ pub enum UiClientMessage {
     Prompt {
         prompt: Vec<UiPromptBlock>,
     },
-    ListSessions,
+    ListSessions {
+        /// Query mode: browse (default), group, or search.
+        #[serde(default)]
+        mode: Option<String>,
+        /// Opaque pagination cursor (offset as string for now).
+        #[serde(default)]
+        cursor: Option<String>,
+        /// Max number of sessions to return.
+        #[serde(default)]
+        limit: Option<u32>,
+        /// Group key for mode=group (cwd path or null-group marker).
+        #[serde(default)]
+        cwd: Option<String>,
+        /// Search query for mode=search.
+        #[serde(default)]
+        query: Option<String>,
+    },
     LoadSession {
         session_id: String,
     },
@@ -735,6 +756,10 @@ pub enum UiServerMessage {
     },
     SessionList {
         groups: Vec<SessionGroup>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        next_cursor: Option<String>,
+        #[typeshare(serialized_as = "number")]
+        total_count: u64,
     },
     SessionLoaded {
         session_id: String,

--- a/crates/agent/src/ui/messages.rs
+++ b/crates/agent/src/ui/messages.rs
@@ -120,27 +120,14 @@ pub struct SessionSummary {
     pub title: Option<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
-    /// Public ID of the parent session (if this is a child session)
     pub parent_session_id: Option<String>,
-    /// Fork origin: "user" or "delegation"
     pub fork_origin: Option<String>,
-    /// Session kind for specialized workflows (e.g. "recurring")
     pub session_kind: Option<String>,
-    /// Whether this session has child sessions
     pub has_children: bool,
-    /// Node label where this session lives. "local" for local sessions,
-    /// peer hostname/label for remote sessions (display only).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub node: Option<String>,
-    /// Stable PeerId of the remote node. Required by the frontend to send
-    /// `attach_remote_session`. Only set for remote sessions.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
-    /// Whether this remote session is currently attached (has a live actor ref).
-    /// `Some(true)` = attached, `Some(false)` = discovered but not attached,
-    /// `None` = local session (not applicable).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub attached: Option<bool>,
+    pub runtime_state: Option<String>,
 }
 
 /// Information about a remote node discovered in the kameo mesh.

--- a/crates/agent/src/ui/mod.rs
+++ b/crates/agent/src/ui/mod.rs
@@ -21,6 +21,8 @@ pub use messages::{RoutingMode, UiAgentInfo};
 
 #[cfg(test)]
 mod fork_tests;
+#[cfg(all(feature = "api", feature = "remote"))]
+mod session_ops_remote_title_tests;
 #[cfg(test)]
 mod session_stream_tests;
 #[cfg(test)]

--- a/crates/agent/src/ui/session.rs
+++ b/crates/agent/src/ui/session.rs
@@ -153,8 +153,24 @@ pub async fn ensure_session(
             .get(conn_id)
             .and_then(|conn| conn.sessions.get(agent_id).cloned())
     };
-    if let Some(session_id) = existing {
-        return Ok(session_id);
+    if let Some(session_id) = &existing {
+        // Verify the session still exists in the registry.
+        // After a force-stop the session is removed, making the binding stale.
+        let still_alive = {
+            let registry = state.agent.registry.lock().await;
+            registry.get(session_id).is_some()
+        };
+        if still_alive {
+            return Ok(session_id.clone());
+        }
+        // Session was destroyed (force-stopped) — clear the stale binding
+        // so the code below creates a fresh session.
+        {
+            let mut connections = state.connections.lock().await;
+            if let Some(conn) = connections.get_mut(conn_id) {
+                conn.sessions.remove(agent_id);
+            }
+        }
     }
 
     let agent =

--- a/crates/agent/src/ui/session_ops_remote_title_tests.rs
+++ b/crates/agent/src/ui/session_ops_remote_title_tests.rs
@@ -1,0 +1,95 @@
+#![cfg(all(test, feature = "api", feature = "remote"))]
+
+use crate::agent::remote::RemoteSessionInfo;
+use crate::ui::handlers::refresh_attached_remote_summary;
+use crate::ui::messages::SessionSummary;
+use std::collections::HashMap;
+
+#[test]
+fn refresh_attached_remote_summary_updates_title_for_attached_session() {
+    let mut by_node = HashMap::<String, Vec<SessionSummary>>::new();
+    by_node.insert(
+        "peer-a".to_string(),
+        vec![SessionSummary {
+            session_id: "sess-1".to_string(),
+            name: None,
+            cwd: None,
+            title: None,
+            created_at: None,
+            updated_at: None,
+            parent_session_id: None,
+            fork_origin: None,
+            session_kind: None,
+            has_children: false,
+            node: Some("peer-a".to_string()),
+            node_id: None,
+            attached: Some(true),
+            runtime_state: Some("active".to_string()),
+        }],
+    );
+
+    let changed = refresh_attached_remote_summary(
+        &mut by_node,
+        "peer-a",
+        "node-123",
+        &RemoteSessionInfo {
+            session_id: "sess-1".to_string(),
+            actor_id: 42,
+            cwd: Some("/tmp".to_string()),
+            created_at: 123,
+            title: Some("Remote title from snapshot".to_string()),
+            peer_label: "peer-a".to_string(),
+            runtime_state: Some("active".to_string()),
+        },
+    );
+
+    assert!(changed);
+    let summary = &by_node["peer-a"][0];
+    assert_eq!(summary.title.as_deref(), Some("Remote title from snapshot"));
+    assert_eq!(summary.name.as_deref(), Some("Remote title from snapshot"));
+    assert_eq!(summary.node_id.as_deref(), Some("node-123"));
+}
+
+#[test]
+fn refresh_attached_remote_summary_does_not_clear_existing_title_on_none() {
+    let mut by_node = HashMap::<String, Vec<SessionSummary>>::new();
+    by_node.insert(
+        "peer-a".to_string(),
+        vec![SessionSummary {
+            session_id: "sess-1".to_string(),
+            name: Some("Existing".to_string()),
+            cwd: None,
+            title: Some("Existing".to_string()),
+            created_at: None,
+            updated_at: None,
+            parent_session_id: None,
+            fork_origin: None,
+            session_kind: None,
+            has_children: false,
+            node: Some("peer-a".to_string()),
+            node_id: None,
+            attached: Some(true),
+            runtime_state: Some("active".to_string()),
+        }],
+    );
+
+    let changed = refresh_attached_remote_summary(
+        &mut by_node,
+        "peer-a",
+        "node-123",
+        &RemoteSessionInfo {
+            session_id: "sess-1".to_string(),
+            actor_id: 42,
+            cwd: Some("/tmp".to_string()),
+            created_at: 123,
+            title: None,
+            peer_label: "peer-a".to_string(),
+            runtime_state: Some("active".to_string()),
+        },
+    );
+
+    assert!(changed);
+    let summary = &by_node["peer-a"][0];
+    assert_eq!(summary.title.as_deref(), Some("Existing"));
+    assert_eq!(summary.name.as_deref(), Some("Existing"));
+}

--- a/crates/agent/ui/src/components/ChatView.tsx
+++ b/crates/agent/ui/src/components/ChatView.tsx
@@ -56,6 +56,9 @@ export function ChatView() {
     sendPrompt,
     cancelSession,
     deleteSession,
+    loadMoreSessions,
+    loadMoreGroupSessions,
+    searchSessions,
     setFileIndexCallback,
     setFileIndexErrorCallback,
     requestFileIndex,
@@ -84,6 +87,9 @@ export function ChatView() {
     sessionGroups,
     thinkingBySession,
     sessionParentMap,
+    sessionNextCursor,
+    sessionTotalCount,
+    sessionPageLoading,
     workspaceIndexStatus,
     llmConfigCache,
     undoState,
@@ -876,10 +882,15 @@ export function ChatView() {
                     onSelectSession={handleSelectSession}
                     onDeleteSession={handleDeleteSession}
                     onNewSession={handleNewSession}
+                    onLoadMoreSessions={() => loadMoreSessions(20)}
+                    onLoadMoreGroupSessions={(cwd) => loadMoreGroupSessions(cwd, 20)}
+                    onSearchSessions={(q) => searchSessions(q, 30)}
                     disabled={!connected || loading}
                     activeSessionId={sessionId}
                     thinkingBySession={thinkingBySession}
                     sessionParentMap={sessionParentMap}
+                    hasMoreSessions={!!sessionNextCursor || sessionGroups.reduce((n, g) => n + g.sessions.length, 0) < sessionTotalCount}
+                    sessionPageLoading={sessionPageLoading}
                   />
                 )
               ) : (

--- a/crates/agent/ui/src/components/HomePage.tsx
+++ b/crates/agent/ui/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Loader } from 'lucide-react';
 import { useSessionManager } from '../hooks/useSessionManager';
 import { useUiClientActions, useUiClientSession } from '../context/UiClientContext';
@@ -15,16 +15,32 @@ import { WelcomeScreen } from './WelcomeScreen';
 export function HomePage() {
   const { selectSession, createSession, goHome } = useSessionManager();
   
-  const { deleteSession } = useUiClientActions();
-  const { 
-    connected, 
-    sessionGroups, 
+  const { deleteSession, loadMoreSessions, loadMoreGroupSessions, searchSessions } = useUiClientActions();
+  const {
+    connected,
+    sessionGroups,
     sessionId,
     thinkingBySession,
     sessionParentMap,
+    sessionNextCursor,
+    sessionTotalCount,
+    sessionPageLoading,
+    sessionsEverLoaded,
   } = useUiClientSession();
   
   const [loading, setLoading] = useState(false);
+
+  const handleLoadMoreSessions = useCallback(() => {
+    loadMoreSessions(20);
+  }, [loadMoreSessions]);
+
+  const handleLoadMoreGroupSessions = useCallback((cwd: string | null) => {
+    loadMoreGroupSessions(cwd, 20);
+  }, [loadMoreGroupSessions]);
+
+  const handleSearchSessions = useCallback((q: string) => {
+    searchSessions(q, 30);
+  }, [searchSessions]);
 
   const handleNewSession = async () => {
     setLoading(true);
@@ -58,7 +74,7 @@ export function HomePage() {
     );
   }
 
-  if (sessionGroups.length > 0) {
+  if (sessionsEverLoaded || sessionGroups.length > 0) {
     return (
       <div className="flex items-center justify-center h-full">
         <SessionPicker
@@ -66,10 +82,15 @@ export function HomePage() {
           onSelectSession={handleSelectSession}
           onDeleteSession={handleDeleteSession}
           onNewSession={handleNewSession}
+          onLoadMoreSessions={handleLoadMoreSessions}
+          onLoadMoreGroupSessions={handleLoadMoreGroupSessions}
+          onSearchSessions={handleSearchSessions}
           disabled={loading}
           activeSessionId={sessionId}
           thinkingBySession={thinkingBySession}
           sessionParentMap={sessionParentMap}
+          hasMoreSessions={!!sessionNextCursor || sessionGroups.reduce((n, g) => n + g.sessions.length, 0) < sessionTotalCount}
+          sessionPageLoading={sessionPageLoading}
         />
       </div>
     );

--- a/crates/agent/ui/src/components/SessionPicker.tsx
+++ b/crates/agent/ui/src/components/SessionPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { SessionGroup, SessionSummary } from '../types';
 import { ChevronDown, ChevronRight, Search, Plus, Clock, GitBranch, Globe, Trash2, Plug } from 'lucide-react';
@@ -9,15 +9,42 @@ interface SessionPickerProps {
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string, sessionLabel?: string) => void;
   onNewSession: () => void;
+  onLoadMoreSessions?: () => void;
+  onLoadMoreGroupSessions?: (cwd: string | null) => void;
+  onSearchSessions?: (query: string) => void;
   disabled?: boolean;
   activeSessionId?: string | null;
   thinkingBySession?: Map<string, Set<string>>;
   sessionParentMap?: Map<string, string>;
+  hasMoreSessions?: boolean;
+  sessionPageLoading?: boolean;
 }
 
-export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewSession, disabled, activeSessionId, thinkingBySession, sessionParentMap }: SessionPickerProps) {
+export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewSession, onLoadMoreSessions, onLoadMoreGroupSessions, onSearchSessions, disabled, activeSessionId, thinkingBySession, sessionParentMap, hasMoreSessions, sessionPageLoading }: SessionPickerProps) {
   const [filterText, setFilterText] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set(groups.map((_, i) => `group-${i}`)));
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Whether server-backed search is active (controls client-side filtering bypass).
+  const isServerSearch = !!onSearchSessions;
+
+  // Debounced search: only fires when the user actually types, not on mount.
+  // Avoids the infinite loop caused by putting onSearchSessions in a useEffect dep array.
+  const handleFilterChange = useCallback((value: string) => {
+    setFilterText(value);
+    if (!onSearchSessions) return;
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      onSearchSessions(value);
+    }, 200);
+  }, [onSearchSessions]);
+
+  // Cleanup debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
+  }, []);
   
   // Build session hierarchy and filter by search text
   const filteredGroups = useMemo(() => {
@@ -59,6 +86,8 @@ export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewS
     });
 
     if (!query) return groupsWithHierarchy;
+    // In server-backed search mode, groups are already filtered across the whole DB.
+    if (isServerSearch) return groupsWithHierarchy;
 
     // Filter with hierarchy awareness: keep a node if it or any descendant matches.
     const filterWithHierarchy = (
@@ -82,7 +111,7 @@ export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewS
           .filter((s): s is SessionSummary & { children?: SessionSummary[] } => s !== null),
       }))
       .filter(group => group.sessions.length > 0);
-  }, [groups, filterText]);
+  }, [groups, filterText, isServerSearch]);
   
   const thinkingSessionIds = useThinkingSessionIds(thinkingBySession, groups, sessionParentMap);
   
@@ -273,7 +302,7 @@ export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewS
               type="text"
               placeholder="Filter by session ID or title..."
               value={filterText}
-              onChange={(e) => setFilterText(e.target.value)}
+              onChange={(e) => handleFilterChange(e.target.value)}
               className="w-full pl-12 pr-4 py-3 bg-surface-elevated border-2 border-surface-border rounded-lg text-ui-primary placeholder:text-ui-muted focus:border-accent-primary focus:outline-none transition-colors session-filter-input"
             />
           </div>
@@ -309,7 +338,9 @@ export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewS
                       {groupLabel}
                     </span>
                     <span className="text-xs text-ui-muted">
-                      {group.sessions.length} session{group.sessions.length !== 1 ? 's' : ''}
+                      {group.sessions.length}
+                      {typeof group.total_count === 'number' ? ` / ${group.total_count}` : ''}
+                      {' '}session{(group.total_count ?? group.sessions.length) !== 1 ? 's' : ''}
                     </span>
                   </Collapsible.Trigger>
                   
@@ -318,6 +349,18 @@ export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewS
                     {group.sessions.map((session, sessionIndex) => 
                       renderSessionCard(session, sessionIndex, 0)
                     )}
+                    {group.next_cursor && (
+                      <div className="pt-2">
+                        <button
+                          type="button"
+                          onClick={() => onLoadMoreGroupSessions?.(group.cwd ?? null)}
+                          disabled={disabled || sessionPageLoading}
+                          className="px-3 py-1.5 rounded-md text-[11px] font-medium border border-surface-border/40 text-ui-secondary hover:text-ui-primary hover:border-accent-primary/50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                        >
+                          {sessionPageLoading ? 'Loading...' : 'Load more in workspace'}
+                        </button>
+                      </div>
+                    )}
                   </Collapsible.Content>
                 </Collapsible.Root>
               );
@@ -325,6 +368,19 @@ export function SessionPicker({ groups, onSelectSession, onDeleteSession, onNewS
           )}
         </div>
         
+        {/* Global pagination (browse/search mode) */}
+        {(hasMoreSessions || sessionPageLoading) && (
+          <div className="text-center mb-6">
+            <button
+              onClick={() => onLoadMoreSessions?.()}
+              disabled={disabled || sessionPageLoading || !hasMoreSessions}
+              className="px-4 py-2 rounded-lg text-xs font-medium border border-surface-border/40 text-ui-secondary hover:text-ui-primary hover:border-accent-primary/50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              {sessionPageLoading ? 'Loading...' : filterText.trim() ? 'Load more results' : 'Load more workspaces'}
+            </button>
+          </div>
+        )}
+
         {/* New session button */}
         <div className="text-center space-y-3">
           <button

--- a/crates/agent/ui/src/context/UiClientContext.tsx
+++ b/crates/agent/ui/src/context/UiClientContext.tsx
@@ -41,6 +41,9 @@ export interface UiClientActionsContextValue {
   attachRemoteSession: (nodeId: string, sessionId: string, sessionLabel?: string) => void;
   refreshAllModels: () => void;
   fetchRecentModels: () => void;
+  loadMoreSessions: (limit?: number) => void;
+  loadMoreGroupSessions: (cwd: string | null, limit?: number) => void;
+  searchSessions: (query: string, limit?: number) => void;
   requestAuthProviders: () => void;
   startOAuthLogin: (provider: string) => void;
   completeOAuthLogin: (flowId: string, response: string) => void;
@@ -138,9 +141,14 @@ export interface UiClientSessionContextValue {
   availableModes: string[];
   reasoningEffort: string | null;
   remoteNodes: RemoteNodeInfo[];
+  sessionNextCursor: string | null;
+  sessionTotalCount: number;
+  sessionPageLoading: boolean;
   meshInvites: MeshInviteInfo[];
   lastCreatedMeshInvite: MeshInviteCreated | null;
   /** Session ID of the last session that failed to load. Used to navigate away and stop retry loops. */
+  /** Tracks whether sessions have ever been loaded (persists across search/browse/delete). */
+  sessionsEverLoaded: boolean;
   lastLoadErrorSessionId: string | null;
   schedules: ScheduleInfo[];
   knowledgeEntries: KnowledgeEntryInfo[];
@@ -214,6 +222,9 @@ export function UiClientProvider({ children }: UiClientProviderProps) {
     attachRemoteSession: uiClient.attachRemoteSession,
     refreshAllModels: uiClient.refreshAllModels,
     fetchRecentModels: uiClient.fetchRecentModels,
+    loadMoreSessions: uiClient.loadMoreSessions,
+    loadMoreGroupSessions: uiClient.loadMoreGroupSessions,
+    searchSessions: uiClient.searchSessions,
     requestAuthProviders: uiClient.requestAuthProviders,
     startOAuthLogin: uiClient.startOAuthLogin,
     completeOAuthLogin: uiClient.completeOAuthLogin,
@@ -302,6 +313,10 @@ export function UiClientProvider({ children }: UiClientProviderProps) {
     availableModes: uiClient.availableModes,
     reasoningEffort: uiClient.reasoningEffort,
     remoteNodes: uiClient.remoteNodes,
+    sessionNextCursor: uiClient.sessionNextCursor,
+    sessionTotalCount: uiClient.sessionTotalCount,
+    sessionPageLoading: uiClient.sessionPageLoading,
+    sessionsEverLoaded: uiClient.sessionsEverLoaded,
     meshInvites: uiClient.meshInvites,
     lastCreatedMeshInvite: uiClient.lastCreatedMeshInvite,
     lastLoadErrorSessionId: uiClient.lastLoadErrorSessionId,
@@ -332,6 +347,10 @@ export function UiClientProvider({ children }: UiClientProviderProps) {
     uiClient.availableModes,
     uiClient.reasoningEffort,
     uiClient.remoteNodes,
+    uiClient.sessionNextCursor,
+    uiClient.sessionTotalCount,
+    uiClient.sessionPageLoading,
+    uiClient.sessionsEverLoaded,
     uiClient.meshInvites,
     uiClient.lastCreatedMeshInvite,
     uiClient.lastLoadErrorSessionId,

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -120,6 +120,11 @@ export type AgentEventKind =
 	/** Reason for queueing (e.g., "waiting for previous operation to complete") */
 	reason: string;
 }}
+	| { type: "session_stop_requested", data?: undefined }
+	| { type: "session_force_stopped", data: {
+	escalated_after_ms: number;
+	reason: string;
+}}
 	| { type: "cancelled", data?: undefined }
 	| { type: "error", data: {
 	message: string;
@@ -721,6 +726,8 @@ export interface RemoteSessionInfo {
 	title?: string;
 	/** Human-readable label of the peer that owns this session */
 	peer_label: string;
+	/** High-level runtime lifecycle state for UI summaries. */
+	runtime_state?: string;
 }
 
 /** Schedule information DTO for the UI. */
@@ -750,30 +757,14 @@ export interface SessionSummary {
 	title?: string;
 	created_at?: string;
 	updated_at?: string;
-	/** Public ID of the parent session (if this is a child session) */
 	parent_session_id?: string;
-	/** Fork origin: "user" or "delegation" */
 	fork_origin?: string;
-	/** Session kind for specialized workflows (e.g. "recurring") */
 	session_kind?: string;
-	/** Whether this session has child sessions */
 	has_children: boolean;
-	/**
-	 * Node label where this session lives. "local" for local sessions,
-	 * peer hostname/label for remote sessions (display only).
-	 */
 	node?: string;
-	/**
-	 * Stable PeerId of the remote node. Required by the frontend to send
-	 * `attach_remote_session`. Only set for remote sessions.
-	 */
 	node_id?: string;
-	/**
-	 * Whether this remote session is currently attached (has a live actor ref).
-	 * `Some(true)` = attached, `Some(false)` = discovered but not attached,
-	 * `None` = local session (not applicable).
-	 */
 	attached?: boolean;
+	runtime_state?: string;
 }
 
 /** Group of sessions by working directory. */

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -772,6 +772,8 @@ export interface SessionGroup {
 	cwd?: string;
 	sessions: SessionSummary[];
 	latest_activity?: string;
+	total_count: number;
+	next_cursor?: string;
 }
 
 /**
@@ -939,7 +941,18 @@ export type UiClientMessage =
 	| { type: "prompt", data: {
 	prompt: UiPromptBlock[];
 }}
-	| { type: "list_sessions", data?: undefined }
+	| { type: "list_sessions", data: {
+	/** Query mode: browse (default), group, or search. */
+	mode?: string;
+	/** Opaque pagination cursor (offset as string for now). */
+	cursor?: string;
+	/** Max number of sessions to return. */
+	limit?: number;
+	/** Group key for mode=group (cwd path or null-group marker). */
+	cwd?: string;
+	/** Search query for mode=search. */
+	query?: string;
+}}
 	| { type: "load_session", data: {
 	session_id: string;
 }}
@@ -1226,6 +1239,8 @@ export type UiServerMessage =
 }}
 	| { type: "session_list", data: {
 	groups: SessionGroup[];
+	next_cursor?: string;
+	total_count: number;
 }}
 	| { type: "session_loaded", data: {
 	session_id: string;

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -53,6 +53,19 @@ export type AgentEventKind =
 	message: string;
 	message_id?: string;
 }}
+	/**
+	 * Ephemeral signal emitted when mid-stream transport error is detected.
+	 * Accumulated text is discarded and a new stream is being created.
+	 */
+	| { type: "stream_recovering", data: {
+	/** Human-readable error message that triggered the retry */
+	message: string;
+	/** Current attempt (1-indexed) */
+	attempt: number;
+	/** Maximum attempts */
+	max_attempts: number;
+	message_id?: string;
+}}
 	| { type: "llm_request_start", data: {
 	message_count: number;
 }}

--- a/crates/agent/ui/src/hooks/useUiClient.ts
+++ b/crates/agent/ui/src/hooks/useUiClient.ts
@@ -152,6 +152,22 @@ export function useUiClient() {
   // @ts-expect-error - setAvailableModes reserved for future backend integration
   const [availableModes, setAvailableModes] = useState<string[]>(['build', 'plan']);
   const [sessionGroups, setSessionGroups] = useState<SessionGroup[]>([]);
+  const [sessionNextCursor, setSessionNextCursor] = useState<string | null>(null);
+  const [sessionTotalCount, setSessionTotalCount] = useState<number>(0);
+  const [sessionPageLoading, setSessionPageLoading] = useState(false);
+  const [sessionGroupNextCursorByCwd, setSessionGroupNextCursorByCwd] = useState<Record<string, string | null>>({});
+  const [sessionsEverLoaded, setSessionsEverLoaded] = useState(false);
+  const sessionNextCursorRef = useRef<string | null>(null);
+  sessionNextCursorRef.current = sessionNextCursor;
+  const sessionPageLoadingRef = useRef(false);
+  sessionPageLoadingRef.current = sessionPageLoading;
+  const sessionGroupNextCursorByCwdRef = useRef<Record<string, string | null>>({});
+  sessionGroupNextCursorByCwdRef.current = sessionGroupNextCursorByCwd;
+  const pendingGroupLoadRef = useRef<string | null>(null);
+  const pendingBrowseCursorRef = useRef<string | null>(null);
+  const sessionGroupsLoadedRef = useRef(false);
+  // Mark as loaded whenever we receive a non-empty session list
+  if (sessionGroups.length > 0) sessionGroupsLoadedRef.current = true;
   const [allModels, setAllModels] = useState<ModelEntry[]>([]);
   const [providerCapabilities, setProviderCapabilities] = useState<Record<string, ProviderCapabilityEntry>>({});
   const [recentModelsByWorkspace, setRecentModelsByWorkspace] = useState<Record<string, RecentModelEntry[]>>({});
@@ -272,6 +288,10 @@ export function useUiClient() {
         sendOnSocket(socket, { type: 'get_recent_models', data: { limit_per_workspace: 10 } });
         sendOnSocket(socket, { type: 'list_remote_nodes' });
         sendOnSocket(socket, { type: 'list_mesh_invites' } as UiClientMessage);
+        sendOnSocket(socket, {
+          type: 'list_sessions',
+          data: { mode: 'browse', limit: 20 },
+        } as UiClientMessage);
 
         // If we had an active session before disconnect, re-subscribe so
         // we resume receiving events (and the backend replays anything we
@@ -784,7 +804,9 @@ export function useUiClient() {
         if (isDeleteError) {
           pendingDeleteLabelsRef.current.clear();
           pushSessionActionNotice('error', d.message);
-          sendMessage({ type: 'list_sessions' } as UiClientMessage);
+          pendingGroupLoadRef.current = null;
+          sendMessage({ type: 'list_sessions', data: { mode: 'browse' } } as UiClientMessage);
+          setSessionPageLoading(false);
         }
 
         if (isLoadError) {
@@ -800,7 +822,8 @@ export function useUiClient() {
           if (failedSessionId) {
             setLastLoadErrorSessionId(failedSessionId);
           }
-          sendMessage({ type: 'list_sessions' } as UiClientMessage);
+          pendingGroupLoadRef.current = null;
+          sendMessage({ type: 'list_sessions', data: { mode: 'browse' } } as UiClientMessage);
         }
 
         // Connection-level errors have no session_id. Do not inject them into the
@@ -828,9 +851,64 @@ export function useUiClient() {
       }
       case 'session_list': {
         const d = msg.data;
-        setSessionGroups(d.groups);
+        const isGroupPagingResponse = pendingGroupLoadRef.current !== null;
+        const isBrowsePagingResponse = pendingBrowseCursorRef.current !== null;
+        pendingGroupLoadRef.current = null;
+        pendingBrowseCursorRef.current = null;
 
-        if (pendingDeleteLabelsRef.current.size > 0) {
+        setSessionNextCursor(d.next_cursor ?? null);
+        setSessionTotalCount(d.total_count ?? 0);
+        setSessionPageLoading(false);
+
+        const nextByCwd: Record<string, string | null> = {};
+        for (const g of d.groups) {
+          nextByCwd[g.cwd ?? '__none__'] = g.next_cursor ?? null;
+        }
+        setSessionGroupNextCursorByCwd((prev) => ({ ...prev, ...nextByCwd }));
+
+        if (!isGroupPagingResponse && !isBrowsePagingResponse) {
+          setSessionGroups(d.groups);
+        } else {
+          setSessionGroups((prev) => {
+            const byCwd = new Map<string, SessionGroup>();
+            for (const group of prev) {
+              byCwd.set(group.cwd ?? '__none__', {
+                cwd: group.cwd,
+                latest_activity: group.latest_activity,
+                sessions: [...group.sessions],
+                total_count: group.total_count,
+                next_cursor: group.next_cursor,
+              });
+            }
+            for (const group of d.groups) {
+              const key = group.cwd ?? '__none__';
+              const existing = byCwd.get(key);
+              if (!existing) {
+                byCwd.set(key, {
+                  cwd: group.cwd,
+                  latest_activity: group.latest_activity,
+                  sessions: [...group.sessions],
+                  total_count: group.total_count,
+                  next_cursor: group.next_cursor,
+                });
+                continue;
+              }
+              const seen = new Set(existing.sessions.map((s) => s.session_id));
+              for (const s of group.sessions) {
+                if (!seen.has(s.session_id)) {
+                  existing.sessions.push(s);
+                }
+              }
+              existing.total_count = group.total_count;
+              existing.next_cursor = group.next_cursor;
+              existing.latest_activity = existing.latest_activity ?? group.latest_activity;
+              byCwd.set(key, existing);
+            }
+            return Array.from(byCwd.values());
+          });
+        }
+
+        if (!isGroupPagingResponse && pendingDeleteLabelsRef.current.size > 0) {
           const remainingSessionIds = new Set(
             d.groups.flatMap((group: any) => group.sessions.map((session: any) => session.session_id))
           );
@@ -1230,6 +1308,13 @@ export function useUiClient() {
     undoStateRef.current = undoState;
   }, [undoState]);
 
+  // Track whether sessions have ever been loaded (persists across search/browse/delete).
+  useEffect(() => {
+    if (sessionGroups.length > 0) {
+      setSessionsEverLoaded(true);
+    }
+  }, [sessionGroups]);
+
   const sendMessage = (message: UiClientMessage) => {
     const socket = socketRef.current;
     if (!socket || socket.readyState !== WebSocket.OPEN) {
@@ -1434,6 +1519,49 @@ export function useUiClient() {
 
   const fetchRecentModels = useCallback(() => {
     sendMessage({ type: 'get_recent_models', data: { limit_per_workspace: 10 } });
+  }, []);
+
+  const loadMoreSessions = useCallback((limit: number = 50) => {
+    const cursor = sessionNextCursorRef.current;
+    if (sessionPageLoadingRef.current || !cursor) {
+      return;
+    }
+    pendingBrowseCursorRef.current = cursor;
+    setSessionPageLoading(true);
+    sendMessage({
+      type: 'list_sessions',
+      data: { mode: 'browse', cursor, limit },
+    } as UiClientMessage);
+  }, []);
+
+  const loadMoreGroupSessions = useCallback((cwd: string | null, limit: number = 20) => {
+    const key = cwd ?? '__none__';
+    const cursor = sessionGroupNextCursorByCwdRef.current[key] ?? null;
+    if (sessionPageLoadingRef.current || !cursor) {
+      return;
+    }
+    pendingGroupLoadRef.current = key;
+    setSessionPageLoading(true);
+    sendMessage({
+      type: 'list_sessions',
+      data: { mode: 'group', cwd: cwd ?? '__none__', cursor, limit },
+    } as UiClientMessage);
+  }, []);
+
+  const searchSessions = useCallback((query: string, limit: number = 30) => {
+    pendingGroupLoadRef.current = null;
+    pendingBrowseCursorRef.current = null;
+    if (!query.trim()) {
+      // When search is cleared, reload the full browse list so sessions reappear.
+      setSessionPageLoading(true);
+      sendMessage({ type: 'list_sessions', data: { mode: 'browse', limit: 20 } } as UiClientMessage);
+      return;
+    }
+    setSessionPageLoading(true);
+    sendMessage({
+      type: 'list_sessions',
+      data: { mode: 'search', query, limit },
+    } as UiClientMessage);
   }, []);
 
   const requestAuthProviders = useCallback(() => {
@@ -1727,6 +1855,10 @@ export function useUiClient() {
     setActiveAgent: selectAgent,
     setRoutingMode: selectRoutingMode,
     sessionGroups,
+    sessionNextCursor,
+    sessionTotalCount,
+    sessionPageLoading,
+    sessionsEverLoaded,
     allModels,
     providerCapabilities,
     modelDownloads,
@@ -1740,6 +1872,9 @@ export function useUiClient() {
     attachRemoteSession,
     refreshAllModels,
     fetchRecentModels,
+    loadMoreSessions,
+    loadMoreGroupSessions,
+    searchSessions,
     requestAuthProviders,
     startOAuthLogin,
     completeOAuthLogin,

--- a/crates/cli/src/chat.rs
+++ b/crates/cli/src/chat.rs
@@ -164,8 +164,8 @@ pub async fn handle_any_response(
                                         usage.output_tokens
                                     );
                                 }
-                                StreamChunk::Done { stop_reason } => {
-                                    log::debug!("Stream done: stop_reason={}", stop_reason);
+                                StreamChunk::Done { finish_reason } => {
+                                    log::debug!("Stream done: finish_reason={:?}", finish_reason);
                                     println!();
                                     break;
                                 }

--- a/crates/providers/anthropic/src/lib.rs
+++ b/crates/providers/anthropic/src/lib.rs
@@ -654,6 +654,19 @@ impl ChatResponse for AnthropicCompleteResponse {
 }
 
 impl Anthropic {
+    /// Map a raw Anthropic `stop_reason` string to a typed `FinishReason`.
+    ///
+    /// Reuses the same mapping logic as `AnthropicCompleteResponse::finish_reason()`.
+    pub(crate) fn map_stop_reason(stop_reason: &str) -> FinishReason {
+        match stop_reason {
+            "end_turn" | "stop_sequence" => FinishReason::Stop,
+            "max_tokens" => FinishReason::Length,
+            "tool_use" => FinishReason::ToolCalls,
+            "refusal" | "pause_turn" => FinishReason::Other,
+            _ => FinishReason::Unknown,
+        }
+    }
+
     fn default_base_url() -> Url {
         Url::parse("https://api.anthropic.com/v1/").unwrap()
     }
@@ -1182,7 +1195,8 @@ impl HTTPChatProvider for Anthropic {
                         if let Some(delta) = stream_resp.delta
                             && let Some(stop_reason) = delta.stop_reason
                         {
-                            chunks.push(querymt::chat::StreamChunk::Done { stop_reason });
+                            let finish_reason = Self::map_stop_reason(&stop_reason);
+                            chunks.push(querymt::chat::StreamChunk::Done { finish_reason });
                         }
                     }
                     _ => {}
@@ -1682,8 +1696,8 @@ mod tests {
         assert!(
             matches!(
                 &chunks[4],
-                querymt::chat::StreamChunk::Done { stop_reason }
-                if stop_reason == "tool_use"
+                querymt::chat::StreamChunk::Done { finish_reason }
+                if *finish_reason == FinishReason::ToolCalls
             ),
             "expected Done, got {:?}",
             chunks[4]

--- a/crates/providers/codex/src/api.rs
+++ b/crates/providers/codex/src/api.rs
@@ -663,8 +663,17 @@ pub fn codex_parse_stream_chunk_with_state(
         };
 
         if data == "[DONE]" {
+            let has_tool_calls = tool_state_buffer
+                .lock()
+                .unwrap()
+                .values()
+                .any(|s| s.started);
             results.push(StreamChunk::Done {
-                stop_reason: "end_turn".to_string(),
+                finish_reason: if has_tool_calls {
+                    FinishReason::ToolCalls
+                } else {
+                    FinishReason::Stop
+                },
             });
             continue;
         }
@@ -751,7 +760,16 @@ pub fn codex_parse_stream_chunk_with_state(
                     }
                 }
                 results.push(StreamChunk::Done {
-                    stop_reason: "end_turn".to_string(),
+                    finish_reason: if tool_state_buffer
+                        .lock()
+                        .unwrap()
+                        .values()
+                        .any(|s| s.started)
+                    {
+                        FinishReason::ToolCalls
+                    } else {
+                        FinishReason::Stop
+                    },
                 });
             }
             "response.failed" => {

--- a/crates/providers/google/src/lib.rs
+++ b/crates/providers/google/src/lib.rs
@@ -1248,9 +1248,29 @@ fn extract_google_stream_chunks(response: GoogleChatResponse) -> Vec<querymt::ch
 
         // Check for finish reason (only in final chunk)
         if let Some(finish_reason) = &candidate.finish_reason {
-            chunks.push(querymt::chat::StreamChunk::Done {
-                stop_reason: finish_reason.clone(),
-            });
+            let has_tool_calls = candidate
+                .content
+                .function_calls
+                .as_ref()
+                .is_some_and(|fcs| !fcs.is_empty());
+            let finish_reason = if has_tool_calls {
+                FinishReason::ToolCalls
+            } else {
+                match finish_reason.as_str() {
+                    "STOP" => FinishReason::Stop,
+                    "MAX_TOKENS" => FinishReason::Length,
+                    "SAFETY"
+                    | "IMAGE_SAFETY"
+                    | "IMAGE_PROHIBITED_CONTENT"
+                    | "BLOCKLIST"
+                    | "SPII"
+                    | "PROHIBITED_CONTENT" => FinishReason::ContentFilter,
+                    "OTHER" | "IMAGE_OTHER" => FinishReason::Other,
+                    "MALFORMED_FUNCTION_CALL" => FinishReason::Error,
+                    _ => FinishReason::Unknown,
+                }
+            };
+            chunks.push(querymt::chat::StreamChunk::Done { finish_reason });
         }
     }
 

--- a/crates/providers/kimi-code/src/lib.rs
+++ b/crates/providers/kimi-code/src/lib.rs
@@ -597,11 +597,11 @@ mod tests {
         assert!(has_tool_complete, "expected ToolUseComplete in {events3:?}");
 
         let has_done = events3.iter().any(|e| {
-            matches!(e, querymt::chat::StreamChunk::Done { stop_reason } if stop_reason == "tool_use")
+            matches!(e, querymt::chat::StreamChunk::Done { finish_reason } if *finish_reason == querymt::chat::FinishReason::ToolCalls)
         });
         assert!(
             has_done,
-            "expected Done with stop_reason 'tool_use' in {events3:?}"
+            "expected Done with FinishReason::ToolCalls in {events3:?}"
         );
     }
 
@@ -612,8 +612,8 @@ mod tests {
         let events = provider.parse_chat_stream_chunk(chunk).unwrap();
         assert_eq!(events.len(), 1);
         match &events[0] {
-            querymt::chat::StreamChunk::Done { stop_reason } => {
-                assert_eq!(stop_reason, "end_turn");
+            querymt::chat::StreamChunk::Done { finish_reason } => {
+                assert_eq!(*finish_reason, querymt::chat::FinishReason::Stop);
             }
             other => panic!("expected Done chunk, got {other:?}"),
         }
@@ -666,8 +666,8 @@ mod tests {
             "expected Done from data:[DONE], got {events:?}"
         );
         match &events[0] {
-            querymt::chat::StreamChunk::Done { stop_reason } => {
-                assert_eq!(stop_reason, "end_turn");
+            querymt::chat::StreamChunk::Done { finish_reason } => {
+                assert_eq!(*finish_reason, querymt::chat::FinishReason::Stop);
             }
             other => panic!("expected Done chunk, got {other:?}"),
         }

--- a/crates/providers/llama-cpp/examples/vision_chat.rs
+++ b/crates/providers/llama-cpp/examples/vision_chat.rs
@@ -151,8 +151,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(querymt::chat::StreamChunk::Usage(u)) => {
                     println!("\n---\ninput={} output={}", u.input_tokens, u.output_tokens);
                 }
-                Ok(querymt::chat::StreamChunk::Done { stop_reason }) => {
-                    println!("stop: {}", stop_reason);
+                Ok(querymt::chat::StreamChunk::Done { finish_reason }) => {
+                    println!("stop: {:?}", finish_reason);
                 }
                 Err(e) => return Err(e.into()),
                 _ => {}

--- a/crates/providers/llama-cpp/src/provider.rs
+++ b/crates/providers/llama-cpp/src/provider.rs
@@ -497,13 +497,12 @@ impl ChatProvider for LlamaCppProvider {
                     ) {
                         Ok((usage, has_tool_calls)) => {
                             let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Usage(usage)));
-                            let stop_reason = if has_tool_calls {
-                                "tool_use"
-                            } else {
-                                "end_turn"
-                            };
                             let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Done {
-                                stop_reason: stop_reason.to_string(),
+                                finish_reason: if has_tool_calls {
+                                    FinishReason::ToolCalls
+                                } else {
+                                    FinishReason::Stop
+                                },
                             }));
                         }
                         Err(err) => {
@@ -551,7 +550,7 @@ impl ChatProvider for LlamaCppProvider {
                     Ok(usage) => {
                         let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Usage(usage)));
                         let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Done {
-                            stop_reason: "end_turn".to_string(),
+                            finish_reason: FinishReason::Stop,
                         }));
                     }
                     Err(err) => {
@@ -592,7 +591,7 @@ impl ChatProvider for LlamaCppProvider {
             if let Some(usage) = final_usage {
                 let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Usage(usage)));
                 let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Done {
-                    stop_reason: "end_turn".to_string(),
+                    finish_reason: FinishReason::Stop,
                 }));
             }
         });

--- a/crates/providers/mrs/src/chat.rs
+++ b/crates/providers/mrs/src/chat.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use futures::TryFutureExt;
 use mistralrs::{ChatCompletionResponse, RequestBuilder, ResponseOk};
-use querymt::chat::{ChatMessage, ChatProvider, ChatResponse, StreamChunk, Tool};
+use querymt::chat::{ChatMessage, ChatProvider, ChatResponse, FinishReason, StreamChunk, Tool};
 use querymt::error::LLMError;
 use querymt::{FunctionCall, ToolCall, Usage};
 use serde::Deserialize;
@@ -200,7 +200,7 @@ impl ChatProvider for MistralRS {
                 let mut chunks = Vec::new();
                 flush_tool_states(&mut tool_states, &mut chunks);
                 chunks.push(StreamChunk::Done {
-                    stop_reason: "end_turn".to_string(),
+                    finish_reason: FinishReason::Stop,
                 });
                 for chunk in chunks {
                     let _ = task_tx.send(Ok(chunk));

--- a/crates/providers/mrs/src/streaming.rs
+++ b/crates/providers/mrs/src/streaming.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use mistralrs::{ChatCompletionChunkResponse, ChatCompletionResponse, ToolCallResponse};
-use querymt::chat::StreamChunk;
+use querymt::chat::{FinishReason, StreamChunk};
 use querymt::{FunctionCall, ToolCall, Usage};
 
 #[derive(Default, Debug)]
@@ -20,12 +20,12 @@ fn usage_from_mistral(usage: &mistralrs::Usage) -> Usage {
     }
 }
 
-fn map_finish_reason(reason: &str) -> String {
+fn map_finish_reason(reason: &str) -> FinishReason {
     match reason {
-        "tool_calls" => "tool_use".to_string(),
-        "stop" => "end_turn".to_string(),
-        "length" => "max_tokens".to_string(),
-        other => other.to_string(),
+        "tool_calls" => FinishReason::ToolCalls,
+        "stop" => FinishReason::Stop,
+        "length" => FinishReason::Length,
+        _ => FinishReason::Other,
     }
 }
 
@@ -116,7 +116,7 @@ pub(crate) fn parse_mistral_stream_chunk(
 
             flush_tool_states(tool_states, &mut chunks);
             chunks.push(StreamChunk::Done {
-                stop_reason: map_finish_reason(finish_reason),
+                finish_reason: map_finish_reason(finish_reason),
             });
             *done_emitted = true;
         }
@@ -158,7 +158,7 @@ pub(crate) fn parse_mistral_done_response(
 
         if !*done_emitted {
             chunks.push(StreamChunk::Done {
-                stop_reason: map_finish_reason(&choice.finish_reason),
+                finish_reason: map_finish_reason(&choice.finish_reason),
             });
             *done_emitted = true;
         }

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -1226,7 +1226,7 @@ pub fn parse_openai_sse_chunk(
                 }
             }
             results.push(StreamChunk::Done {
-                stop_reason: "end_turn".to_string(),
+                finish_reason: FinishReason::Stop,
             });
             done_emitted = true;
             continue;
@@ -1316,17 +1316,16 @@ pub fn parse_openai_sse_chunk(
                     }
                 }
 
-                // Map finish_reason to unified stop_reason
-                let stop_reason = match finish_reason.as_str() {
-                    "tool_calls" => "tool_use",
-                    "stop" => "end_turn",
-                    "length" => "max_tokens",
-                    other => other,
+                // Map finish_reason to FinishReason
+                let finish_reason = match finish_reason.as_str() {
+                    "tool_calls" => FinishReason::ToolCalls,
+                    "stop" => FinishReason::Stop,
+                    "length" => FinishReason::Length,
+                    "content_filter" => FinishReason::ContentFilter,
+                    _ => FinishReason::Unknown,
                 };
 
-                results.push(StreamChunk::Done {
-                    stop_reason: stop_reason.to_string(),
-                });
+                results.push(StreamChunk::Done { finish_reason });
                 done_emitted = true;
             }
         }

--- a/crates/querymt-extism-macros/src/lib.rs
+++ b/crates/querymt-extism-macros/src/lib.rs
@@ -248,7 +248,7 @@ macro_rules! impl_extism_http_plugin {
         // chat_stream wrapper (wireframe implementation)
         #[plugin_fn]
         pub fn chat_stream(Json(input): Json<ExtismChatRequest<$Config>>) -> FnResult<()> {
-            use querymt::chat::StreamChunk;
+            use querymt::chat::{FinishReason, StreamChunk};
             use querymt::plugin::extism_impl::ExtismChatChunk;
             use $crate::{
                 qmt_http_stream_close_wrapper, qmt_http_stream_next_wrapper,
@@ -268,7 +268,7 @@ macro_rules! impl_extism_http_plugin {
                     // Cancelled during stream open - yield Done and return
                     qmt_yield_chunk_wrapper(&ExtismChatChunk {
                         chunk: StreamChunk::Done {
-                            stop_reason: "cancelled".to_string(),
+                            finish_reason: FinishReason::Stop,
                         },
                         usage: None,
                     })?;
@@ -358,7 +358,7 @@ macro_rules! impl_extism_http_plugin {
                 if !done_received {
                     qmt_yield_chunk_wrapper(&ExtismChatChunk {
                         chunk: StreamChunk::Done {
-                            stop_reason: "cancelled".to_string(),
+                            finish_reason: FinishReason::Stop,
                         },
                         usage: None,
                     })?;

--- a/crates/querymt/examples/extism_cancel/src/main.rs
+++ b/crates/querymt/examples/extism_cancel/src/main.rs
@@ -169,8 +169,8 @@ async fn main() -> Result<()> {
                             }
                             print!("{}", delta);
                         }
-                        Ok(StreamChunk::Done { stop_reason }) => {
-                            info!("stream done: {stop_reason}");
+                        Ok(StreamChunk::Done { finish_reason }) => {
+                            info!("stream done: {:?}", finish_reason);
                             break;
                         }
                         Ok(_) => {}

--- a/crates/querymt/src/adapters.rs
+++ b/crates/querymt/src/adapters.rs
@@ -47,9 +47,7 @@ impl LLMProviderFromHTTP {
             .chat_request(messages, tools)
             .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
 
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let resp = call_outbound(req).await?;
 
         self.inner.parse_chat(resp)
     }
@@ -96,15 +94,11 @@ impl ChatProvider for LLMProviderFromHTTP {
             .chat_request(messages, tools)
             .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
 
-        let stream = call_outbound_stream(req)
-            .await
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let stream = call_outbound_stream(req).await?;
 
         let inner = self.inner.clone();
         let s = stream
-            .map(move |res: reqwest::Result<bytes::Bytes>| {
-                res.map_err(|e: reqwest::Error| LLMError::HttpError(e.to_string()))
-            })
+            .map(move |res: reqwest::Result<bytes::Bytes>| res.map_err(LLMError::from))
             .chain(futures::stream::once(futures::future::ready(Ok(
                 bytes::Bytes::from_static(b"\n"),
             ))))

--- a/crates/querymt/src/chat/mod.rs
+++ b/crates/querymt/src/chat/mod.rs
@@ -837,10 +837,11 @@ pub enum StreamChunk {
     /// Usage metadata containing token counts
     Usage(Usage),
 
-    /// Stream ended with stop reason
+    /// Stream ended with finish reason
     Done {
-        /// The reason the stream stopped (e.g., "end_turn", "tool_use")
-        stop_reason: String,
+        /// The typed finish reason from the provider, mapped at emission time
+        /// using the same logic as `ChatResponse::finish_reason()`.
+        finish_reason: FinishReason,
     },
 }
 

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -1,6 +1,80 @@
+use serde::{Deserialize, Serialize};
 use std::string::FromUtf8Error;
-
 use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportErrorKind {
+    ConnectionRefused,
+    ConnectionReset,
+    Timeout,
+    ConnectionClosed,
+    Dns,
+    Tls,
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LLMErrorPayload {
+    GenericError {
+        message: String,
+    },
+    ProviderError {
+        message: String,
+    },
+    AuthError {
+        message: String,
+    },
+    ToolConfigError {
+        message: String,
+    },
+    PluginError {
+        message: String,
+    },
+    InvalidRequest {
+        message: String,
+    },
+    ResponseFormatError {
+        message: String,
+        raw_response: String,
+    },
+    RateLimited {
+        message: String,
+        retry_after_secs: Option<u64>,
+    },
+    HttpStatus {
+        status_code: u16,
+        message: String,
+        retry_after_secs: Option<u64>,
+    },
+    HttpError {
+        message: String,
+    },
+    Transport {
+        kind: TransportErrorKind,
+        message: String,
+    },
+    Cancelled,
+    RemoteStreamDisconnected {
+        message: String,
+    },
+    RemoteStreamReconnected {
+        message: String,
+    },
+    NotImplemented {
+        message: String,
+    },
+    JsonError {
+        message: String,
+    },
+    InvalidUrl {
+        message: String,
+    },
+    IoError {
+        message: String,
+    },
+}
 
 /// Error types that can occur when interacting with LLM providers.
 #[derive(Error, Debug)]
@@ -44,8 +118,21 @@ pub enum LLMError {
         retry_after_secs: Option<u64>,
     },
 
+    #[error("HTTP {status_code}: {message}")]
+    HttpStatus {
+        status_code: u16,
+        message: String,
+        retry_after_secs: Option<u64>,
+    },
+
     #[error("HTTP Error: {0}")]
     HttpError(String),
+
+    #[error("{message}")]
+    Transport {
+        kind: TransportErrorKind,
+        message: String,
+    },
 
     /// Request was cancelled by the caller (e.g. timeout, user interrupt).
     #[error("Cancelled")]
@@ -76,9 +163,275 @@ pub enum LLMError {
     IoError(#[from] std::io::Error),
 }
 
+impl LLMError {
+    pub fn to_payload(&self) -> LLMErrorPayload {
+        match self {
+            Self::GenericError(message) => LLMErrorPayload::GenericError {
+                message: message.clone(),
+            },
+            Self::ProviderError(message) => LLMErrorPayload::ProviderError {
+                message: message.clone(),
+            },
+            Self::AuthError(message) => LLMErrorPayload::AuthError {
+                message: message.clone(),
+            },
+            Self::ToolConfigError(message) => LLMErrorPayload::ToolConfigError {
+                message: message.clone(),
+            },
+            Self::PluginError(message) => LLMErrorPayload::PluginError {
+                message: message.clone(),
+            },
+            Self::InvalidRequest(message) => LLMErrorPayload::InvalidRequest {
+                message: message.clone(),
+            },
+            Self::ResponseFormatError {
+                message,
+                raw_response,
+            } => LLMErrorPayload::ResponseFormatError {
+                message: message.clone(),
+                raw_response: raw_response.clone(),
+            },
+            Self::RateLimited {
+                message,
+                retry_after_secs,
+            } => LLMErrorPayload::RateLimited {
+                message: message.clone(),
+                retry_after_secs: *retry_after_secs,
+            },
+            Self::HttpStatus {
+                status_code,
+                message,
+                retry_after_secs,
+            } => LLMErrorPayload::HttpStatus {
+                status_code: *status_code,
+                message: message.clone(),
+                retry_after_secs: *retry_after_secs,
+            },
+            Self::HttpError(message) => LLMErrorPayload::HttpError {
+                message: message.clone(),
+            },
+            Self::Transport { kind, message } => LLMErrorPayload::Transport {
+                kind: *kind,
+                message: message.clone(),
+            },
+            Self::Cancelled => LLMErrorPayload::Cancelled,
+            Self::RemoteStreamDisconnected { message } => {
+                LLMErrorPayload::RemoteStreamDisconnected {
+                    message: message.clone(),
+                }
+            }
+            Self::RemoteStreamReconnected { message } => LLMErrorPayload::RemoteStreamReconnected {
+                message: message.clone(),
+            },
+            Self::NotImplemented(message) => LLMErrorPayload::NotImplemented {
+                message: message.clone(),
+            },
+            Self::JsonError(err) => LLMErrorPayload::JsonError {
+                message: err.to_string(),
+            },
+            Self::InvalidUrl(err) => LLMErrorPayload::InvalidUrl {
+                message: err.to_string(),
+            },
+            Self::IoError(err) => LLMErrorPayload::IoError {
+                message: err.to_string(),
+            },
+        }
+    }
+
+    pub fn from_payload(payload: LLMErrorPayload) -> Self {
+        match payload {
+            LLMErrorPayload::GenericError { message } => Self::GenericError(message),
+            LLMErrorPayload::ProviderError { message } => Self::ProviderError(message),
+            LLMErrorPayload::AuthError { message } => Self::AuthError(message),
+            LLMErrorPayload::ToolConfigError { message } => Self::ToolConfigError(message),
+            LLMErrorPayload::PluginError { message } => Self::PluginError(message),
+            LLMErrorPayload::InvalidRequest { message } => Self::InvalidRequest(message),
+            LLMErrorPayload::ResponseFormatError {
+                message,
+                raw_response,
+            } => Self::ResponseFormatError {
+                message,
+                raw_response,
+            },
+            LLMErrorPayload::RateLimited {
+                message,
+                retry_after_secs,
+            } => Self::RateLimited {
+                message,
+                retry_after_secs,
+            },
+            LLMErrorPayload::HttpStatus {
+                status_code,
+                message,
+                retry_after_secs,
+            } => Self::HttpStatus {
+                status_code,
+                message,
+                retry_after_secs,
+            },
+            LLMErrorPayload::HttpError { message } => Self::HttpError(message),
+            LLMErrorPayload::Transport { kind, message } => Self::Transport { kind, message },
+            LLMErrorPayload::Cancelled => Self::Cancelled,
+            LLMErrorPayload::RemoteStreamDisconnected { message } => {
+                Self::RemoteStreamDisconnected { message }
+            }
+            LLMErrorPayload::RemoteStreamReconnected { message } => {
+                Self::RemoteStreamReconnected { message }
+            }
+            LLMErrorPayload::NotImplemented { message } => Self::NotImplemented(message),
+            LLMErrorPayload::JsonError { message } => Self::PluginError(message),
+            LLMErrorPayload::InvalidUrl { message } => Self::HttpError(message),
+            LLMErrorPayload::IoError { message } => Self::Transport {
+                kind: TransportErrorKind::Other,
+                message,
+            },
+        }
+    }
+
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        match self {
+            Self::RateLimited {
+                retry_after_secs, ..
+            }
+            | Self::HttpStatus {
+                retry_after_secs, ..
+            } => *retry_after_secs,
+            _ => None,
+        }
+    }
+
+    pub fn is_retryable_setup_failure(&self) -> bool {
+        match self {
+            Self::RateLimited { .. } | Self::Transport { .. } => true,
+            Self::HttpStatus { status_code, .. } => matches!(status_code, 502 | 503 | 504 | 529),
+            Self::HttpError(message) => classify_transport_message(message).is_some(),
+            _ => false,
+        }
+    }
+}
+
+pub fn parse_retry_after(headers: &http::HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .or_else(|| {
+            headers
+                .get("x-ratelimit-reset-requests")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| {
+                    if s.ends_with('s') {
+                        let num_part = s.trim_end_matches('s');
+                        if let Some(m_pos) = num_part.find('m') {
+                            num_part[..m_pos].parse::<u64>().ok().map(|m| m * 60)
+                        } else {
+                            num_part.parse::<u64>().ok()
+                        }
+                    } else {
+                        None
+                    }
+                })
+        })
+}
+
+pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let retry_after_secs = parse_retry_after(headers);
+    let clean_message = serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|json| {
+            json.pointer("/error/message")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| {
+            format!("{}", String::from_utf8_lossy(body))
+                .trim()
+                .to_string()
+        })
+        .trim()
+        .to_string();
+    let message = if clean_message.is_empty() {
+        format!("HTTP {}", status_code)
+    } else {
+        clean_message
+    };
+
+    match status_code {
+        401 | 403 => LLMError::AuthError(message),
+        429 => LLMError::RateLimited {
+            message,
+            retry_after_secs,
+        },
+        400 => LLMError::InvalidRequest(message),
+        502 | 503 | 504 | 529 => LLMError::HttpStatus {
+            status_code,
+            message,
+            retry_after_secs,
+        },
+        500..=599 => LLMError::ProviderError(message),
+        _ => LLMError::ProviderError(message),
+    }
+}
+
+pub fn classify_transport_message(message: &str) -> Option<TransportErrorKind> {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("connection refused") {
+        Some(TransportErrorKind::ConnectionRefused)
+    } else if lower.contains("connection reset") || lower.contains("reset before headers") {
+        Some(TransportErrorKind::ConnectionReset)
+    } else if lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("delayed connect error")
+    {
+        Some(TransportErrorKind::Timeout)
+    } else if lower.contains("connection closed") || lower.contains("eof") {
+        Some(TransportErrorKind::ConnectionClosed)
+    } else if lower.contains("dns")
+        || lower.contains("name or service not known")
+        || lower.contains("failed to lookup address")
+    {
+        Some(TransportErrorKind::Dns)
+    } else if lower.contains("tls") || lower.contains("certificate") || lower.contains("handshake")
+    {
+        Some(TransportErrorKind::Tls)
+    } else {
+        None
+    }
+}
+
+pub fn transport_error(kind: TransportErrorKind, message: impl Into<String>) -> LLMError {
+    LLMError::Transport {
+        kind,
+        message: message.into(),
+    }
+}
+
 #[cfg(feature = "http-client")]
 impl From<reqwest::Error> for LLMError {
     fn from(err: reqwest::Error) -> Self {
+        if err.is_timeout() {
+            return transport_error(TransportErrorKind::Timeout, err.to_string());
+        }
+        if err.is_connect() {
+            if let Some(kind) = classify_transport_message(&err.to_string()) {
+                return transport_error(kind, err.to_string());
+            }
+            return transport_error(TransportErrorKind::ConnectionRefused, err.to_string());
+        }
+        if let Some(status) = err.status() {
+            return LLMError::HttpStatus {
+                status_code: status.as_u16(),
+                message: err.to_string(),
+                retry_after_secs: None,
+            };
+        }
+        if let Some(kind) = classify_transport_message(&err.to_string()) {
+            return transport_error(kind, err.to_string());
+        }
         LLMError::HttpError(err.to_string())
     }
 }

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -301,11 +301,42 @@ impl LLMError {
     }
 
     pub fn is_retryable_setup_failure(&self) -> bool {
+        self.is_retryable()
+    }
+
+    /// Whether this error is worth retrying (transient infrastructure error).
+    ///
+    /// Strategy: most transport/infrastructure errors are transient and succeed
+    /// on a second attempt. Only semantic/auth/validation errors are not retryable.
+    /// The mesh-specific `RemoteStreamDisconnected`/`RemoteStreamReconnected` events
+    /// are excluded — they have their own handling in the streaming loop.
+    pub fn is_retryable(&self) -> bool {
         match self {
-            Self::RateLimited { .. } | Self::Transport { .. } => true,
-            Self::HttpStatus { status_code, .. } => matches!(status_code, 502 | 503 | 504 | 529),
-            Self::HttpError(message) => classify_transport_message(message).is_some(),
-            _ => false,
+            // Always retry: transient infrastructure
+            Self::Transport { .. } => true,
+            Self::HttpError(_) => true, // unclassified HTTP transport error — could be transient
+            Self::RateLimited { .. } => true,
+            Self::HttpStatus { status_code, .. } => {
+                matches!(status_code, 429 | 502 | 503 | 504 | 529)
+            }
+            Self::PluginError(_) => true, // may be a transient WASM/HTTP issue
+            Self::IoError { .. } => true,
+
+            // Never retry: semantic errors
+            Self::AuthError(_) => false,
+            Self::InvalidRequest(_) => false,
+            Self::ProviderError(_) => false,
+            Self::ToolConfigError(_) => false,
+            Self::ResponseFormatError { .. } => false,
+            Self::GenericError(_) => false,
+            Self::Cancelled => false,
+            Self::JsonError { .. } => false,
+            Self::InvalidUrl { .. } => false,
+            Self::NotImplemented(_) => false,
+
+            // Mesh transport events — handled by the existing continue logic
+            Self::RemoteStreamDisconnected { .. } => false,
+            Self::RemoteStreamReconnected { .. } => false,
         }
     }
 }
@@ -377,32 +408,6 @@ pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &
     }
 }
 
-pub fn classify_transport_message(message: &str) -> Option<TransportErrorKind> {
-    let lower = message.to_ascii_lowercase();
-    if lower.contains("connection refused") {
-        Some(TransportErrorKind::ConnectionRefused)
-    } else if lower.contains("connection reset") || lower.contains("reset before headers") {
-        Some(TransportErrorKind::ConnectionReset)
-    } else if lower.contains("timed out")
-        || lower.contains("timeout")
-        || lower.contains("delayed connect error")
-    {
-        Some(TransportErrorKind::Timeout)
-    } else if lower.contains("connection closed") || lower.contains("eof") {
-        Some(TransportErrorKind::ConnectionClosed)
-    } else if lower.contains("dns")
-        || lower.contains("name or service not known")
-        || lower.contains("failed to lookup address")
-    {
-        Some(TransportErrorKind::Dns)
-    } else if lower.contains("tls") || lower.contains("certificate") || lower.contains("handshake")
-    {
-        Some(TransportErrorKind::Tls)
-    } else {
-        None
-    }
-}
-
 pub fn transport_error(kind: TransportErrorKind, message: impl Into<String>) -> LLMError {
     LLMError::Transport {
         kind,
@@ -417,10 +422,13 @@ impl From<reqwest::Error> for LLMError {
             return transport_error(TransportErrorKind::Timeout, err.to_string());
         }
         if err.is_connect() {
-            if let Some(kind) = classify_transport_message(&err.to_string()) {
-                return transport_error(kind, err.to_string());
-            }
             return transport_error(TransportErrorKind::ConnectionRefused, err.to_string());
+        }
+        if err.is_body() {
+            return transport_error(TransportErrorKind::Other, err.to_string());
+        }
+        if err.is_decode() {
+            return transport_error(TransportErrorKind::Other, err.to_string());
         }
         if let Some(status) = err.status() {
             return LLMError::HttpStatus {
@@ -428,9 +436,6 @@ impl From<reqwest::Error> for LLMError {
                 message: err.to_string(),
                 retry_after_secs: None,
             };
-        }
-        if let Some(kind) = classify_transport_message(&err.to_string()) {
-            return transport_error(kind, err.to_string());
         }
         LLMError::HttpError(err.to_string())
     }

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -317,7 +317,7 @@ impl LLMError {
             Self::HttpError(_) => true, // unclassified HTTP transport error — could be transient
             Self::RateLimited { .. } => true,
             Self::HttpStatus { status_code, .. } => {
-                matches!(status_code, 429 | 502 | 503 | 504 | 529)
+                matches!(status_code, 429 | 500..=599)
             }
             Self::PluginError(_) => true, // may be a transient WASM/HTTP issue
             Self::IoError { .. } => true,
@@ -398,12 +398,11 @@ pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &
             retry_after_secs,
         },
         400 => LLMError::InvalidRequest(message),
-        502 | 503 | 504 | 529 => LLMError::HttpStatus {
+        500..=599 => LLMError::HttpStatus {
             status_code,
             message,
             retry_after_secs,
         },
-        500..=599 => LLMError::ProviderError(message),
         _ => LLMError::ProviderError(message),
     }
 }

--- a/crates/querymt/src/outbound.rs
+++ b/crates/querymt/src/outbound.rs
@@ -1,37 +1,40 @@
 mod http_client {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod imp {
+        use crate::error::{LLMError, classify_http_status};
         use http::{Request, Response};
         use once_cell::sync::Lazy;
         use reqwest::Client;
-        use std::error::Error;
 
         /// A single, global client, built once
         pub static CLIENT: Lazy<Client> = Lazy::new(Client::new);
 
-        pub async fn call_outbound(
-            req: Request<Vec<u8>>,
-        ) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+        pub async fn call_outbound(req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
             let client = &*CLIENT;
 
             let method = req
                 .method()
                 .as_str()
                 .parse::<reqwest::Method>()
-                .map_err(Box::<dyn Error>::from)?;
+                .map_err(|e| LLMError::HttpError(e.to_string()))?;
 
             let mut rb = client.request(method, req.uri().to_string());
 
             for (name, value) in req.headers().iter() {
-                let val_str = value.to_str()?;
+                let val_str = value
+                    .to_str()
+                    .map_err(|e| LLMError::HttpError(e.to_string()))?;
                 rb = rb.header(name.as_str(), val_str);
             }
 
-            let resp = rb.body(req.into_body()).send().await?.error_for_status()?;
-
+            let resp = rb.body(req.into_body()).send().await?;
             let status = resp.status();
             let headers = resp.headers().clone();
             let bytes = resp.bytes().await?.to_vec();
+
+            if !status.is_success() {
+                return Err(classify_http_status(status.as_u16(), &headers, &bytes));
+            }
 
             let mut builder = Response::builder().status(status.as_u16());
             for (name, value) in headers.iter() {
@@ -42,24 +45,31 @@ mod http_client {
 
         pub async fn call_outbound_stream(
             req: Request<Vec<u8>>,
-        ) -> Result<impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>, Box<dyn Error>>
-        {
+        ) -> Result<impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>, LLMError> {
             let client = &*CLIENT;
 
             let method = req
                 .method()
                 .as_str()
                 .parse::<reqwest::Method>()
-                .map_err(Box::<dyn Error>::from)?;
+                .map_err(|e| LLMError::HttpError(e.to_string()))?;
 
             let mut rb = client.request(method, req.uri().to_string());
 
             for (name, value) in req.headers().iter() {
-                let val_str = value.to_str()?;
+                let val_str = value
+                    .to_str()
+                    .map_err(|e| LLMError::HttpError(e.to_string()))?;
                 rb = rb.header(name.as_str(), val_str);
             }
 
-            let resp = rb.body(req.into_body()).send().await?.error_for_status()?;
+            let resp = rb.body(req.into_body()).send().await?;
+            let status = resp.status();
+            if !status.is_success() {
+                let headers = resp.headers().clone();
+                let bytes = resp.bytes().await?.to_vec();
+                return Err(classify_http_status(status.as_u16(), &headers, &bytes));
+            }
             Ok(resp.bytes_stream())
         }
     }
@@ -68,18 +78,15 @@ mod http_client {
     pub mod imp {
         use crate::error::LLMError;
         use http::{Request, Response};
-        use std::error::Error;
 
-        pub async fn call_outbound(
-            _req: Request<Vec<u8>>,
-        ) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
-            Err(Box::new(LLMError::InvalidRequest("".into())))
+        pub async fn call_outbound(_req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+            Err(LLMError::InvalidRequest("".into()))
         }
 
         pub async fn call_outbound_stream(
             _req: Request<Vec<u8>>,
-        ) -> Result<futures::stream::Empty<reqwest::Result<bytes::Bytes>>, Box<dyn Error>> {
-            Err(Box::new(LLMError::InvalidRequest("".into())))
+        ) -> Result<futures::stream::Empty<reqwest::Result<bytes::Bytes>>, LLMError> {
+            Err(LLMError::InvalidRequest("".into()))
         }
     }
 }

--- a/crates/querymt/src/plugin/adapters.rs
+++ b/crates/querymt/src/plugin/adapters.rs
@@ -53,9 +53,7 @@ impl LLMProviderFactory for HTTPFactoryAdapter {
         async move {
             let req: Request<Vec<u8>> = inner.list_models_request(&cloned_cfg)?;
 
-            let resp: Response<Vec<u8>> = call_outbound(req)
-                .await
-                .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
+            let resp: Response<Vec<u8>> = call_outbound(req).await?;
 
             inner
                 .parse_list_models(resp)

--- a/crates/querymt/src/plugin/extism_impl/host/functions.rs
+++ b/crates/querymt/src/plugin/extism_impl/host/functions.rs
@@ -294,48 +294,16 @@ pub(crate) fn qmt_http_stream_open(
                 res = reqwest_req.send() => res,
             };
 
-            let resp = send_res.map_err(|e| {
-                (
-                    crate::error::LLMError::ProviderError(format!("Request failed: {}", e)),
-                    0u16,
-                )
-            })?;
+            let resp = send_res.map_err(|e| (crate::error::LLMError::from(e), 0u16))?;
             if !resp.status().is_success() {
                 let status_code = resp.status().as_u16();
-
-                // Extract retry-after header before consuming the response body
-                let retry_after_secs = crate::plugin::http::parse_retry_after(resp.headers());
-
+                let headers = resp.headers().clone();
                 let body = resp
-                    .text()
+                    .bytes()
                     .await
-                    .unwrap_or_else(|_| "could not read body".to_string());
-
-                // Parse JSON for clean message (same logic as handle_http_error! macro)
-                let clean_message = serde_json::from_str::<serde_json::Value>(&body)
-                    .ok()
-                    .and_then(|json| {
-                        json.pointer("/error/message")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .unwrap_or_else(|| format!("HTTP {}: {}", status_code, body));
-
-                // Create structured LLMError based on status code
-                use crate::error::LLMError;
-                let llm_error = match status_code {
-                    401 | 403 => LLMError::AuthError(clean_message),
-                    429 => LLMError::RateLimited {
-                        message: clean_message,
-                        retry_after_secs,
-                    },
-                    400 => LLMError::InvalidRequest(clean_message),
-                    499 => LLMError::Cancelled,
-                    500 | 529 => {
-                        LLMError::ProviderError(format!("Server error: {}", clean_message))
-                    }
-                    _ => LLMError::ProviderError(clean_message),
-                };
+                    .unwrap_or_else(|_| bytes::Bytes::from_static(b"could not read body"));
+                let llm_error =
+                    crate::error::classify_http_status(status_code, &headers, body.as_ref());
 
                 return Err((llm_error, status_code));
             }

--- a/crates/querymt/src/plugin/extism_impl/host/functions.rs
+++ b/crates/querymt/src/plugin/extism_impl/host/functions.rs
@@ -226,7 +226,7 @@ pub(crate) fn qmt_http_stream_open(
         // If we return an `extism::Error` here during cancellation, Wasmtime will treat it like a
         // failed host call and emit a WASM backtrace. Instead, we represent cancellation as
         // a *sentinel stream id* (0). The WASM-side stream wrapper interprets EOF-without-Done as
-        // cancellation and emits a clean `StreamChunk::Done { stop_reason: "cancelled" }`.
+        // cancellation and emits a clean `StreamChunk::Done { finish_reason: FinishReason::Stop }`.
         use crate::plugin::extism_impl::SerializableHttpRequest;
 
         let req_json: Vec<u8> = plugin.memory_get_val(&inputs[0])?;

--- a/crates/querymt/src/plugin/extism_impl/host/mod.rs
+++ b/crates/querymt/src/plugin/extism_impl/host/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use extism::{Manifest, Plugin, PluginBuilder, Wasm, convert::Json};
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use serde_json::Value;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
@@ -46,6 +46,17 @@ use super::{ExtismCompleteRequest, PluginError};
 fn decode_plugin_error(e: extism::Error, code: i32) -> LLMError {
     let raw = format!("{:#}", e);
     PluginError::decode(code, &raw)
+}
+
+fn decode_stream_item(
+    item: Result<Vec<u8>, LLMError>,
+) -> Result<StreamChunk, LLMError> {
+    match item {
+        Ok(bytes) => serde_json::from_slice::<crate::plugin::extism_impl::ExtismChatChunk>(&bytes)
+            .map(|c| c.chunk)
+            .map_err(|e| LLMError::PluginError(format!("Failed to deserialize chunk: {}", e))),
+        Err(llm_err) => Err(llm_err),
+    }
 }
 
 macro_rules! with_host_functions {
@@ -543,8 +554,7 @@ impl ChatProvider for ExtismProvider {
             ));
         }
 
-        use crate::plugin::extism_impl::ExtismChatChunk;
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         if let Some(user_data) = &self.user_data {
             let state = user_data
@@ -674,28 +684,29 @@ impl ChatProvider for ExtismProvider {
             }
         }
 
-        let guard = StreamCancelGuard {
-            user_data: self.user_data.clone().unwrap(),
-        };
+        let first_item = rx.recv().await.ok_or_else(|| {
+            LLMError::PluginError("Extism streaming ended before the first chunk".into())
+        })?;
 
-        let stream = futures::stream::unfold(rx, |mut rx| async move {
-            rx.recv().await.map(|item| {
-                let chunk_res: Result<StreamChunk, LLMError> = match item {
-                    Ok(bytes) => serde_json::from_slice::<ExtismChatChunk>(&bytes)
-                        .map(|c| c.chunk)
-                        .map_err(|e| {
-                            LLMError::PluginError(format!("Failed to deserialize chunk: {}", e))
-                        }),
-                    Err(llm_err) => Err(llm_err),
+        match decode_stream_item(first_item) {
+            Ok(first_chunk) => {
+                let guard = StreamCancelGuard {
+                    user_data: self.user_data.clone().unwrap(),
                 };
-                (chunk_res, rx)
-            })
-        });
 
-        Ok(Box::pin(GuardedStream {
-            inner: Box::pin(stream),
-            _guard: guard,
-        }))
+                let stream = futures::stream::once(async move { Ok(first_chunk) }).chain(
+                    futures::stream::unfold(rx, |mut rx| async move {
+                        rx.recv().await.map(|item| (decode_stream_item(item), rx))
+                    }),
+                );
+
+                Ok(Box::pin(GuardedStream {
+                    inner: Box::pin(stream),
+                    _guard: guard,
+                }))
+            }
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -935,5 +946,40 @@ impl HTTPEmbeddingProvider for ExtismProvider {
 impl HTTPLLMProvider for ExtismProvider {
     fn tools(&self) -> Option<&[Tool]> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chat::StreamChunk;
+
+    #[test]
+    fn decode_stream_item_returns_chunk_for_valid_payload() {
+        let bytes = serde_json::to_vec(&crate::plugin::extism_impl::ExtismChatChunk {
+            chunk: StreamChunk::Text("hello".into()),
+            usage: None,
+        })
+        .expect("serialize chunk");
+
+        let chunk = decode_stream_item(Ok(bytes)).expect("chunk should decode");
+        assert!(matches!(chunk, StreamChunk::Text(text) if text == "hello"));
+    }
+
+    #[test]
+    fn decode_stream_item_preserves_llm_error() {
+        let decoded = decode_stream_item(Err(LLMError::HttpStatus {
+            status_code: 503,
+            message: "upstream connect error".into(),
+            retry_after_secs: None,
+        }))
+        .expect_err("error should propagate");
+        assert!(matches!(
+            decoded,
+            LLMError::HttpStatus {
+                status_code: 503,
+                ..
+            }
+        ));
     }
 }

--- a/crates/querymt/src/plugin/extism_impl/host/mod.rs
+++ b/crates/querymt/src/plugin/extism_impl/host/mod.rs
@@ -48,9 +48,7 @@ fn decode_plugin_error(e: extism::Error, code: i32) -> LLMError {
     PluginError::decode(code, &raw)
 }
 
-fn decode_stream_item(
-    item: Result<Vec<u8>, LLMError>,
-) -> Result<StreamChunk, LLMError> {
+fn decode_stream_item(item: Result<Vec<u8>, LLMError>) -> Result<StreamChunk, LLMError> {
     match item {
         Ok(bytes) => serde_json::from_slice::<crate::plugin::extism_impl::ExtismChatChunk>(&bytes)
             .map(|c| c.chunk)

--- a/crates/querymt/src/plugin/extism_impl/interface.rs
+++ b/crates/querymt/src/plugin/extism_impl/interface.rs
@@ -2,7 +2,7 @@ use crate::{
     ToolCall, Usage,
     chat::{ChatMessage, ChatResponse, FinishReason, Tool},
     completion::CompletionRequest,
-    error::LLMError,
+    error::{LLMError, LLMErrorPayload},
     stt, tts,
 };
 use serde::{Deserialize, Serialize};
@@ -18,87 +18,31 @@ use std::fmt;
 /// and received via `call_get_error_code` on the host side.
 /// The error string is JSON-serialized [`PluginError`].
 pub mod error_codes {
-    pub const GENERIC: i32 = 0;
-    pub const PROVIDER: i32 = 1;
-    pub const AUTH: i32 = 2;
-    pub const INVALID_REQUEST: i32 = 3;
-    pub const RATE_LIMITED: i32 = 4;
-    pub const HTTP: i32 = 5;
-    pub const NOT_IMPLEMENTED: i32 = 6;
-    pub const CANCELLED: i32 = 7;
+    pub const STRUCTURED: i32 = 1;
 }
 
 /// Structured error that crosses the WASM boundary as JSON.
 ///
-/// On the plugin side, [`LLMError`] is converted into this type and serialized
-/// to JSON as the extism error string, paired with an [`error_codes`] integer
-/// via `WithReturnCode`. On the host side, `call_get_error_code` yields
-/// `(error_string, code)` — the code selects the variant and the JSON string
-/// is deserialized back into this type to reconstruct the original [`LLMError`].
+/// On the plugin side, [`LLMError`] is converted into a serializable payload and
+/// sent as JSON paired with a stable code. On the host side, the payload is
+/// reconstructed back into the original [`LLMError`] without stringifying it.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
-#[serde(tag = "kind", content = "data")]
-pub enum PluginError {
-    #[error("LLM Provider Error: {0}")]
-    Provider(String),
-
-    #[error("Auth Error: {0}")]
-    Auth(String),
-
-    #[error("Invalid Request: {0}")]
-    InvalidRequest(String),
-
-    #[error("Rate limited: {message}")]
-    RateLimited {
-        message: String,
-        retry_after_secs: Option<u64>,
-    },
-
-    #[error("HTTP Error: {0}")]
-    Http(String),
-
-    #[error("Cancelled")]
-    Cancelled,
-
-    #[error("Not Implemented: {0}")]
-    NotImplemented(String),
-
-    #[error("{0}")]
-    Generic(String),
+#[error("{payload:?}")]
+pub struct PluginError {
+    pub payload: LLMErrorPayload,
 }
 
 impl PluginError {
     /// Convert an [`LLMError`] into a `PluginError` for WASM transport.
     pub fn from_llm_error(err: &LLMError) -> Self {
-        match err {
-            LLMError::ProviderError(msg) => Self::Provider(msg.clone()),
-            LLMError::AuthError(msg) => Self::Auth(msg.clone()),
-            LLMError::InvalidRequest(msg) => Self::InvalidRequest(msg.clone()),
-            LLMError::RateLimited {
-                message,
-                retry_after_secs,
-            } => Self::RateLimited {
-                message: message.clone(),
-                retry_after_secs: *retry_after_secs,
-            },
-            LLMError::HttpError(msg) => Self::Http(msg.clone()),
-            LLMError::Cancelled => Self::Cancelled,
-            LLMError::NotImplemented(msg) => Self::NotImplemented(msg.clone()),
-            other => Self::Generic(other.to_string()),
+        Self {
+            payload: err.to_payload(),
         }
     }
 
     /// Error code for this variant, matching [`error_codes`].
     pub fn code(&self) -> i32 {
-        match self {
-            Self::Provider(_) => error_codes::PROVIDER,
-            Self::Auth(_) => error_codes::AUTH,
-            Self::InvalidRequest(_) => error_codes::INVALID_REQUEST,
-            Self::RateLimited { .. } => error_codes::RATE_LIMITED,
-            Self::Http(_) => error_codes::HTTP,
-            Self::Cancelled => error_codes::CANCELLED,
-            Self::NotImplemented(_) => error_codes::NOT_IMPLEMENTED,
-            Self::Generic(_) => error_codes::GENERIC,
-        }
+        error_codes::STRUCTURED
     }
 
     /// Serialize an [`LLMError`] into a `(json_string, error_code)` pair
@@ -112,54 +56,13 @@ impl PluginError {
 
     /// Reconstruct an [`LLMError`] from an error code and JSON string
     /// received from the WASM plugin.
-    ///
-    /// The error code determines which [`LLMError`] variant to construct.
-    /// The JSON string is deserialized for the structured payload (e.g.
-    /// `retry_after_secs` on rate-limit errors). Falls back to using the
-    /// raw string as the message if JSON parsing fails.
     pub fn decode(code: i32, json: &str) -> LLMError {
-        // Try to deserialize the JSON into PluginError first
-        let msg_from_json = || -> String {
-            serde_json::from_str::<PluginError>(json)
-                .map(|pe| match pe {
-                    Self::Provider(m)
-                    | Self::Auth(m)
-                    | Self::InvalidRequest(m)
-                    | Self::Http(m)
-                    | Self::NotImplemented(m)
-                    | Self::Generic(m) => m,
-                    Self::Cancelled => "cancelled".to_string(),
-                    Self::RateLimited { message, .. } => message,
-                })
-                .unwrap_or_else(|_| json.to_string())
-        };
-
-        match code {
-            error_codes::PROVIDER => LLMError::ProviderError(msg_from_json()),
-            error_codes::AUTH => LLMError::AuthError(msg_from_json()),
-            error_codes::INVALID_REQUEST => LLMError::InvalidRequest(msg_from_json()),
-            error_codes::RATE_LIMITED => {
-                if let Ok(PluginError::RateLimited {
-                    message,
-                    retry_after_secs,
-                }) = serde_json::from_str::<PluginError>(json)
-                {
-                    LLMError::RateLimited {
-                        message,
-                        retry_after_secs,
-                    }
-                } else {
-                    LLMError::RateLimited {
-                        message: msg_from_json(),
-                        retry_after_secs: None,
-                    }
-                }
-            }
-            error_codes::HTTP => LLMError::HttpError(msg_from_json()),
-            error_codes::CANCELLED => LLMError::Cancelled,
-            error_codes::NOT_IMPLEMENTED => LLMError::NotImplemented(msg_from_json()),
-            _ => LLMError::PluginError(msg_from_json()),
+        if code == error_codes::STRUCTURED {
+            return serde_json::from_str::<PluginError>(json)
+                .map(|pe| LLMError::from_payload(pe.payload))
+                .unwrap_or_else(|_| LLMError::PluginError(json.to_string()));
         }
+        LLMError::PluginError(json.to_string())
     }
 }
 

--- a/crates/querymt/src/plugin/http.rs
+++ b/crates/querymt/src/plugin/http.rs
@@ -1,42 +1,6 @@
 use crate::{HTTPLLMProvider, error::LLMError};
 use http::{Request, Response};
 
-/// Parse retry-after duration from HTTP headers.
-///
-/// Checks both `retry-after` (standard) and `x-ratelimit-reset-requests` (custom format).
-/// Supports formats:
-/// - `retry-after`: integer seconds (e.g., "60")
-/// - `x-ratelimit-reset-requests`: duration strings like "6m0s" or "1s"
-///
-/// Returns the duration in seconds if found, otherwise `None`.
-pub fn parse_retry_after(headers: &http::HeaderMap) -> Option<u64> {
-    headers
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .or_else(|| {
-            // Fallback: try parsing x-ratelimit-reset-requests as duration
-            headers
-                .get("x-ratelimit-reset-requests")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| {
-                    // Parse formats like "6m0s" or "1s"
-                    if s.ends_with('s') {
-                        let num_part = s.trim_end_matches('s');
-                        if let Some(m_pos) = num_part.find('m') {
-                            // Format: "6m0s" -> extract minutes
-                            num_part[..m_pos].parse::<u64>().ok().map(|m| m * 60)
-                        } else {
-                            // Format: "1s"
-                            num_part.parse::<u64>().ok()
-                        }
-                    } else {
-                        None
-                    }
-                })
-        })
-}
-
 pub trait HTTPLLMProviderFactory: Send + Sync {
     fn name(&self) -> &str;
 
@@ -72,47 +36,13 @@ macro_rules! handle_http_error {
     ($resp:expr) => {{
         if !$resp.status().is_success() {
             let status_code = $resp.status().as_u16();
-
-            if status_code == 499 {
-                return Err(LLMError::Cancelled);
-            }
-
-            // Extract retry-after header for rate limit errors
-            let retry_after_secs = if status_code == 429 {
-                $crate::plugin::http::parse_retry_after($resp.headers())
-            } else {
-                None
-            };
-
+            let headers = $resp.headers().clone();
             let error_body = $resp.into_body();
-
-            // Try to parse JSON and extract error.message for a clean message
-            let clean_message = serde_json::from_slice::<serde_json::Value>(&error_body)
-                .ok()
-                .and_then(|json| {
-                    json.pointer("/error/message")
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string)
-                })
-                .unwrap_or_else(|| {
-                    format!(
-                        "HTTP {}: {}",
-                        status_code,
-                        String::from_utf8_lossy(&error_body)
-                    )
-                });
-
-            // Route to appropriate error variant based on status code
-            return Err(match status_code {
-                401 | 403 => LLMError::AuthError(clean_message),
-                429 => LLMError::RateLimited {
-                    message: clean_message,
-                    retry_after_secs,
-                },
-                400 => LLMError::InvalidRequest(clean_message),
-                500 | 529 => LLMError::ProviderError(format!("Server error: {}", clean_message)),
-                _ => LLMError::ProviderError(clean_message),
-            });
+            return Err($crate::error::classify_http_status(
+                status_code,
+                &headers,
+                &error_body,
+            ));
         }
     }};
 }

--- a/crates/querymt/src/providers/registry.rs
+++ b/crates/querymt/src/providers/registry.rs
@@ -28,10 +28,14 @@ async fn download_and_cache_providers(file_path: &Path) -> Result<ProvidersRegis
     let response = client.get(API_URL).send().await?;
 
     if !response.status().is_success() {
-        return Err(LLMError::ProviderError(format!(
-            "HTTP Error: {}",
-            response.status()
-        )));
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = response.bytes().await?.to_vec();
+        return Err(crate::error::classify_http_status(
+            status.as_u16(),
+            &headers,
+            &body,
+        ));
     }
 
     // API returns a top-level map of providers, convert into ProvidersRegistry


### PR DESCRIPTION
decouple session attachment from DHT lookup

Refactored remote session lifecycle to return live `RemoteActorRef` from `RemoteNodeManager` immediately, eliminating the blocking DHT lookups and registry attachment steps in `LocalAgentHandle` and `UI`. New `ForkRemoteSession` API added to create child sessions at specific message boundaries via the node manager.

**Key changes:**
- **`LocalAgentHandle`**: `create_remote_session` now returns `CreateRemoteSessionResponse` containing the live session ref instead of `(String, ActorRef)`; `fork_remote_session` added.
- **`RemoteNodeManager`**: Split session creation into `materialize_remote_session` (spawns actor, registers in local registry with best-effort background DHT) and public message handlers. Added `ForkRemoteSession` implementation.
- **`SessionActorRef`**: `fork_at_message` for local sessions now returns `Ok(forked_id)`; remote forks are now routed through `RemoteNodeManager` via the new message.
- **UI Handlers**: `handle_create_remote_session` and `handle_fork_session` updated to use the new direct-ref handoff path, simplifying event forwarding and workspace initialization logic.
- **Tests**: Added integration tests for remote fork lifecycle and updated existing tests to reflect the new response structure.