### PR TITLE
feat: expose session relationships in ACP metadata

### DIFF
--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -470,7 +470,10 @@ async fn acp_session_list_includes_relationship_and_operational_meta() -> Result
         .meta
         .as_ref()
         .expect("parent ACP session meta should be set");
-    assert_eq!(parent_meta.get("hasChildren"), Some(&serde_json::json!(true)));
+    assert_eq!(
+        parent_meta.get("hasChildren"),
+        Some(&serde_json::json!(true))
+    );
     assert_eq!(parent_meta.get("forkCount"), Some(&serde_json::json!(1)));
     assert!(!parent_meta.contains_key("parentSessionId"));
     assert!(!parent_meta.contains_key("forkOrigin"));
@@ -489,14 +492,26 @@ async fn acp_session_list_includes_relationship_and_operational_meta() -> Result
         child_meta.get("parentSessionId"),
         Some(&serde_json::json!(parent.public_id))
     );
-    assert_eq!(child_meta.get("forkOrigin"), Some(&serde_json::json!("user")));
-    assert_eq!(child_meta.get("hasChildren"), Some(&serde_json::json!(false)));
+    assert_eq!(
+        child_meta.get("forkOrigin"),
+        Some(&serde_json::json!("user"))
+    );
+    assert_eq!(
+        child_meta.get("hasChildren"),
+        Some(&serde_json::json!(false))
+    );
     assert_eq!(child_meta.get("forkCount"), Some(&serde_json::json!(0)));
     assert!(!child_meta.contains_key("sessionKind"));
     assert_eq!(child_meta.get("messageCount"), Some(&serde_json::json!(2)));
-    assert_eq!(child_meta.get("userMessageCount"), Some(&serde_json::json!(1)));
+    assert_eq!(
+        child_meta.get("userMessageCount"),
+        Some(&serde_json::json!(1))
+    );
     assert_eq!(child_meta.get("hasErrors"), Some(&serde_json::json!(true)));
-    assert_eq!(child_meta.get("runtimeStatus"), Some(&serde_json::json!("idle")));
+    assert_eq!(
+        child_meta.get("runtimeStatus"),
+        Some(&serde_json::json!("idle"))
+    );
     Ok(())
 }
 

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -515,6 +515,52 @@ async fn acp_session_list_includes_relationship_and_operational_meta() -> Result
     Ok(())
 }
 
+#[tokio::test]
+async fn acp_session_list_marks_scheduled_recurring_session() -> Result<()> {
+    let storage =
+        Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
+    let agent = test_agent_with_storage(Some(storage.clone())).await?;
+    let session = storage
+        .session_store()
+        .create_session(
+            Some("Scheduled Session".to_string()),
+            Some("/tmp/scheduled".into()),
+            None,
+            None,
+        )
+        .await?;
+
+    crate::control::schedules::create_schedule(
+        &agent.handle(),
+        crate::control::schedules::CreateScheduleControlRequest {
+            node_id: None,
+            session_id: session.public_id.clone(),
+            prompt: "daily summary".to_string(),
+            trigger: crate::session::domain_schedule::ScheduleTrigger::Interval { seconds: 300 },
+            max_steps: None,
+            max_cost_usd: None,
+            max_runs: None,
+        },
+    )
+    .await?;
+
+    let page = agent
+        .sessions()
+        .list_for_acp(AcpListSessionsRequest::new())
+        .await?;
+    let info = page
+        .sessions
+        .iter()
+        .find(|info| info.session_id.to_string() == session.public_id)
+        .expect("scheduled session should be listed");
+    let meta = info.meta.as_ref().expect("ACP session meta should be set");
+    assert_eq!(
+        meta.get("sessionKind"),
+        Some(&serde_json::json!("recurring"))
+    );
+    Ok(())
+}
+
 #[cfg(feature = "remote")]
 #[tokio::test]
 async fn list_sessions_remote_bookmarks_mode_includes_detached_bookmarks() -> Result<()> {

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -406,35 +406,43 @@ async fn acp_list_sessions_pages_workspace_sessions_without_cross_workspace_leak
 }
 
 #[tokio::test]
