### PR TITLE
fix: missing `tls-ring` feature in otel dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14565,6 +14565,7 @@ dependencies = [
  "pin-project",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/crates/querymt-utils/Cargo.toml
+++ b/crates/querymt-utils/Cargo.toml
@@ -29,7 +29,7 @@ tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["logs"] }
-opentelemetry-otlp = { version = "0.32", features = ["metrics", "grpc-tonic", "logs"] }
+opentelemetry-otlp = { version = "0.32", features = ["metrics", "grpc-tonic", "logs", "tls-ring"] }
 opentelemetry-appender-tracing = { version = "0.32", features = ["log"] }
 opentelemetry-semantic-conventions = "0.32"
 


### PR DESCRIPTION
```
$ ./target/debug/examples/qmtcode --dashboard=0.0.0.0:42069 --mesh=/ip4/0.0.0.0/tcp/9001

thread 'main' (37618) panicked at crates/querymt-utils/src/telemetry.rs:301:33:
Failed to set up telemetry: TracerProvider("endpoint: endpoint 'https://otel.query.mt' uses HTTPS but no TLS feature is enabled; enable one of the `tls-ring`, `tls-aws-lc`, or `tls-provider-agnostic` features on `opentelemetry-otlp`")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```