### PR TITLE
fix(agent): preserve reasoning effort across delegation and session loads

### DIFF
--- a/crates/agent/src/agent/delegation_loop_tests.rs
+++ b/crates/agent/src/agent/delegation_loop_tests.rs
@@ -21,8 +21,8 @@ use crate::test_utils::{
 };
 use mockall::Sequence;
 use querymt::LLMParams;
-use querymt::chat::ChatRole;
 use querymt::chat::FinishReason;
+use querymt::chat::{ChatRole, ReasoningEffort};
 use querymt::plugin::host::PluginRegistry;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -135,6 +135,14 @@ struct TestHarness {
 
 impl TestHarness {
     async fn new(history: Vec<AgentMessage>, behavior: DelegateBehavior) -> Self {
+        Self::new_with_delegate_reasoning(history, behavior, None).await
+    }
+
+    async fn new_with_delegate_reasoning(
+        history: Vec<AgentMessage>,
+        behavior: DelegateBehavior,
+        delegate_reasoning_effort: Option<ReasoningEffort>,
+    ) -> Self {
         let provider = Arc::new(Mutex::new(MockLlmProvider::new()));
         let shared_provider = SharedLlmProvider {
             inner: provider.clone(),
@@ -203,7 +211,9 @@ impl TestHarness {
         // resolves correctly when creating delegation sessions.
         let mut agent_registry = DefaultAgentRegistry::new();
         for id in ["agent", "agent1", "agent2"] {
-            let delegate_handle = build_delegate_handle(behavior.clone(), store.clone()).await;
+            let delegate_handle =
+                build_delegate_handle(behavior.clone(), store.clone(), delegate_reasoning_effort)
+                    .await;
             agent_registry.register_handle(
                 agent_info(id),
                 delegate_handle as Arc<dyn crate::agent::handle::AgentHandle>,
@@ -274,6 +284,92 @@ impl TestHarness {
         .expect("state machine")
     }
 
+    async fn set_parent_reasoning_effort(&self, effort: Option<ReasoningEffort>) {
+        let store = self.config.provider.history_store();
+        let current = store
+            .get_session_llm_config(&self.exec_ctx.session_id)
+            .await
+            .expect("parent config lookup")
+            .expect("parent config");
+        let mut params = current
+            .params
+            .map(serde_json::from_value::<LLMParams>)
+            .transpose()
+            .expect("deserialize parent params")
+            .unwrap_or_default()
+            .provider(&current.provider)
+            .model(&current.model);
+        params.reasoning_effort = effort;
+        let updated = store
+            .create_or_get_llm_config(&params)
+            .await
+            .expect("create parent config");
+        store
+            .set_session_llm_config(&self.exec_ctx.session_id, updated.id)
+            .await
+            .expect("set parent config");
+    }
+
+    async fn run_single_delegation(&mut self) -> CycleOutcome {
+        let delegate_call = mock_querymt_tool_call(
+            "call-1",
+            "delegate",
+            r#"{"target_agent_id":"agent","objective":"task"}"#,
+        );
+        let mut seq = Sequence::new();
+        self.provider_mut()
+            .await
+            .expect_chat()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(move |_| {
+                Ok(Box::new(MockChatResponse::with_tools(
+                    "Delegating task",
+                    vec![delegate_call.clone()],
+                )))
+            });
+        self.provider_mut()
+            .await
+            .expect_chat()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| Ok(Box::new(MockChatResponse::text_only("Done"))));
+        self.provider_mut()
+            .await
+            .expect_call_tool()
+            .returning(|_, _| Ok(vec![querymt::chat::Content::text("ok")]))
+            .times(1);
+        self.provider_mut()
+            .await
+            .expect_tools()
+            .return_const(None)
+            .times(0..);
+
+        self.run().await
+    }
+
+    async fn child_llm_params(&self) -> (String, LLMParams) {
+        let store = self.config.provider.history_store();
+        let child_sessions = store
+            .list_child_sessions(&self.exec_ctx.session_id)
+            .await
+            .expect("child sessions");
+        let child_session_id = child_sessions.first().expect("child session id");
+        let config = store
+            .get_session_llm_config(child_session_id)
+            .await
+            .expect("child config lookup")
+            .expect("child config");
+        let params = config
+            .params
+            .map(serde_json::from_value::<LLMParams>)
+            .transpose()
+            .expect("deserialize child params")
+            .unwrap_or_default();
+
+        (config.model, params)
+    }
+
     async fn provider_mut(&self) -> tokio::sync::MutexGuard<'_, MockLlmProvider> {
         self.provider.lock().await
     }
@@ -284,6 +380,7 @@ impl TestHarness {
 async fn build_delegate_handle(
     behavior: DelegateBehavior,
     shared_store: Arc<dyn SessionStore>,
+    reasoning_effort: Option<ReasoningEffort>,
 ) -> Arc<crate::agent::LocalAgentHandle> {
     let delegate_provider = Arc::new(Mutex::new(MockLlmProvider::new()));
     {
@@ -373,10 +470,12 @@ async fn build_delegate_handle(
     }));
     let delegate_plugin_registry = Arc::new(delegate_plugin_registry);
 
+    let mut delegate_params = LLMParams::new().provider("mock").model("mock-model");
+    delegate_params.reasoning_effort = reasoning_effort;
     let delegate_session_provider = Arc::new(crate::session::provider::SessionProvider::new(
         delegate_plugin_registry,
         shared_store,
-        LLMParams::new().provider("mock").model("mock-model"),
+        delegate_params,
     ));
     let delegate_event_storage = Arc::new(
         SqliteStorage::connect(":memory:".into())
@@ -443,8 +542,51 @@ fn agent_info(id: &str) -> AgentInfo {
 // Helper functions moved to crate::test_utils::helpers
 
 #[tokio::test]
+async fn test_delegate_inherits_parent_reasoning_effort() {
+    let mut harness = TestHarness::new_with_delegate_reasoning(
+        vec![],
+        DelegateBehavior::AlwaysOk,
+        Some(ReasoningEffort::Low),
+    )
+    .await;
+    harness
+        .set_parent_reasoning_effort(Some(ReasoningEffort::High))
+        .await;
+
+    let outcome = harness.run_single_delegation().await;
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    let (_, child_params) = harness.child_llm_params().await;
+    assert_eq!(child_params.reasoning_effort, Some(ReasoningEffort::High));
+}
+
+#[tokio::test]
+async fn test_delegate_inherits_parent_auto_reasoning_effort() {
+    let mut harness = TestHarness::new_with_delegate_reasoning(
+        vec![],
+        DelegateBehavior::AlwaysOk,
+        Some(ReasoningEffort::Low),
+    )
+    .await;
+
+    let outcome = harness.run_single_delegation().await;
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    let (_, child_params) = harness.child_llm_params().await;
+    assert_eq!(child_params.reasoning_effort, None);
+}
+
+#[tokio::test]
 async fn test_delegate_model_override_applies_before_prompt() {
-    let mut harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    let mut harness = TestHarness::new_with_delegate_reasoning(
+        vec![],
+        DelegateBehavior::AlwaysOk,
+        Some(ReasoningEffort::Low),
+    )
+    .await;
+    harness
+        .set_parent_reasoning_effort(Some(ReasoningEffort::High))
+        .await;
     harness
         .config
         .delegate_model_overrides
@@ -458,65 +600,12 @@ async fn test_delegate_model_override_applies_before_prompt() {
         )
         .await;
 
-    let delegate_call = mock_querymt_tool_call(
-        "call-1",
-        "delegate",
-        r#"{"target_agent_id":"agent","objective":"task"}"#,
-    );
-    let mut seq = Sequence::new();
-    harness
-        .provider_mut()
-        .await
-        .expect_chat()
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(move |_| {
-            Ok(Box::new(MockChatResponse::with_tools(
-                "Delegating task",
-                vec![delegate_call.clone()],
-            )))
-        });
-    harness
-        .provider_mut()
-        .await
-        .expect_chat()
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(|_| Ok(Box::new(MockChatResponse::text_only("Done"))));
-    harness
-        .provider_mut()
-        .await
-        .expect_call_tool()
-        .returning(|_, _| Ok(vec![querymt::chat::Content::text("ok")]))
-        .times(1);
-    harness
-        .provider_mut()
-        .await
-        .expect_tools()
-        .return_const(None)
-        .times(0..);
-
-    let outcome = harness.run().await;
+    let outcome = harness.run_single_delegation().await;
 
     assert_eq!(outcome, CycleOutcome::Completed);
-    let child_sessions = harness
-        .config
-        .provider
-        .history_store()
-        .list_child_sessions(&harness.exec_ctx.session_id)
-        .await
-        .expect("child sessions");
-    let child_session_id = child_sessions.first().expect("child session id");
-    let child_config = harness
-        .config
-        .provider
-        .history_store()
-        .get_session_llm_config(child_session_id)
-        .await
-        .expect("child config lookup")
-        .expect("child config");
-    assert_eq!(child_config.provider, "mock");
-    assert_eq!(child_config.model, "override-model");
+    let (child_model, child_params) = harness.child_llm_params().await;
+    assert_eq!(child_model, "override-model");
+    assert_eq!(child_params.reasoning_effort, Some(ReasoningEffort::High));
 }
 
 #[tokio::test]

--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -326,6 +326,9 @@ impl LocalAgentHandle {
                 })?;
 
             let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+            let reasoning_effort = profile_handle
+                .session_reasoning_effort(&session_ref, &session_id)
+                .await;
             let profile_list = profiles.list_profiles().await.map_err(|err| {
                 Error::internal_error().data(serde_json::json!({
                     "message": format_prefixed_error_chain("Failed to list profiles", &err),
@@ -333,7 +336,7 @@ impl LocalAgentHandle {
             })?;
             let config_options = crate::agent::session_registry::config_options_with_profiles(
                 current_mode,
-                **profile_handle.config.default_reasoning_effort.load(),
+                reasoning_effort,
                 Some(profile_id.as_str()),
                 &profile_list,
             );
@@ -369,15 +372,14 @@ impl LocalAgentHandle {
             .finalize_session(&prepared, bridge)
             .await?;
 
-        // Get current mode for response
+        // Get current per-session settings for the response.
         let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+        let reasoning_effort = self
+            .session_reasoning_effort(&session_ref, &session_id)
+            .await;
 
         let config_options = self
-            .session_config_options(
-                Some(&session_id),
-                current_mode,
-                **self.config.default_reasoning_effort.load(),
-            )
+            .session_config_options(Some(&session_id), current_mode, reasoning_effort)
             .await?;
 
         Ok(NewSessionResponse::new(session_id)
@@ -453,6 +455,9 @@ impl LocalAgentHandle {
                 }
             };
             let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+            let reasoning_effort = profile_handle
+                .session_reasoning_effort(&session_ref, &session_id)
+                .await;
             let profile_list = profiles.list_profiles().await.map_err(|err| {
                 Error::internal_error().data(serde_json::json!({
                     "message": format_prefixed_error_chain("Failed to list profiles", &err),
@@ -460,7 +465,7 @@ impl LocalAgentHandle {
             })?;
             let config_options = crate::agent::session_registry::config_options_with_profiles(
                 current_mode,
-                **profile_handle.config.default_reasoning_effort.load(),
+                reasoning_effort,
                 Some(binding.profile_id.as_str()),
                 &profile_list,
             );
@@ -482,14 +487,13 @@ impl LocalAgentHandle {
         };
 
         if let Some(session_ref) = existing_session_ref {
-            // Registry lock is now dropped, safe to make async actor call
+            // Registry lock is now dropped, safe to make async actor calls.
             let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+            let reasoning_effort = self
+                .session_reasoning_effort(&session_ref, &session_id)
+                .await;
             let config_options = self
-                .session_config_options(
-                    Some(&session_id),
-                    current_mode,
-                    **self.config.default_reasoning_effort.load(),
-                )
+                .session_config_options(Some(&session_id), current_mode, reasoning_effort)
                 .await?;
             let mut response = LoadSessionResponse::new()
                 .modes(crate::agent::session_registry::mode_state(current_mode))
@@ -528,15 +532,14 @@ impl LocalAgentHandle {
                 .await?;
         }
 
-        // Get current mode for response
+        // Get current per-session settings for the response.
         let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+        let reasoning_effort = self
+            .session_reasoning_effort(&session_ref, &session_id)
+            .await;
 
         let config_options = self
-            .session_config_options(
-                Some(&session_id),
-                current_mode,
-                **self.config.default_reasoning_effort.load(),
-            )
+            .session_config_options(Some(&session_id), current_mode, reasoning_effort)
             .await?;
 
         let mut response = LoadSessionResponse::new()

--- a/crates/agent/src/agent/handle/send_agent_config.rs
+++ b/crates/agent/src/agent/handle/send_agent_config.rs
@@ -94,7 +94,9 @@ impl LocalAgentHandle {
                 session_ref.set_session_model_with_node(msg).await?;
 
                 let mode = session_ref.get_mode().await.unwrap_or(AgentMode::Build);
-                let effort = session_ref.get_reasoning_effort().await.ok().flatten();
+                let effort = self
+                    .session_reasoning_effort(&session_ref, &session_id)
+                    .await;
 
                 let config_options = self
                     .session_config_options(Some(&session_id), mode, effort)
@@ -142,7 +144,9 @@ impl LocalAgentHandle {
 
                 let session_ref = self.session_ref_for_agent_session(&session_id).await?;
                 let mode = session_ref.get_mode().await.unwrap_or(AgentMode::Build);
-                let effort = session_ref.get_reasoning_effort().await.ok().flatten();
+                let effort = self
+                    .session_reasoning_effort(&session_ref, &session_id)
+                    .await;
                 let config_options = self
                     .session_config_options(Some(&session_id), mode, effort)
                     .await?;
@@ -159,7 +163,9 @@ impl LocalAgentHandle {
                 let session_ref = self.session_ref_for_agent_session(&session_id).await?;
                 session_ref.set_mode(mode).await.map_err(Error::from)?;
 
-                let effort = session_ref.get_reasoning_effort().await.ok().flatten();
+                let effort = self
+                    .session_reasoning_effort(&session_ref, &session_id)
+                    .await;
                 let config_options = self
                     .session_config_options(Some(&session_id), mode, effort)
                     .await?;

--- a/crates/agent/src/agent/handle/send_agent_lifecycle.rs
+++ b/crates/agent/src/agent/handle/send_agent_lifecycle.rs
@@ -119,7 +119,7 @@ impl LocalAgentHandle {
         };
 
         if let Some(existing_ref) = existing_actor_ref {
-            // Registry lock is now dropped, safe to make async actor call
+            // Registry lock is now dropped, safe to make async actor calls.
             let current_mode = existing_ref
                 .ask(crate::agent::messages::GetMode)
                 .mailbox_timeout(std::time::Duration::from_secs(10))
@@ -127,13 +127,13 @@ impl LocalAgentHandle {
                 .send()
                 .await
                 .map_err(|e| Error::internal_error().data(e.to_string()))?;
+            let session_ref = SessionActorRef::from(existing_ref);
+            let reasoning_effort = self
+                .session_reasoning_effort(&session_ref, &session_id)
+                .await;
 
             let config_options = self
-                .session_config_options(
-                    Some(&session_id),
-                    current_mode,
-                    **self.config.default_reasoning_effort.load(),
-                )
+                .session_config_options(Some(&session_id), current_mode, reasoning_effort)
                 .await?;
             return Ok(ResumeSessionResponse::new()
                 .modes(crate::agent::session_registry::mode_state(current_mode))
@@ -168,15 +168,14 @@ impl LocalAgentHandle {
                 .await?;
         }
 
-        // Get current mode for response
+        // Get current per-session settings for the response.
         let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+        let reasoning_effort = self
+            .session_reasoning_effort(&session_ref, &session_id)
+            .await;
 
         let config_options = self
-            .session_config_options(
-                Some(&session_id),
-                current_mode,
-                **self.config.default_reasoning_effort.load(),
-            )
+            .session_config_options(Some(&session_id), current_mode, reasoning_effort)
             .await?;
 
         Ok(ResumeSessionResponse::new()

--- a/crates/agent/src/agent/handle/session_config.rs
+++ b/crates/agent/src/agent/handle/session_config.rs
@@ -1,6 +1,24 @@
 use super::*;
 
 impl LocalAgentHandle {
+    pub(super) async fn session_reasoning_effort(
+        &self,
+        session_ref: &crate::agent::remote::SessionActorRef,
+        session_id: &str,
+    ) -> Option<querymt::chat::ReasoningEffort> {
+        match session_ref.get_reasoning_effort().await {
+            Ok(effort) => effort,
+            Err(err) => {
+                tracing::warn!(
+                    session_id,
+                    error = %err,
+                    "failed to get session reasoning effort; using initial config"
+                );
+                self.config.provider.initial_config().reasoning_effort
+            }
+        }
+    }
+
     /// Switch provider and model for a session (simple form)
     pub async fn set_provider(
         &self,

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -412,6 +412,96 @@ async fn test_set_profile_config_option_rejects_different_bound_profile() {
 }
 
 #[tokio::test]
+async fn test_load_session_reports_persisted_reasoning_effort() {
+    let f = RealStorageHandleFixture::new().await;
+    let session_id = seed_session_with_reasoning(&f, Some(ReasoningEffort::High)).await;
+    let req = crate::acp::protocol::LoadSessionRequest::new(
+        SessionId::from(session_id),
+        std::path::PathBuf::new(),
+    );
+
+    let response = f.handle.load_session(req).await.expect("load session");
+
+    assert_eq!(
+        config_option_value(
+            response.config_options.as_deref().expect("config options"),
+            "reasoning_effort",
+        )
+        .as_deref(),
+        Some("high")
+    );
+}
+
+#[tokio::test]
+async fn test_load_session_reports_auto_when_reasoning_effort_is_unset() {
+    let f = RealStorageHandleFixture::new_with_initial_reasoning(Some(ReasoningEffort::Low)).await;
+    let session_id = seed_session_with_reasoning(&f, None).await;
+    let req = crate::acp::protocol::LoadSessionRequest::new(
+        SessionId::from(session_id),
+        std::path::PathBuf::new(),
+    );
+
+    let response = f.handle.load_session(req).await.expect("load session");
+
+    assert_eq!(
+        config_option_value(
+            response.config_options.as_deref().expect("config options"),
+            "reasoning_effort",
+        )
+        .as_deref(),
+        Some("auto")
+    );
+}
+
+#[tokio::test]
+async fn test_load_session_falls_back_to_initial_reasoning_when_config_is_missing() {
+    let f = RealStorageHandleFixture::new_with_initial_reasoning(Some(ReasoningEffort::Low)).await;
+    let session = f
+        .storage
+        .create_session(None, None, None, None)
+        .await
+        .expect("create session");
+    let req = crate::acp::protocol::LoadSessionRequest::new(
+        SessionId::from(session.public_id),
+        std::path::PathBuf::new(),
+    );
+
+    let response = f.handle.load_session(req).await.expect("load session");
+
+    assert_eq!(
+        config_option_value(
+            response.config_options.as_deref().expect("config options"),
+            "reasoning_effort",
+        )
+        .as_deref(),
+        Some("low")
+    );
+}
+
+#[tokio::test]
+async fn test_reasoning_query_failure_falls_back_to_initial_config() {
+    let f = RealStorageHandleFixture::new_with_initial_reasoning(Some(ReasoningEffort::Low)).await;
+    let actor = SessionActor::new(
+        f.handle.config.clone(),
+        "stopped-session".to_string(),
+        crate::agent::core::SessionRuntime::new(
+            None,
+            std::collections::HashMap::new(),
+            crate::agent::core::McpToolState::empty(),
+        ),
+    );
+    let session_ref = SessionActorRef::from(SessionActor::spawn(actor));
+    session_ref.shutdown().await.expect("shutdown actor");
+
+    assert_eq!(
+        f.handle
+            .session_reasoning_effort(&session_ref, "stopped-session")
+            .await,
+        Some(ReasoningEffort::Low)
+    );
+}
+
+#[tokio::test]
 async fn test_set_profile_config_option_accepts_same_bound_profile() {
     let (f, _profile_dir) = profile_fixture_with_files(&[("alpha.toml", ALPHA_PROFILE_TOML)]).await;
     register_bound_test_session(&f, "session-1", "alpha").await;

--- a/crates/agent/src/agent/handle/tests/mod.rs
+++ b/crates/agent/src/agent/handle/tests/mod.rs
@@ -15,6 +15,7 @@ use crate::test_utils::{
     empty_plugin_registry, mock_llm_config, mock_plugin_registry, mock_session,
 };
 use querymt::LLMParams;
+use querymt::chat::ReasoningEffort;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
@@ -300,6 +301,40 @@ fn select_option_values(option: &SessionConfigOption) -> Vec<String> {
         .collect()
 }
 
+fn config_option_value(options: &[SessionConfigOption], id: &str) -> Option<String> {
+    options
+        .iter()
+        .find(|option| option.id.0.as_ref() == id)
+        .and_then(|option| match &option.kind {
+            crate::acp::protocol::SessionConfigKind::Select(select) => {
+                Some(select.current_value.0.to_string())
+            }
+            _ => None,
+        })
+}
+
+async fn seed_session_with_reasoning(
+    fixture: &RealStorageHandleFixture,
+    effort: Option<ReasoningEffort>,
+) -> String {
+    let store = fixture.storage.session_store();
+    let session = store
+        .create_session(None, None, None, None)
+        .await
+        .expect("create session");
+    let mut params = LLMParams::new().provider("mock").model("mock-model");
+    params.reasoning_effort = effort;
+    let config = store
+        .create_or_get_llm_config(&params)
+        .await
+        .expect("create LLM config");
+    store
+        .set_session_llm_config(&session.public_id, config.id)
+        .await
+        .expect("set session LLM config");
+    session.public_id
+}
+
 fn test_profile_metadata(
     id: &str,
     name: &str,
@@ -320,6 +355,10 @@ fn test_profile_metadata(
 
 impl RealStorageHandleFixture {
     async fn new() -> Self {
+        Self::new_with_initial_reasoning(None).await
+    }
+
+    async fn new_with_initial_reasoning(reasoning_effort: Option<ReasoningEffort>) -> Self {
         let provider = Arc::new(Mutex::new(MockLlmProvider::new()));
         let shared = SharedLlmProvider {
             inner: provider,
@@ -334,12 +373,11 @@ impl RealStorageHandleFixture {
                 .expect("create storage"),
         );
 
-        let mut builder = AgentConfigBuilder::new(
-            Arc::new(plugin_registry),
-            storage.clone(),
-            LLMParams::new().provider("mock").model("mock-model"),
-        )
-        .with_tool_policy(ToolPolicy::ProviderOnly);
+        let mut initial_config = LLMParams::new().provider("mock").model("mock-model");
+        initial_config.reasoning_effort = reasoning_effort;
+        let mut builder =
+            AgentConfigBuilder::new(Arc::new(plugin_registry), storage.clone(), initial_config)
+                .with_tool_policy(ToolPolicy::ProviderOnly);
 
         if let Some(repo) = storage.schedule_repository() {
             builder = builder.with_schedule_repository(repo);

--- a/crates/agent/src/agent/remote/remote_handle.rs
+++ b/crates/agent/src/agent/remote/remote_handle.rs
@@ -43,6 +43,24 @@ pub struct RemoteAgentHandle {
 }
 
 impl RemoteAgentHandle {
+    async fn session_reasoning_effort(
+        &self,
+        session_ref: &SessionActorRef,
+        session_id: &str,
+    ) -> Option<querymt::chat::ReasoningEffort> {
+        match session_ref.get_reasoning_effort().await {
+            Ok(effort) => effort,
+            Err(err) => {
+                tracing::warn!(
+                    session_id,
+                    error = %err,
+                    "failed to get remote session reasoning effort; falling back to Auto"
+                );
+                None
+            }
+        }
+    }
+
     /// Create a new `RemoteAgentHandle` for a remote peer.
     pub fn new(peer_label: String, target_node_id: Option<String>, mesh: MeshHandle) -> Self {
         Self {
@@ -341,11 +359,14 @@ impl AgentHandle for RemoteAgentHandle {
 
         if let Some(session_ref) = self.sessions.lock().await.get(&session_id).cloned() {
             let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+            let reasoning_effort = self
+                .session_reasoning_effort(&session_ref, &session_id)
+                .await;
             return Ok(LoadSessionResponse::new()
                 .modes(crate::agent::session_registry::mode_state(current_mode))
                 .config_options(crate::agent::session_registry::config_options(
                     current_mode,
-                    None,
+                    reasoning_effort,
                 )));
         }
 
@@ -364,12 +385,15 @@ impl AgentHandle for RemoteAgentHandle {
             .attach_handoff_session(&session_id, response.handoff)
             .await?;
         let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+        let reasoning_effort = self
+            .session_reasoning_effort(&session_ref, &session_id)
+            .await;
 
         Ok(LoadSessionResponse::new()
             .modes(crate::agent::session_registry::mode_state(current_mode))
             .config_options(crate::agent::session_registry::config_options(
                 current_mode,
-                None,
+                reasoning_effort,
             )))
     }
 

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -381,6 +381,12 @@ impl SessionActor {
         }
     }
 
+    /// Override the reasoning effort restored for this session.
+    pub fn with_reasoning_effort(mut self, effort: Option<ReasoningEffort>) -> Self {
+        self.reasoning_effort = effort;
+        self
+    }
+
     /// Attach a [`MeshHandle`] to this actor (builder pattern, for remote sessions).
     ///
     /// Called by `RemoteNodeManager` after `new()` so the `SubscribeEvents`

--- a/crates/agent/src/agent/session_materializer.rs
+++ b/crates/agent/src/agent/session_materializer.rs
@@ -776,9 +776,52 @@ impl SessionMaterializer {
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
         }
 
+        let initial_reasoning_effort = self.config.provider.initial_config().reasoning_effort;
+        let reasoning_effort = match self
+            .config
+            .provider
+            .history_store()
+            .get_session_llm_config(&session_id)
+            .await
+        {
+            Ok(Some(config)) => match config
+                .params
+                .as_ref()
+                .and_then(|params| params.get("reasoning_effort"))
+            {
+                Some(value) => match serde_json::from_value(value.clone()) {
+                    Ok(effort) => Some(effort),
+                    Err(err) => {
+                        tracing::warn!(
+                            session_id,
+                            error = %err,
+                            "invalid persisted reasoning effort; using initial config"
+                        );
+                        initial_reasoning_effort
+                    }
+                },
+                None => None,
+            },
+            Ok(None) => {
+                tracing::warn!(
+                    session_id,
+                    "session LLM config missing; using initial reasoning config"
+                );
+                initial_reasoning_effort
+            }
+            Err(err) => {
+                tracing::warn!(
+                    session_id,
+                    error = %err,
+                    "failed to load persisted reasoning effort; using initial config"
+                );
+                initial_reasoning_effort
+            }
+        };
         let runtime = SessionRuntime::new(cwd.clone(), mcp_services, tool_state);
         #[cfg(feature = "remote")]
         let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
+            .with_reasoning_effort(reasoning_effort)
             .with_mesh(if _options.attach_mesh_handle {
                 // Use the mesh handle from the materializer's shared state
                 self.mesh()
@@ -786,7 +829,8 @@ impl SessionMaterializer {
                 None
             });
         #[cfg(not(feature = "remote"))]
-        let actor = { SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone()) };
+        let actor = SessionActor::new(self.config.clone(), session_id.clone(), runtime.clone())
+            .with_reasoning_effort(reasoning_effort);
         let actor_ref = SessionActor::spawn(actor);
 
         // Bridge will be set during registration if available

--- a/crates/agent/src/agent/session_registry.rs
+++ b/crates/agent/src/agent/session_registry.rs
@@ -888,21 +888,27 @@ impl SessionRegistry {
                 .emit_event(&session_id, crate::events::AgentEventKind::SessionCreated);
         }
 
-        let current_mode = {
-            let session_ref = self
-                .sessions
-                .get(&session_id)
-                .ok_or_else(|| Error::internal_error().data("session actor missing after resume"))?
-                .clone();
-            session_ref.get_mode().await.map_err(Error::from)?
+        let session_ref = self
+            .sessions
+            .get(&session_id)
+            .ok_or_else(|| Error::internal_error().data("session actor missing after resume"))?
+            .clone();
+        let current_mode = session_ref.get_mode().await.map_err(Error::from)?;
+        let reasoning_effort = match session_ref.get_reasoning_effort().await {
+            Ok(effort) => effort,
+            Err(err) => {
+                tracing::warn!(
+                    session_id,
+                    error = %err,
+                    "failed to get session reasoning effort; using initial config"
+                );
+                self.config.provider.initial_config().reasoning_effort
+            }
         };
 
         Ok(crate::acp::protocol::ResumeSessionResponse::new()
             .modes(mode_state(current_mode))
-            .config_options(config_options(
-                current_mode,
-                **self.config.default_reasoning_effort.load(),
-            )))
+            .config_options(config_options(current_mode, reasoning_effort)))
     }
 
     /// List all sessions (queries the store, not the actors).

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -12,7 +12,7 @@ use crate::tools::ToolRegistry;
 use crate::verification::VerificationSpec;
 use crate::verification::service::{VerificationContext, VerificationService};
 use log::{debug, error, warn};
-use querymt::chat::ChatRole;
+use querymt::chat::{ChatRole, ReasoningEffort};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -437,6 +437,20 @@ struct DelegationFailureContext<'a> {
 /// This creates sessions via `AgentHandle::create_delegation_session()`. History and
 /// planning context are exchanged via kameo messages (`GetHistory`,
 /// `SetPlanningContext`), so this path works for both local and remote sessions.
+fn reasoning_effort_from_llm_config(
+    config: &crate::session::store::LLMConfig,
+) -> Result<Option<ReasoningEffort>, serde_json::Error> {
+    let Some(value) = config
+        .params
+        .as_ref()
+        .and_then(|params| params.get("reasoning_effort"))
+    else {
+        return Ok(None);
+    };
+
+    serde_json::from_value(value.clone())
+}
+
 #[instrument(
     name = "delegation.execute",
     skip(ctx, target, cancel_token),
@@ -497,6 +511,83 @@ async fn execute_delegation(
     {
         warn!("Failed to update delegation status to Running: {}", e);
     }
+
+    // Snapshot the parent's current per-session setting. UI changes persist this value
+    // before returning, so delegation inherits the value active when it starts.
+    let parent_reasoning_effort = match ctx.store.get_session_llm_config(&parent_session_id).await {
+        Ok(Some(config)) => match reasoning_effort_from_llm_config(&config) {
+            Ok(effort) => effort,
+            Err(err) => {
+                let error_message = format!(
+                    "Failed to read reasoning effort from parent session '{}': {err}",
+                    parent_session_id
+                );
+                fail_delegation(
+                    DelegationFailureContext {
+                        event_sink: &ctx.event_sink,
+                        delegator: &ctx.delegator,
+                        store: &ctx.store,
+                        hooks: Some(&ctx.hooks),
+                        config: &ctx.config,
+                        parent_session_id: &parent_session_id,
+                        delegation_id: &delegation.public_id,
+                        target_agent_id: Some(&delegation.target_agent_id),
+                        objective: Some(&delegation.objective),
+                    },
+                    &error_message,
+                )
+                .await;
+                ctx.active_delegations.lock().await.remove(&delegation_id);
+                return;
+            }
+        },
+        Ok(None) => {
+            let error_message = format!(
+                "Parent session '{}' has no LLM configuration",
+                parent_session_id
+            );
+            fail_delegation(
+                DelegationFailureContext {
+                    event_sink: &ctx.event_sink,
+                    delegator: &ctx.delegator,
+                    store: &ctx.store,
+                    hooks: Some(&ctx.hooks),
+                    config: &ctx.config,
+                    parent_session_id: &parent_session_id,
+                    delegation_id: &delegation.public_id,
+                    target_agent_id: Some(&delegation.target_agent_id),
+                    objective: Some(&delegation.objective),
+                },
+                &error_message,
+            )
+            .await;
+            ctx.active_delegations.lock().await.remove(&delegation_id);
+            return;
+        }
+        Err(err) => {
+            let error_message = format!(
+                "Failed to load LLM configuration for parent session '{}': {err}",
+                parent_session_id
+            );
+            fail_delegation(
+                DelegationFailureContext {
+                    event_sink: &ctx.event_sink,
+                    delegator: &ctx.delegator,
+                    store: &ctx.store,
+                    hooks: Some(&ctx.hooks),
+                    config: &ctx.config,
+                    parent_session_id: &parent_session_id,
+                    delegation_id: &delegation.public_id,
+                    target_agent_id: Some(&delegation.target_agent_id),
+                    objective: Some(&delegation.objective),
+                },
+                &error_message,
+            )
+            .await;
+            ctx.active_delegations.lock().await.remove(&delegation_id);
+            return;
+        }
+    };
 
     // 1. Create session via AgentHandle trait
     // Prefer parent session's cwd over orchestrator default
@@ -659,6 +750,36 @@ async fn execute_delegation(
             ctx.active_delegations.lock().await.remove(&delegation_id);
             return;
         }
+    }
+
+    // Apply this after any model override because SetSessionModel rebuilds the
+    // child's LLM configuration. None deliberately propagates the parent's Auto setting.
+    if let Err(err) = session_ref
+        .set_reasoning_effort(parent_reasoning_effort)
+        .await
+    {
+        let error_message = format!(
+            "Failed to inherit reasoning effort for delegate '{}': {err}",
+            delegation.target_agent_id
+        );
+        let _ = session_ref.shutdown().await;
+        fail_delegation(
+            DelegationFailureContext {
+                event_sink: &ctx.event_sink,
+                delegator: &ctx.delegator,
+                store: &ctx.store,
+                hooks: Some(&ctx.hooks),
+                config: &ctx.config,
+                parent_session_id: &parent_session_id,
+                delegation_id: &delegation.public_id,
+                target_agent_id: Some(&delegation.target_agent_id),
+                objective: Some(&delegation.objective),
+            },
+            &error_message,
+        )
+        .await;
+        ctx.active_delegations.lock().await.remove(&delegation_id);
+        return;
     }
 
     emit_delegation_event(


### PR DESCRIPTION
## Summary

- inherit the parent session's current reasoning effort when creating delegated sessions
- restore persisted per-session reasoning effort when materializing sessions
- report the live reasoning effort through local and remote ACP lifecycle responses
- fall back to the profile/delegate initial config, then Auto, while retaining warning logs

