### PR TITLE
fix(ui): hide session controls on home screen

### DIFF
--- a/crates/agent/ui/src/components/AppHeader.tsx
+++ b/crates/agent/ui/src/components/AppHeader.tsx
@@ -184,34 +184,36 @@ export function AppHeader(props: AppHeaderProps) {
         {/* Desktop controls */}
         {!isMobile && (
           <div className="hidden md:flex items-center gap-2 min-w-0">
-            <ModelPickerPopover
-              open={modelPickerOpen}
-              onOpenChange={setModelPickerOpen}
-              connected={connected}
-              routingMode={props.routingMode}
-              activeAgentId={props.activeAgentId}
-              sessionId={sessionId}
-              sessionsByAgent={props.sessionsByAgent}
-              agents={props.agents}
-              allModels={props.allModels}
-              currentProvider={activeAgentModel?.provider}
-              currentModel={activeAgentModel?.model}
-              currentNode={activeAgentModel?.node}
-              remoteNodes={remoteNodes}
-              currentWorkspace={props.currentWorkspace}
-              recentModelsByWorkspace={props.recentModelsByWorkspace}
-              agentMode={agentMode}
-              reasoningEffort={props.reasoningEffort}
-              onRefresh={props.refreshAllModels}
-              onSetSessionModel={props.setSessionModel}
-              onSetReasoningEffort={props.setReasoningEffort}
-              onCycleReasoningEffort={props.cycleReasoningEffort}
-              providerCapabilities={props.providerCapabilities}
-              modelDownloads={props.modelDownloads}
-              onAddCustomModelFromHf={props.addCustomModelFromHf}
-              onAddCustomModelFromFile={props.addCustomModelFromFile}
-              onDeleteCustomModel={props.deleteCustomModel}
-            />
+            {sessionId && (
+              <ModelPickerPopover
+                open={modelPickerOpen}
+                onOpenChange={setModelPickerOpen}
+                connected={connected}
+                routingMode={props.routingMode}
+                activeAgentId={props.activeAgentId}
+                sessionId={sessionId}
+                sessionsByAgent={props.sessionsByAgent}
+                agents={props.agents}
+                allModels={props.allModels}
+                currentProvider={activeAgentModel?.provider}
+                currentModel={activeAgentModel?.model}
+                currentNode={activeAgentModel?.node}
+                remoteNodes={remoteNodes}
+                currentWorkspace={props.currentWorkspace}
+                recentModelsByWorkspace={props.recentModelsByWorkspace}
+                agentMode={agentMode}
+                reasoningEffort={props.reasoningEffort}
+                onRefresh={props.refreshAllModels}
+                onSetSessionModel={props.setSessionModel}
+                onSetReasoningEffort={props.setReasoningEffort}
+                onCycleReasoningEffort={props.cycleReasoningEffort}
+                providerCapabilities={props.providerCapabilities}
+                modelDownloads={props.modelDownloads}
+                onAddCustomModelFromHf={props.addCustomModelFromHf}
+                onAddCustomModelFromFile={props.addCustomModelFromFile}
+                onDeleteCustomModel={props.deleteCustomModel}
+              />
+            )}
 
             <RemoteNodeIndicator remoteNodes={remoteNodes} />
             {props.desktopActions}

--- a/crates/agent/ui/src/components/AppShell.tsx
+++ b/crates/agent/ui/src/components/AppShell.tsx
@@ -116,6 +116,7 @@ export function AppShell() {
 
   const location = useLocation();
   const isHomePage = location.pathname === '/';
+  const visibleSessionId = isHomePage ? null : sessionId;
   const isMobile = useIsMobile();
   const [shortcutGatewayOpen, setShortcutGatewayOpen] = useState(false);
   const [themeSwitcherOpen, setThemeSwitcherOpen] = useState(false);
@@ -207,18 +208,18 @@ export function AppShell() {
   // --- Derived values ---
 
   const currentWorkspace = useMemo(() => {
-    if (!sessionId) return null;
+    if (!visibleSessionId) return null;
     for (const group of sessionGroups) {
-      if (group.sessions.some(s => s.session_id === sessionId)) {
+      if (group.sessions.some(s => s.session_id === visibleSessionId)) {
         return group.cwd || null;
       }
     }
     return null;
-  }, [sessionId, sessionGroups]);
+  }, [visibleSessionId, sessionGroups]);
 
   const activeAgentModel = useMemo(
-    () => agentModels[activeAgentId],
-    [agentModels, activeAgentId],
+    () => visibleSessionId ? agentModels[activeAgentId] : undefined,
+    [agentModels, activeAgentId, visibleSessionId],
   );
 
   // --- Callbacks ---
@@ -240,6 +241,12 @@ export function AppShell() {
     [setModelPickerOpen],
   );
 
+  useEffect(() => {
+    if (!isHomePage) return;
+    setModelPickerOpen(false);
+    setStatsDrawerOpen(false);
+  }, [isHomePage, setModelPickerOpen, setStatsDrawerOpen]);
+
   // --- Render ---
 
   const meshInvitePanel = (
@@ -259,7 +266,7 @@ export function AppShell() {
       <AppHeader
         isHomePage={isHomePage}
         isMobile={isMobile}
-        sessionId={sessionId}
+        sessionId={visibleSessionId}
         connected={connected}
         reconnecting={reconnecting}
         isSessionActive={isSessionActive}
@@ -307,7 +314,7 @@ export function AppShell() {
           connected={connected}
           routingMode={routingMode}
           activeAgentId={activeAgentId}
-          sessionId={sessionId}
+          sessionId={visibleSessionId}
           sessionsByAgent={sessionsByAgent}
           agents={agents}
           allModels={allModels}

--- a/crates/agent/ui/src/components/AppShellHomeHeaderVisibility.test.tsx
+++ b/crates/agent/ui/src/components/AppShellHomeHeaderVisibility.test.tsx
@@ -1,0 +1,198 @@
+import { useEffect } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AppShell } from './AppShell';
+
+const mocks = vi.hoisted(() => {
+  const uiStoreState = {
+    loading: false,
+    sessionSwitcherOpen: false,
+    setSessionSwitcherOpen: vi.fn(),
+    modelPickerOpen: true,
+    setModelPickerOpen: vi.fn(),
+    statsDrawerOpen: true,
+    setStatsDrawerOpen: vi.fn(),
+    mobileMenuOpen: true,
+    setMobileMenuOpen: vi.fn(),
+    delegationDrawerOpen: false,
+    selectedToolEvent: null,
+    selectedTheme: 'default-dark',
+    setSelectedTheme: vi.fn(),
+    createScheduleDialogOpen: false,
+    setCreateScheduleDialogOpen: vi.fn(),
+  };
+
+  return {
+    isMobile: false,
+    uiStoreState,
+    actions: {
+      newSession: vi.fn(),
+      cancelSession: vi.fn(),
+      deleteSession: vi.fn(),
+      refreshAllModels: vi.fn(),
+      requestAuthProviders: vi.fn(),
+      startOAuthLogin: vi.fn(),
+      completeOAuthLogin: vi.fn(),
+      disconnectOAuth: vi.fn(),
+      clearOAuthState: vi.fn(),
+      setApiToken: vi.fn(),
+      clearApiToken: vi.fn(),
+      setAuthMethodPref: vi.fn(),
+      clearApiTokenResult: vi.fn(),
+      setSessionModel: vi.fn(),
+      addCustomModelFromHf: vi.fn(),
+      addCustomModelFromFile: vi.fn(),
+      deleteCustomModel: vi.fn(),
+      cycleAgentMode: vi.fn(),
+      cycleReasoningEffort: vi.fn(),
+      setReasoningEffort: vi.fn(),
+      submitWorkspacePathDialog: vi.fn(),
+      cancelWorkspacePathDialog: vi.fn(),
+      createMeshInvite: vi.fn(),
+      listMeshInvites: vi.fn(),
+      revokeMeshInvite: vi.fn(),
+      dismissConnectionError: vi.fn(),
+      dismissSessionActionNotice: vi.fn(),
+      updatePlugins: vi.fn(),
+      createSchedule: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../context/UiClientContext', () => ({
+  useUiClientActions: () => mocks.actions,
+  useUiClientSession: () => ({
+    connected: true,
+    reconnecting: false,
+    thinkingAgentId: null,
+    thinkingAgentIds: new Set(),
+    sessionId: 'session-1',
+    agents: [],
+    agentModels: { 'agent-1': { provider: 'test', model: 'model-1' } },
+    sessionLimits: null,
+    isConversationComplete: false,
+    routingMode: 'broadcast',
+    activeAgentId: 'agent-1',
+    sessionsByAgent: { 'agent-1': 'session-1' },
+    sessionGroups: [{ cwd: '/workspace', sessions: [{ session_id: 'session-1' }] }],
+    thinkingBySession: {},
+    agentMode: 'standard',
+    reasoningEffort: 'medium',
+    remoteNodes: [],
+    meshInvites: [],
+    lastCreatedMeshInvite: null,
+  }),
+  useUiClientConfig: () => ({
+    allModels: [],
+    providerCapabilities: {},
+    recentModelsByWorkspace: {},
+    authProviders: [],
+    oauthFlow: null,
+    oauthResult: null,
+    modelDownloads: {},
+    apiTokenResult: null,
+    workspacePathDialogOpen: false,
+    workspacePathDialogDefaultValue: '',
+    connectionErrors: [],
+    sessionActionNotices: [],
+    isUpdatingPlugins: false,
+    pluginUpdateStatus: null,
+    pluginUpdateResults: null,
+  }),
+}));
+
+vi.mock('../store/uiStore', () => {
+  const useUiStore = () => mocks.uiStoreState;
+  useUiStore.getState = () => ({ loadPersistedState: vi.fn() });
+  return { useUiStore };
+});
+
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mocks.isMobile }));
+vi.mock('../hooks/useGlobalKeyboardShortcuts', () => ({ useGlobalKeyboardShortcuts: vi.fn() }));
+vi.mock('../hooks/useThemeSync', () => ({ useThemeSync: vi.fn() }));
+vi.mock('../hooks/useAutoModelSwitch', () => ({ useAutoModelSwitch: vi.fn() }));
+vi.mock('../context/SessionTimerContext', () => ({
+  SessionTimerProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./MeshInvitePanel', () => ({ MeshInvitePanel: () => <div data-testid="mesh-invite-panel" /> }));
+vi.mock('./ToastStack', () => ({ ToastStack: () => <div data-testid="toast-stack" /> }));
+vi.mock('./AppHeader', () => ({
+  AppHeader: ({ sessionId, activeAgentModel, currentWorkspace, setMobileMenuOpen }: any) => {
+    useEffect(() => {
+      if (mocks.isMobile) setMobileMenuOpen(true);
+    }, [setMobileMenuOpen]);
+
+    return (
+      <div
+        data-testid="app-header"
+        data-session-id={sessionId ?? ''}
+        data-active-model={activeAgentModel?.model ?? ''}
+        data-workspace={currentWorkspace ?? ''}
+      />
+    );
+  },
+}));
+vi.mock('./MobileDropdownMenu', () => ({
+  MobileDropdownMenu: ({ sessionId, activeAgentModel, currentWorkspace }: any) => (
+    <div
+      data-testid="mobile-dropdown-menu"
+      data-session-id={sessionId ?? ''}
+      data-active-model={activeAgentModel?.model ?? ''}
+      data-workspace={currentWorkspace ?? ''}
+    />
+  ),
+}));
+vi.mock('./GlobalOverlays', () => ({
+  GlobalOverlays: ({ sessionId }: any) => <div data-testid="global-overlays" data-session-id={sessionId ?? ''} />,
+}));
+
+function renderShell(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<AppShell />}>
+          <Route index element={<div data-testid="home-page" />} />
+          <Route path="session/:sessionId" element={<div data-testid="session-page" />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppShell home header session visibility', () => {
+  beforeEach(() => {
+    mocks.isMobile = false;
+    vi.clearAllMocks();
+  });
+
+  it('passes no visible session details to header on the home route', async () => {
+    renderShell('/');
+
+    expect(screen.getByTestId('app-header')).toHaveAttribute('data-session-id', '');
+    expect(screen.getByTestId('app-header')).toHaveAttribute('data-active-model', '');
+    expect(screen.getByTestId('app-header')).toHaveAttribute('data-workspace', '');
+    expect(screen.getByTestId('global-overlays')).toHaveAttribute('data-session-id', 'session-1');
+    await waitFor(() => expect(mocks.uiStoreState.setModelPickerOpen).toHaveBeenCalledWith(false));
+    expect(mocks.uiStoreState.setStatsDrawerOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps visible session details on session routes', () => {
+    renderShell('/session/session-1');
+
+    expect(screen.getByTestId('app-header')).toHaveAttribute('data-session-id', 'session-1');
+    expect(screen.getByTestId('app-header')).toHaveAttribute('data-active-model', 'model-1');
+    expect(screen.getByTestId('app-header')).toHaveAttribute('data-workspace', '/workspace');
+    expect(mocks.uiStoreState.setModelPickerOpen).not.toHaveBeenCalled();
+    expect(mocks.uiStoreState.setStatsDrawerOpen).not.toHaveBeenCalled();
+  });
+
+  it('passes no visible session details to the mobile menu on the home route', () => {
+    mocks.isMobile = true;
+    renderShell('/');
+
+    expect(screen.getByTestId('mobile-dropdown-menu')).toHaveAttribute('data-session-id', '');
+    expect(screen.getByTestId('mobile-dropdown-menu')).toHaveAttribute('data-active-model', '');
+    expect(screen.getByTestId('mobile-dropdown-menu')).toHaveAttribute('data-workspace', '');
+  });
+});

--- a/crates/agent/ui/src/components/MobileDropdownMenu.tsx
+++ b/crates/agent/ui/src/components/MobileDropdownMenu.tsx
@@ -48,35 +48,37 @@ export function MobileDropdownMenu(props: MobileDropdownMenuProps) {
   return (
     <div className="md:hidden bg-surface-elevated border-b border-surface-border px-3 py-2.5 flex flex-col gap-2 z-30">
       {/* Model picker on mobile */}
-      <ModelPickerPopover
-        open={props.modelPickerOpen}
-        onOpenChange={props.handleMobilePickerOpenChange}
-        isInMobileMenu
-        connected={props.connected}
-        routingMode={props.routingMode}
-        activeAgentId={props.activeAgentId}
-        sessionId={props.sessionId}
-        sessionsByAgent={props.sessionsByAgent}
-        agents={props.agents}
-        allModels={props.allModels}
-        currentProvider={props.activeAgentModel?.provider}
-        currentModel={props.activeAgentModel?.model}
-        currentNode={props.activeAgentModel?.node}
-        remoteNodes={props.remoteNodes}
-        currentWorkspace={props.currentWorkspace}
-        recentModelsByWorkspace={props.recentModelsByWorkspace}
-        agentMode={props.agentMode}
-        reasoningEffort={props.reasoningEffort}
-        onRefresh={props.refreshAllModels}
-        onSetSessionModel={props.setSessionModel}
-        onSetReasoningEffort={props.setReasoningEffort}
-        onCycleReasoningEffort={props.cycleReasoningEffort}
-        providerCapabilities={props.providerCapabilities}
-        modelDownloads={props.modelDownloads}
-        onAddCustomModelFromHf={props.addCustomModelFromHf}
-        onAddCustomModelFromFile={props.addCustomModelFromFile}
-        onDeleteCustomModel={props.deleteCustomModel}
-      />
+      {props.sessionId && (
+        <ModelPickerPopover
+          open={props.modelPickerOpen}
+          onOpenChange={props.handleMobilePickerOpenChange}
+          isInMobileMenu
+          connected={props.connected}
+          routingMode={props.routingMode}
+          activeAgentId={props.activeAgentId}
+          sessionId={props.sessionId}
+          sessionsByAgent={props.sessionsByAgent}
+          agents={props.agents}
+          allModels={props.allModels}
+          currentProvider={props.activeAgentModel?.provider}
+          currentModel={props.activeAgentModel?.model}
+          currentNode={props.activeAgentModel?.node}
+          remoteNodes={props.remoteNodes}
+          currentWorkspace={props.currentWorkspace}
+          recentModelsByWorkspace={props.recentModelsByWorkspace}
+          agentMode={props.agentMode}
+          reasoningEffort={props.reasoningEffort}
+          onRefresh={props.refreshAllModels}
+          onSetSessionModel={props.setSessionModel}
+          onSetReasoningEffort={props.setReasoningEffort}
+          onCycleReasoningEffort={props.cycleReasoningEffort}
+          providerCapabilities={props.providerCapabilities}
+          modelDownloads={props.modelDownloads}
+          onAddCustomModelFromHf={props.addCustomModelFromHf}
+          onAddCustomModelFromFile={props.addCustomModelFromFile}
+          onDeleteCustomModel={props.deleteCustomModel}
+        />
+      )}
       <div className="flex items-center gap-2">
         <button
           type="button"

--- a/crates/agent/ui/src/components/ModelPickerSessionVisibility.test.tsx
+++ b/crates/agent/ui/src/components/ModelPickerSessionVisibility.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppHeader } from './AppHeader';
+import { MobileDropdownMenu } from './MobileDropdownMenu';
+
+vi.mock('./GlitchText', () => ({
+  GlitchText: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+vi.mock('./ModelPickerPopover', () => ({
+  ModelPickerPopover: ({ isInMobileMenu }: { isInMobileMenu?: boolean }) => (
+    <div data-testid={isInMobileMenu ? 'mobile-model-picker' : 'desktop-model-picker'} />
+  ),
+}));
+
+vi.mock('./HeaderStatsBar', () => ({
+  HeaderStatsBar: () => <div data-testid="header-stats-bar" />,
+}));
+
+vi.mock('./RemoteNodeIndicator', () => ({
+  RemoteNodeIndicator: () => <div data-testid="remote-node-indicator" />,
+}));
+
+const baseModelProps = {
+  modelPickerOpen: true,
+  connected: true,
+  routingMode: 'broadcast' as const,
+  activeAgentId: 'agent-1',
+  sessionsByAgent: { 'agent-1': 'session-1' },
+  agents: [],
+  allModels: [],
+  activeAgentModel: undefined,
+  remoteNodes: [],
+  currentWorkspace: null,
+  recentModelsByWorkspace: {},
+  agentMode: 'standard',
+  reasoningEffort: null,
+  refreshAllModels: vi.fn(),
+  setSessionModel: vi.fn(),
+  setReasoningEffort: vi.fn(),
+  cycleReasoningEffort: vi.fn(),
+  providerCapabilities: {},
+  modelDownloads: {},
+  addCustomModelFromHf: vi.fn(),
+  addCustomModelFromFile: vi.fn(),
+  deleteCustomModel: vi.fn(),
+};
+
+const appHeaderProps = {
+  ...baseModelProps,
+  isHomePage: false,
+  isMobile: false,
+  sessionId: 'session-1',
+  reconnecting: false,
+  isSessionActive: false,
+  isConversationComplete: false,
+  cycleAgentMode: vi.fn(),
+  setSessionSwitcherOpen: vi.fn(),
+  agentModels: {},
+  sessionLimits: null,
+  statsDrawerOpen: false,
+  setStatsDrawerOpen: vi.fn(),
+  setModelPickerOpen: vi.fn(),
+  mobileMenuOpen: false,
+  setMobileMenuOpen: vi.fn(),
+};
+
+const mobileDropdownProps = {
+  ...baseModelProps,
+  sessionId: 'session-1',
+  handleMobilePickerOpenChange: vi.fn(),
+  setShortcutGatewayOpen: vi.fn(),
+  setMobileMenuOpen: vi.fn(),
+};
+
+describe('model picker session visibility', () => {
+  it('renders the desktop model picker only when a session exists', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <AppHeader {...appHeaderProps} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('desktop-model-picker')).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <AppHeader {...appHeaderProps} sessionId={null} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId('desktop-model-picker')).not.toBeInTheDocument();
+    expect(screen.getByTestId('remote-node-indicator')).toBeInTheDocument();
+  });
+
+  it('renders the mobile model picker only when a session exists', () => {
+    const { rerender } = render(<MobileDropdownMenu {...mobileDropdownProps} />);
+
+    expect(screen.getByTestId('mobile-model-picker')).toBeInTheDocument();
+
+    rerender(<MobileDropdownMenu {...mobileDropdownProps} sessionId={null} />);
+
+    expect(screen.queryByTestId('mobile-model-picker')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open shortcut gateway' })).toBeInTheDocument();
+    expect(screen.getByTestId('remote-node-indicator')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Hide the model picker when no active session is visible
- Suppress session-scoped header details on the home route
- Close model and stats overlays when returning to home
- Cover desktop, mobile, and route-scoped header visibility

closes #487 