### PR TITLE
fix(mobile-ffi): initialize Android TLS verifier via canonical FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,12 +1575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6644,22 +6638,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -6667,7 +6645,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -6686,15 +6664,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -11098,7 +11067,7 @@ dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema 0.12.0",
  "anyhow",
- "jni 0.21.1",
+ "jni",
  "libc",
  "libp2p",
  "log",
@@ -11116,7 +11085,7 @@ dependencies = [
  "querymt-agent",
  "querymt-utils",
  "rmcp",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -11759,7 +11728,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
@@ -12163,34 +12132,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls 0.23.40",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls 0.23.40",
@@ -16001,7 +15949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
- "jni 0.22.4",
+ "jni",
  "log",
  "ndk-context",
  "objc2",
@@ -16381,15 +16329,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -16431,21 +16370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -16516,12 +16440,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -16540,12 +16458,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -16561,12 +16473,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -16600,12 +16506,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -16621,12 +16521,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -16648,12 +16542,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -16669,12 +16557,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/querymt-mobile-ffi/Cargo.toml
+++ b/crates/querymt-mobile-ffi/Cargo.toml
@@ -62,7 +62,7 @@ rmcp = { version = "1.0", features = ["client", "transport-async-rw", "elicitati
 libp2p = { version = "0.56", optional = true, default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-jni = "0.21"
-rustls-platform-verifier = "0.6.2"
+jni = "0.22"
+rustls-platform-verifier = "0.7.0"
 
 [build-dependencies]

--- a/crates/querymt-mobile-ffi/include/querymt_mobile_ffi.h
+++ b/crates/querymt-mobile-ffi/include/querymt_mobile_ffi.h
@@ -41,6 +41,9 @@ typedef void (*qmt_ffi_acp_message_handler_fn)(
 // Lifecycle
 // ============================================================================
 
+#ifdef __ANDROID__
+int32_t qmt_ffi_android_init(void *env, void *context);
+#endif
 int32_t qmt_ffi_init_agent(const char *config_toml, uint64_t *out_agent);
 int32_t qmt_ffi_shutdown(uint64_t agent_handle);
 int32_t qmt_ffi_set_lifecycle_state(uint64_t agent_handle, int32_t backgrounded);

--- a/crates/querymt-mobile-ffi/src/lib.rs
+++ b/crates/querymt-mobile-ffi/src/lib.rs
@@ -826,6 +826,29 @@ unsafe fn qmt_internal_set_log_handler(
 // Canonical qmt_ffi API
 // ============================================================================
 
+/// Initialize Android JNI state required by TLS certificate verification.
+///
+/// Android callers must invoke this entrypoint before `qmt_ffi_init_agent` and
+/// before any TLS/reqwest work. The `rustls-platform-verifier` backend needs the
+/// current `JNIEnv*` and an Android `Context`; repeated calls are safe because
+/// the verifier initialization is idempotent.
+///
+/// Returns a `QMT_FFI_*` status code and sets the thread-local last error on
+/// failure.
+///
+/// # Safety
+///
+/// - `env` must be a valid `JNIEnv*` for the current thread.
+/// - `context` must be a valid Android application `Context` JNI object.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qmt_ffi_android_init(
+    env: *mut std::ffi::c_void,
+    context: *mut std::ffi::c_void,
+) -> i32 {
+    unsafe { qmt_internal_android_init(env, context) }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qmt_ffi_init_agent(
     config_toml: *const std::ffi::c_char,
@@ -919,33 +942,28 @@ unsafe fn android_init_impl(env: *mut std::ffi::c_void, context: *mut std::ffi::
         return FfiErrorCode::InvalidArgument as i32;
     }
 
-    let mut env = match unsafe { jni::JNIEnv::from_raw(env.cast::<jni::sys::JNIEnv>()) } {
-        Ok(env) => env,
-        Err(err) => {
-            set_last_error(
-                FfiErrorCode::RuntimeError,
-                format!("failed to wrap JNIEnv: {err}"),
-            );
-            return FfiErrorCode::RuntimeError as i32;
-        }
-    };
-
-    let context = unsafe { jni::objects::JObject::from_raw(context.cast::<jni::sys::_jobject>()) };
-    match rustls_platform_verifier::android::init_with_env(&mut env, context) {
-        Ok(()) => {
+    let mut env = unsafe { jni::EnvUnowned::from_raw(env.cast::<jni::sys::JNIEnv>()) };
+    let context = context.cast::<jni::sys::_jobject>();
+    match env
+        .with_env_no_catch(|env| {
+            let context = unsafe { jni::objects::JObject::from_raw(env, context) };
+            rustls_platform_verifier::android::init_with_env(env, context)
+        })
+        .into_outcome()
+    {
+        jni::Outcome::Ok(()) => {
             // init_with_env stores global refs internally and is idempotent.
-            std::mem::forget(env);
             ffi_helpers::clear_last_error();
             FfiErrorCode::Ok as i32
         }
-        Err(err) => {
-            std::mem::forget(env);
+        jni::Outcome::Err(err) => {
             set_last_error(
                 FfiErrorCode::RuntimeError,
                 format!("failed to initialize rustls platform verifier: {err}"),
             );
             FfiErrorCode::RuntimeError as i32
         }
+        jni::Outcome::Panic(payload) => std::panic::resume_unwind(payload),
     }
 }
 


### PR DESCRIPTION
Expose Android JNI verifier initialization for the mobile FFI and align rustls-platform-verifier/jni versions with the runtime TLS stack. Document qmt_ffi_android_init usage and safety requirements. Fixes Android agent startup panic: "Expect rustls-platform-verifier to be initialized".