-async fn acp_session_list_includes_meta_from_stats_and_finish_reason() -> Result<()> {
+async fn acp_session_list_includes_relationship_and_operational_meta() -> Result<()> {
     let storage =
         Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
     let agent = test_agent_with_storage(Some(storage.clone())).await?;
     let session_store = storage.session_store();
-    let session = session_store
+    let parent = session_store
         .create_session(
-            Some("Meta Session".to_string()),
+            Some("Parent Session".to_string()),
             Some("/tmp/meta".into()),
             None,
             None,
         )
         .await?;
+    let child = session_store
+        .create_session(
+            Some("Child Session".to_string()),
+            Some("/tmp/meta".into()),
+            Some(parent.public_id.clone()),
+            Some(crate::session::domain::ForkOrigin::User),
+        )
+        .await?;
 
     session_store
         .add_message(
-            &session.public_id,
-            AgentMessage::new(session.public_id.clone(), ChatRole::User),
+            &child.public_id,
+            AgentMessage::new(child.public_id.clone(), ChatRole::User),
         )
         .await?;
     session_store
         .add_message(
-            &session.public_id,
-            AgentMessage::new(session.public_id.clone(), ChatRole::Assistant),
+            &child.public_id,
+            AgentMessage::new(child.public_id.clone(), ChatRole::Assistant),
         )
         .await?;
     storage
         .append_durable(&NewDurableEvent {
-            session_id: session.public_id.clone(),
+            session_id: child.public_id.clone(),
             origin: EventOrigin::Local,
             source_node: None,
             kind: AgentEventKind::LlmRequestEnd {
@@ -453,17 +461,42 @@ async fn acp_session_list_includes_meta_from_stats_and_finish_reason() -> Result
         .sessions()
         .list_for_acp(AcpListSessionsRequest::new())
         .await?;
-    let info = page
+    let parent_info = page
         .sessions
         .iter()
-        .find(|info| info.session_id.to_string() == session.public_id)
-        .expect("session should be listed");
-    let meta = info.meta.as_ref().expect("ACP session meta should be set");
+        .find(|info| info.session_id.to_string() == parent.public_id)
+        .expect("parent session should be listed");
+    let parent_meta = parent_info
+        .meta
+        .as_ref()
+        .expect("parent ACP session meta should be set");
+    assert_eq!(parent_meta.get("hasChildren"), Some(&serde_json::json!(true)));
+    assert_eq!(parent_meta.get("forkCount"), Some(&serde_json::json!(1)));
+    assert!(!parent_meta.contains_key("parentSessionId"));
+    assert!(!parent_meta.contains_key("forkOrigin"));
+    assert!(!parent_meta.contains_key("sessionKind"));
 
-    assert_eq!(meta.get("messageCount"), Some(&serde_json::json!(2)));
-    assert_eq!(meta.get("userMessageCount"), Some(&serde_json::json!(1)));
-    assert_eq!(meta.get("hasErrors"), Some(&serde_json::json!(true)));
-    assert_eq!(meta.get("runtimeStatus"), Some(&serde_json::json!("idle")));
+    let child_info = page
+        .sessions
+        .iter()
+        .find(|info| info.session_id.to_string() == child.public_id)
+        .expect("child session should be listed");
+    let child_meta = child_info
+        .meta
+        .as_ref()
+        .expect("child ACP session meta should be set");
+    assert_eq!(
+        child_meta.get("parentSessionId"),
+        Some(&serde_json::json!(parent.public_id))
+    );
+    assert_eq!(child_meta.get("forkOrigin"), Some(&serde_json::json!("user")));
+    assert_eq!(child_meta.get("hasChildren"), Some(&serde_json::json!(false)));
+    assert_eq!(child_meta.get("forkCount"), Some(&serde_json::json!(0)));
+    assert!(!child_meta.contains_key("sessionKind"));
+    assert_eq!(child_meta.get("messageCount"), Some(&serde_json::json!(2)));
+    assert_eq!(child_meta.get("userMessageCount"), Some(&serde_json::json!(1)));
+    assert_eq!(child_meta.get("hasErrors"), Some(&serde_json::json!(true)));
+    assert_eq!(child_meta.get("runtimeStatus"), Some(&serde_json::json!("idle")));
     Ok(())
 }
 

--- a/crates/agent/src/api/sessions.rs
+++ b/crates/agent/src/api/sessions.rs
@@ -360,7 +360,9 @@ impl AgentSessions {
                 has_errors,
                 runtime_status,
             };
-            info.meta = Some(meta.to_acp_meta());
+            let mut acp_meta = info.meta.take().unwrap_or_default();
+            acp_meta.extend(meta.to_acp_meta());
+            info.meta = Some(acp_meta);
         }
 
         Ok(())
@@ -707,6 +709,35 @@ fn session_list_item_to_acp_info(item: SessionListItem) -> SessionInfo {
     info.updated_at = item
         .updated_at
         .and_then(|updated_at| updated_at.format(&Rfc3339).ok());
+
+    let mut meta = Meta::new();
+    if let Some(parent_session_id) = item.parent_session_id {
+        meta.insert(
+            "parentSessionId".to_string(),
+            serde_json::Value::String(parent_session_id),
+        );
+    }
+    if let Some(fork_origin) = item.fork_origin {
+        meta.insert(
+            "forkOrigin".to_string(),
+            serde_json::Value::String(fork_origin),
+        );
+    }
+    if let Some(session_kind) = item.session_kind {
+        meta.insert(
+            "sessionKind".to_string(),
+            serde_json::Value::String(session_kind),
+        );
+    }
+    meta.insert(
+        "hasChildren".to_string(),
+        serde_json::Value::Bool(item.has_children),
+    );
+    meta.insert(
+        "forkCount".to_string(),
+        serde_json::Value::from(item.fork_count),
+    );
+    info.meta = Some(meta);
     info
 }
 

--- a/crates/agent/src/session/sqlite_storage/view_store.rs
+++ b/crates/agent/src/session/sqlite_storage/view_store.rs
@@ -1039,7 +1039,10 @@ impl ViewStore for SqliteStorage {
                         s.updated_at,
                         p.public_id,
                         s.fork_origin,
-                        s.session_kind,
+                        CASE WHEN EXISTS(
+                            SELECT 1 FROM tasks t
+                            WHERE t.session_id = s.id AND t.kind = 'recurring'
+                        ) THEN 'recurring' ELSE s.session_kind END,
                         (SELECT COUNT(*) FROM sessions c WHERE c.parent_session_id = s.id AND c.fork_origin = 'user'),
                         i.summary
                     FROM sessions s
@@ -1063,7 +1066,10 @@ impl ViewStore for SqliteStorage {
                         s.updated_at,
                         p.public_id,
                         s.fork_origin,
-                        s.session_kind,
+                        CASE WHEN EXISTS(
+                            SELECT 1 FROM tasks t
+                            WHERE t.session_id = s.id AND t.kind = 'recurring'
+                        ) THEN 'recurring' ELSE s.session_kind END,
                         (SELECT COUNT(*) FROM sessions c WHERE c.parent_session_id = s.id AND c.fork_origin = 'user'),
                         i.summary
                     FROM sessions s


### PR DESCRIPTION
## Summary
- Expose parent session, fork origin, session kind, child presence, and fork count in ACP session metadata.
- Preserve existing operational session metadata when relationship data is added.

## Testing
- Added coverage for root and forked session metadata.
- Ran the focused session API test and diff check locally.