### PR TITLE
fix(agent): paginate ACP sessions by workspace

### DIFF
--- a/crates/agent/src/agent/handle/send_agent_lifecycle.rs
+++ b/crates/agent/src/agent/handle/send_agent_lifecycle.rs
@@ -88,7 +88,14 @@ impl LocalAgentHandle {
             .ok_or_else(|| Error::internal_error().data("view store unavailable"))?;
         let page = crate::api::AgentSessions::list_for_acp_with_runtime(self, view_store, req)
             .await
-            .map_err(|e| Error::internal_error().data(e.to_string()))?;
+            .map_err(|error| match error {
+                crate::api::AcpSessionListError::InvalidCursor => {
+                    Error::invalid_params().data("invalid session list cursor")
+                }
+                crate::api::AcpSessionListError::Backend(error) => {
+                    Error::internal_error().data(error.to_string())
+                }
+            })?;
         Ok(ListSessionsResponse::new(page.sessions).next_cursor(page.next_cursor))
     }
 

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -187,25 +187,98 @@ async fn test_list_sessions_empty() {
 }
 
 #[tokio::test]
-async fn test_list_sessions_filters_by_cwd() {
-    let cwd_a = std::env::temp_dir().join("querymt-list-sessions-a");
-    let cwd_b = std::env::temp_dir().join("querymt-list-sessions-b");
+async fn test_list_sessions_cwd_pagination_and_cursor_errors() {
+    let f = RealStorageHandleFixture::new().await;
+    let workspace = std::env::temp_dir().join("querymt-list-sessions-workspace");
+    let other_workspace = std::env::temp_dir().join("querymt-list-sessions-other-workspace");
+    let session_store = f.storage.session_store();
+    let mut workspace_session_ids = HashSet::new();
 
-    let mut session_a = mock_session("session-a");
-    session_a.cwd = Some(cwd_a.clone());
-    let mut session_b = mock_session("session-b");
-    session_b.cwd = Some(cwd_b.clone());
+    for index in 0..12 {
+        let session = session_store
+            .create_session(
+                Some(format!("Workspace Session {index}")),
+                Some(workspace.clone()),
+                None,
+                None,
+            )
+            .await
+            .expect("create workspace session");
+        workspace_session_ids.insert(session.public_id);
+    }
+    for index in 0..2 {
+        session_store
+            .create_session(
+                Some(format!("Other Workspace Session {index}")),
+                Some(other_workspace.clone()),
+                None,
+                None,
+            )
+            .await
+            .expect("create other workspace session");
+    }
 
-    let f = HandleFixture::with_list_sessions(vec![session_a, session_b]).await;
-
-    let resp = f
+    let first_page = f
         .handle
-        .list_sessions(ListSessionsRequest::new().cwd(cwd_a.clone()))
+        .list_sessions(ListSessionsRequest::new().cwd(workspace.clone()))
         .await
-        .expect("list_sessions filtered by cwd");
+        .expect("list first workspace page");
+    assert_eq!(first_page.sessions.len(), 10);
+    assert!(
+        first_page
+            .sessions
+            .iter()
+            .all(|session| session.cwd == workspace)
+    );
+    let first_page_ids: HashSet<_> = first_page
+        .sessions
+        .iter()
+        .map(|session| session.session_id.to_string())
+        .collect();
+    assert_eq!(first_page_ids.len(), 10);
+    let next_cursor = first_page
+        .next_cursor
+        .expect("workspace page should continue");
 
-    assert_eq!(resp.sessions.len(), 1);
-    assert_eq!(resp.sessions[0].cwd, cwd_a);
+    let second_page = f
+        .handle
+        .list_sessions(
+            ListSessionsRequest::new()
+                .cwd(workspace.clone())
+                .cursor(next_cursor),
+        )
+        .await
+        .expect("list second workspace page");
+    assert_eq!(second_page.sessions.len(), 2);
+    assert!(
+        second_page
+            .sessions
+            .iter()
+            .all(|session| session.cwd == workspace)
+    );
+    let second_page_ids: HashSet<_> = second_page
+        .sessions
+        .iter()
+        .map(|session| session.session_id.to_string())
+        .collect();
+    assert!(first_page_ids.is_disjoint(&second_page_ids));
+    assert_eq!(
+        first_page_ids
+            .union(&second_page_ids)
+            .cloned()
+            .collect::<HashSet<_>>(),
+        workspace_session_ids
+    );
+    assert!(second_page.next_cursor.is_none());
+
+    for cursor in ["not-a-number", "9223372036854775808"] {
+        let error = f
+            .handle
+            .list_sessions(ListSessionsRequest::new().cursor(cursor))
+            .await
+            .expect_err("invalid ACP cursor should fail");
+        assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
+    }
 }
 
 #[tokio::test]

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -247,16 +247,15 @@ async fn acp_list_sessions_orders_by_updated_at_and_paginates() -> Result<()> {
     );
     assert!(cursor_page.next_cursor.is_none());
 
-    let invalid_cursor_page = AgentSessions::list_for_acp_from_view_store(
+    let invalid_cursor_error = AgentSessions::list_for_acp_from_view_store(
         view_store.clone(),
         AcpListSessionsRequest::new().cursor("not-a-number"),
     )
-    .await?;
-    assert_eq!(invalid_cursor_page.total_count, 2);
-    assert_eq!(invalid_cursor_page.sessions.len(), 2);
+    .await
+    .expect_err("invalid ACP cursors must be rejected");
     assert_eq!(
-        invalid_cursor_page.sessions[0].session_id.to_string(),
-        second.public_id
+        invalid_cursor_error.to_string(),
+        "invalid session list cursor"
     );
 
     let untitled = session_store
@@ -305,6 +304,104 @@ async fn acp_list_sessions_orders_by_updated_at_and_paginates() -> Result<()> {
         intent_info.title.as_deref(),
         Some("This title comes from the initial intent snapshot and should be truncated if ...")
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn acp_list_sessions_pages_workspace_sessions_without_cross_workspace_leaks() -> Result<()> {
+    let agent = test_agent().await?;
+    let session_store = agent.storage_backend().session_store();
+    let workspace = PathBuf::from("/tmp/acp-workspace");
+    let other_workspace = PathBuf::from("/tmp/acp-other-workspace");
+    let mut workspace_session_ids = Vec::new();
+
+    for index in 0..12 {
+        let session = session_store
+            .create_session(
+                Some(format!("Workspace Session {index}")),
+                Some(workspace.clone()),
+                None,
+                None,
+            )
+            .await?;
+        workspace_session_ids.push(session.public_id);
+    }
+    for index in 0..90 {
+        session_store
+            .create_session(
+                Some(format!("Other Workspace Session {index}")),
+                Some(other_workspace.clone()),
+                None,
+                None,
+            )
+            .await?;
+    }
+
+    let view_store = agent.storage_backend().view_store().expect("view store");
+    let first_page = AgentSessions::list_for_acp_from_view_store(
+        view_store.clone(),
+        AcpListSessionsRequest::new().cwd(workspace.clone()),
+    )
+    .await?;
+    assert_eq!(first_page.total_count, 12);
+    assert_eq!(first_page.sessions.len(), 10);
+    assert!(
+        first_page
+            .sessions
+            .iter()
+            .all(|session| session.cwd == workspace)
+    );
+    assert_eq!(
+        first_page
+            .sessions
+            .iter()
+            .map(|session| session.session_id.to_string())
+            .collect::<Vec<_>>(),
+        workspace_session_ids[2..]
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>(),
+    );
+    let next_cursor = first_page
+        .next_cursor
+        .expect("workspace page should continue");
+
+    let second_page = AgentSessions::list_for_acp_from_view_store(
+        view_store.clone(),
+        AcpListSessionsRequest::new()
+            .cwd(workspace.clone())
+            .cursor(next_cursor),
+    )
+    .await?;
+    assert_eq!(second_page.total_count, 12);
+    assert_eq!(second_page.sessions.len(), 2);
+    assert!(
+        second_page
+            .sessions
+            .iter()
+            .all(|session| session.cwd == workspace)
+    );
+    assert_eq!(
+        second_page
+            .sessions
+            .iter()
+            .map(|session| session.session_id.to_string())
+            .collect::<Vec<_>>(),
+        workspace_session_ids[..2]
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>(),
+    );
+    assert!(second_page.next_cursor.is_none());
+
+    let unfiltered =
+        AgentSessions::list_for_acp_from_view_store(view_store, AcpListSessionsRequest::new())
+            .await?;
+    assert_eq!(unfiltered.total_count, 102);
+    assert_eq!(unfiltered.sessions.len(), 100);
+    assert_eq!(unfiltered.next_cursor.as_deref(), Some("100"));
     Ok(())
 }
 

--- a/crates/agent/src/api/mod.rs
+++ b/crates/agent/src/api/mod.rs
@@ -74,6 +74,7 @@ pub use mesh::{AgentMesh, Mesh, MeshJoinOutcome, MeshRuntime, MeshSpec};
 pub use profiles::{AgentProfiles, ProfileRuntimeHandle};
 pub use quorum::QuorumBuilder;
 pub use session::AgentSession;
+pub(crate) use sessions::AcpSessionListError;
 pub use sessions::{
     AgentLoadedSession, AgentSessions, ListSessionsOptions, RemoteSessionMode, SessionChildrenPage,
     SessionGroup, SessionListMode, SessionListPage, SessionMeta, SessionSummary,

--- a/crates/agent/src/api/sessions.rs
+++ b/crates/agent/src/api/sessions.rs
@@ -101,6 +101,36 @@ pub struct AcpSessionListPage {
     pub total_count: u64,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AcpSessionListError {
+    #[error("invalid session list cursor")]
+    InvalidCursor,
+    #[error(transparent)]
+    Backend(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AcpSessionCursor(i64);
+
+impl AcpSessionCursor {
+    fn parse(cursor: Option<&str>) -> std::result::Result<Option<Self>, AcpSessionListError> {
+        cursor
+            .map(|cursor| {
+                cursor
+                    .parse::<i64>()
+                    .ok()
+                    .filter(|offset| *offset >= 0)
+                    .map(Self)
+                    .ok_or(AcpSessionListError::InvalidCursor)
+            })
+            .transpose()
+    }
+
+    fn into_string(self) -> String {
+        self.0.to_string()
+    }
+}
+
 #[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionMeta {
@@ -238,14 +268,16 @@ impl AgentSessions {
         &self,
         request: AcpListSessionsRequest,
     ) -> Result<AcpSessionListPage> {
-        Self::list_for_acp_with_runtime(&self.agent, self.view_store()?, request).await
+        Self::list_for_acp_with_runtime(&self.agent, self.view_store()?, request)
+            .await
+            .map_err(anyhow::Error::from)
     }
 
     pub(crate) async fn list_for_acp_with_runtime(
         agent: &LocalAgentHandle,
         view_store: Arc<dyn ViewStore>,
         request: AcpListSessionsRequest,
-    ) -> Result<AcpSessionListPage> {
+    ) -> std::result::Result<AcpSessionListPage, AcpSessionListError> {
         let mut page = Self::list_for_acp_from_view_store(view_store.clone(), request).await?;
         Self::hydrate_acp_session_meta(agent, view_store, &mut page.sessions).await?;
         Ok(page)
@@ -254,13 +286,21 @@ impl AgentSessions {
     pub(crate) async fn list_for_acp_from_view_store(
         view_store: Arc<dyn ViewStore>,
         request: AcpListSessionsRequest,
-    ) -> Result<AcpSessionListPage> {
+    ) -> std::result::Result<AcpSessionListPage, AcpSessionListError> {
+        let cursor = AcpSessionCursor::parse(request.cursor.as_deref())?;
         let requested_cwd = request.cwd.map(|cwd| cwd.display().to_string());
-        let limit = 100usize;
+        // ACP workspace requests load incrementally; global discovery remains a larger flat page.
+        let limit = if requested_cwd.is_some() { 10 } else { 100 };
 
         let (sessions, next_cursor, total_count) = view_store
-            .list_session_items(requested_cwd, request.cursor, limit, SessionScope::All)
-            .await?;
+            .list_session_items(
+                requested_cwd,
+                cursor.map(AcpSessionCursor::into_string),
+                limit,
+                SessionScope::All,
+            )
+            .await
+            .map_err(anyhow::Error::from)?;
 
         Ok(AcpSessionListPage {
             sessions: sessions

--- a/crates/agent/src/session/sqlite_storage/view_store.rs
+++ b/crates/agent/src/session/sqlite_storage/view_store.rs
@@ -1007,7 +1007,8 @@ impl ViewStore for SqliteStorage {
     ) -> SessionResult<(Vec<SessionListItem>, Option<String>, usize)> {
         let offset = cursor
             .as_deref()
-            .and_then(|c| c.parse::<usize>().ok())
+            .and_then(|cursor| cursor.parse::<i64>().ok())
+            .filter(|offset| *offset >= 0)
             .unwrap_or(0);
         let limit = limit.clamp(1, 200);
         let scope_where = session_scope_where(session_scope, "s");
@@ -1046,7 +1047,7 @@ impl ViewStore for SqliteStorage {
                     LEFT JOIN intent_snapshots i
                         ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
                     WHERE s.cwd = ?1 AND {}
-                    ORDER BY s.updated_at DESC
+                    ORDER BY s.updated_at DESC, s.id DESC
                     LIMIT ?2 OFFSET ?3
                     "#,
                     scope_where
@@ -1070,7 +1071,7 @@ impl ViewStore for SqliteStorage {
                     LEFT JOIN intent_snapshots i
                         ON i.id = (SELECT MIN(id) FROM intent_snapshots WHERE session_id = s.id)
                     WHERE {}
-                    ORDER BY s.updated_at DESC
+                    ORDER BY s.updated_at DESC, s.id DESC
                     LIMIT ?1 OFFSET ?2
                     "#,
                     scope_where
@@ -1078,18 +1079,16 @@ impl ViewStore for SqliteStorage {
             };
 
             let sessions = if let Some(ref cwd_value) = cwd {
-                stmt.query_map(params![cwd_value, limit as i64, offset as i64], map_session_list_item_row)?
+                stmt.query_map(params![cwd_value, limit as i64, offset], map_session_list_item_row)?
                     .collect::<Result<Vec<_>, _>>()?
             } else {
-                stmt.query_map(params![limit as i64, offset as i64], map_session_list_item_row)?
+                stmt.query_map(params![limit as i64, offset], map_session_list_item_row)?
                     .collect::<Result<Vec<_>, _>>()?
             };
 
-            let next_cursor = if offset + sessions.len() < total_count {
-                Some((offset + sessions.len()).to_string())
-            } else {
-                None
-            };
+            let next_cursor = offset.checked_add(sessions.len() as i64).and_then(|next_offset| {
+                (usize::try_from(next_offset).ok()? < total_count).then_some(next_offset.to_string())
+            });
 
             Ok((sessions, next_cursor, total_count))
         })


### PR DESCRIPTION
## What changed

- limit cwd-filtered ACP `session/list` responses to 10 sessions while preserving the 100-session global discovery page
- validate cursors and report malformed or out-of-range values as ACP `InvalidParams`
- make session ordering deterministic with an ID tie-breaker and safe cursor arithmetic
- add API and real-handler coverage for workspace isolation, pagination, terminal cursors, and global discovery

## Why

ACP clients group sessions by `cwd` and paginate a selected workspace with `session/list { cwd, cursor }`. Returning one global page of 100 made workspace counts reflect only that mixed page and prevented reliable per-workspace loading.

## Validation

- `cargo check -p querymt-agent`
- `cargo fmt --all -- --check`
- targeted ACP handler and API session-list tests
- `git diff --check`
