### PR TITLE
fix(groq): enable streaming and omit unsupported reasoning_content

### DIFF
--- a/crates/providers/groq/src/lib.rs
+++ b/crates/providers/groq/src/lib.rs
@@ -3,13 +3,15 @@ use http::{
     header::{AUTHORIZATION, CONTENT_TYPE},
 };
 use qmt_openai::api::{
-    OpenAIProviderConfig, openai_chat_request, openai_embed_request, openai_list_models_request,
-    openai_parse_chat, openai_parse_embed, openai_parse_list_models, url_schema,
+    OpenAIProviderConfig, OpenAIToolUseState, openai_chat_request, openai_embed_request,
+    openai_list_models_request, openai_parse_chat, openai_parse_embed, openai_parse_list_models,
+    parse_openai_sse_chunk, url_schema,
 };
 use querymt::{
     HTTPLLMProvider, ToolCall,
     chat::{
-        ChatMessage, ChatResponse, StructuredOutputFormat, Tool, ToolChoice, http::HTTPChatProvider,
+        ChatMessage, ChatResponse, StreamChunk, StructuredOutputFormat, Tool, ToolChoice,
+        http::{ChatStreamParser, HTTPChatProvider},
     },
     completion::{CompletionRequest, CompletionResponse, http::HTTPCompletionProvider},
     embedding::http::HTTPEmbeddingProvider,
@@ -20,6 +22,7 @@ use querymt::{
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 use url::Url;
 
@@ -142,6 +145,12 @@ impl OpenAIProviderConfig for Groq {
         self.reasoning_effort
     }
 
+    // Groq rejects `reasoning_content` on input assistant messages even when
+    // models emit reasoning in responses (e.g. qwen3 tool loops).
+    fn include_reasoning_content(&self) -> bool {
+        false
+    }
+
     fn json_schema(&self) -> Option<&StructuredOutputFormat> {
         self.json_schema.as_ref()
     }
@@ -156,8 +165,37 @@ impl HTTPChatProvider for Groq {
         openai_chat_request(self, messages, tools)
     }
 
+    fn chat_stream_request(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        let mut cfg = self.clone();
+        cfg.stream = Some(true);
+        openai_chat_request(&cfg, messages, tools)
+    }
+
     fn parse_chat(&self, response: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
         openai_parse_chat(self, response)
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Ok(Box::new(GroqStreamParser::default()))
+    }
+}
+
+#[derive(Default)]
+struct GroqStreamParser {
+    tool_states: HashMap<usize, OpenAIToolUseState>,
+}
+
+impl ChatStreamParser for GroqStreamParser {
+    fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, LLMError> {
+        parse_openai_sse_chunk(chunk, &mut self.tool_states)
     }
 }
 
@@ -247,9 +285,6 @@ impl HTTPLLMProviderFactory for GroqFactory {
     }
 
     fn parse_list_models(&self, resp: Response<Vec<u8>>) -> Result<Vec<String>, LLMError> {
-        let models = openai_parse_list_models(&resp)?;
-        println!("->> {:?}", models);
-
         openai_parse_list_models(&resp)
     }
 
@@ -285,5 +320,134 @@ mod extism_exports {
         config = Groq,
         factory = GroqFactory,
         name   = "groq",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Groq;
+    use querymt::chat::{ChatMessage, StreamChunk, http::HTTPChatProvider};
+    use serde_json::Value;
+
+    fn test_provider() -> Groq {
+        serde_json::from_value(serde_json::json!({
+            "api_key": "test-key",
+            "model": "llama-3.3-70b-versatile"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn supports_streaming() {
+        assert!(test_provider().supports_streaming());
+    }
+
+    #[test]
+    fn chat_request_omits_reasoning_content_for_assistant_tool_calls() {
+        let provider = test_provider();
+        let messages = vec![
+            ChatMessage::user().text("what's this project about?").build(),
+            ChatMessage::assistant()
+                .thinking("I should read the README.")
+                .tool_use(
+                    "call_1",
+                    "read_tool",
+                    serde_json::json!({"path": "README.md"}),
+                )
+                .build(),
+        ];
+
+        let request = provider
+            .chat_request(&messages, None)
+            .expect("request should build");
+        let body: Value =
+            serde_json::from_slice(request.body()).expect("body should be valid json");
+        let api_messages = body
+            .get("messages")
+            .and_then(Value::as_array)
+            .expect("messages array should be present");
+
+        let assistant_tool_msg = api_messages
+            .iter()
+            .find(|msg| {
+                msg.get("role").and_then(Value::as_str) == Some("assistant")
+                    && msg.get("tool_calls").is_some()
+            })
+            .expect("assistant tool call message should be present");
+
+        assert!(
+            assistant_tool_msg.get("reasoning_content").is_none(),
+            "Groq must not send reasoning_content on assistant messages"
+        );
+    }
+
+    #[test]
+    fn chat_stream_request_forces_stream_true() {
+        let provider = test_provider();
+
+        let req = provider
+            .chat_stream_request(&[], None)
+            .expect("stream request should build");
+        let body: Value = serde_json::from_slice(req.body()).expect("body should be valid json");
+        assert_eq!(body.get("stream"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn stream_parsers_are_isolated_per_stream() {
+        let provider = test_provider();
+
+        let mut parser_a = provider
+            .chat_stream_parser()
+            .expect("parser A should initialize");
+        let mut parser_b = provider
+            .chat_stream_parser()
+            .expect("parser B should initialize");
+
+        let a_delta = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{\"path\":"}}]}}]}
+"#;
+        let b_delta = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_b","type":"function","function":{"name":"write_file","arguments":"{\"path\":"}}]}}]}
+"#;
+        let a_more = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"a.txt\"}"}}]}}]}
+"#;
+        let b_more = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"b.txt\"}"}}]}}]}
+"#;
+        let a_done = br#"data: [DONE]
+"#;
+        let b_done = br#"data: [DONE]
+"#;
+
+        let _ = parser_a.parse_chunk(a_delta).expect("parse A delta");
+        let _ = parser_b.parse_chunk(b_delta).expect("parse B delta");
+        let _ = parser_a.parse_chunk(a_more).expect("parse A more");
+        let _ = parser_b.parse_chunk(b_more).expect("parse B more");
+
+        let a_events = parser_a.parse_chunk(a_done).expect("parse A done");
+        let b_events = parser_b.parse_chunk(b_done).expect("parse B done");
+
+        let a_complete = a_events.iter().find_map(|chunk| {
+            if let StreamChunk::ToolUseComplete { tool_call, .. } = chunk {
+                Some(tool_call)
+            } else {
+                None
+            }
+        });
+        let b_complete = b_events.iter().find_map(|chunk| {
+            if let StreamChunk::ToolUseComplete { tool_call, .. } = chunk {
+                Some(tool_call)
+            } else {
+                None
+            }
+        });
+
+        let a_complete = a_complete.expect("A should emit ToolUseComplete");
+        let b_complete = b_complete.expect("B should emit ToolUseComplete");
+
+        assert_eq!(a_complete.id, "call_a");
+        assert_eq!(a_complete.function.name, "read_file");
+        assert_eq!(a_complete.function.arguments, r#"{"path":"a.txt"}"#);
+
+        assert_eq!(b_complete.id, "call_b");
+        assert_eq!(b_complete.function.name, "write_file");
+        assert_eq!(b_complete.function.arguments, r#"{"path":"b.txt"}"#);
     }
 }

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -411,6 +411,14 @@ pub trait OpenAIProviderConfig {
     fn reasoning_effort(&self) -> Option<ReasoningEffort> {
         None
     }
+    /// Whether to serialize prior thinking into assistant messages as
+    /// `reasoning_content`.
+    ///
+    /// Some OpenAI-compatible APIs (DeepSeek, Kimi) require this when thinking
+    /// is enabled. Others (e.g. Groq) reject the field entirely.
+    fn include_reasoning_content(&self) -> bool {
+        true
+    }
     fn json_schema(&self) -> Option<&StructuredOutputFormat>;
     fn extra_body(&self) -> Option<Map<String, Value>> {
         None
@@ -791,9 +799,10 @@ pub fn openai_chat_request<C: OpenAIProviderConfig>(
     let auth = determine_effective_auth(token, cfg.auth_type(), cfg.base_url())?;
 
     let mut openai_msgs: Vec<OpenAIChatMessage<'_>> = vec![];
+    let include_reasoning = cfg.include_reasoning_content();
 
     for msg in messages {
-        convert_chat_message_to_openai(msg, &mut openai_msgs);
+        convert_chat_message_to_openai(msg, &mut openai_msgs, include_reasoning);
     }
 
     let system_parts = cfg.system();
@@ -894,7 +903,13 @@ pub fn openai_parse_chat<C: OpenAIProviderConfig>(
 }
 
 /// Extract the thinking/reasoning content from a ChatMessage, if any.
-fn extract_reasoning_content<'a>(msg: &'a ChatMessage) -> Option<Cow<'a, str>> {
+fn extract_reasoning_content<'a>(
+    msg: &'a ChatMessage,
+    include: bool,
+) -> Option<Cow<'a, str>> {
+    if !include {
+        return None;
+    }
     msg.thinking().map(Cow::Borrowed)
 }
 
@@ -904,6 +919,7 @@ fn extract_reasoning_content<'a>(msg: &'a ChatMessage) -> Option<Cow<'a, str>> {
 fn convert_chat_message_to_openai<'a>(
     chat_msg: &'a ChatMessage,
     out: &mut Vec<OpenAIChatMessage<'a>>,
+    include_reasoning: bool,
 ) {
     let role: Cow<'a, str> = match chat_msg.role {
         ChatRole::User => Cow::Borrowed("user"),
@@ -953,7 +969,7 @@ fn convert_chat_message_to_openai<'a>(
                     tool_call_id: None,
                     tool_calls: None,
                     content: Some(Right(Cow::Owned(text))),
-                    reasoning_content: extract_reasoning_content(chat_msg),
+                    reasoning_content: extract_reasoning_content(chat_msg, include_reasoning),
                 });
             }
         }
@@ -1004,7 +1020,7 @@ fn convert_chat_message_to_openai<'a>(
                 Some(tool_calls)
             },
             content: content_val,
-            reasoning_content: extract_reasoning_content(chat_msg),
+            reasoning_content: extract_reasoning_content(chat_msg, include_reasoning),
         });
         return;
     }
@@ -1046,7 +1062,7 @@ fn convert_chat_message_to_openai<'a>(
             tool_call_id: None,
             tool_calls: None,
             content: Some(Left(content_blocks)),
-            reasoning_content: extract_reasoning_content(chat_msg),
+            reasoning_content: extract_reasoning_content(chat_msg, include_reasoning),
         });
     } else {
         // Simple text-only message
@@ -1056,7 +1072,7 @@ fn convert_chat_message_to_openai<'a>(
             tool_call_id: None,
             tool_calls: None,
             content: Some(Right(Cow::Owned(text))),
-            reasoning_content: extract_reasoning_content(chat_msg),
+            reasoning_content: extract_reasoning_content(chat_msg, include_reasoning),
         });
     }
 }
@@ -1435,6 +1451,174 @@ mod tests {
             }
             other => panic!("expected AuthError, got {other}"),
         }
+    }
+
+    #[test]
+    fn chat_request_includes_reasoning_content_by_default() {
+        use super::{OpenAIProviderConfig, openai_chat_request};
+        use querymt::chat::{ChatMessage, StructuredOutputFormat, Tool, ToolChoice};
+        use serde_json::Value;
+        use url::Url;
+
+        struct Cfg {
+            base_url: Url,
+        }
+
+        impl OpenAIProviderConfig for Cfg {
+            fn api_key(&self) -> &str {
+                "test-key"
+            }
+            fn base_url(&self) -> &Url {
+                &self.base_url
+            }
+            fn model(&self) -> &str {
+                "gpt-test"
+            }
+            fn max_tokens(&self) -> Option<&u32> {
+                None
+            }
+            fn temperature(&self) -> Option<&f32> {
+                None
+            }
+            fn system(&self) -> &[String] {
+                &[]
+            }
+            fn timeout_seconds(&self) -> Option<&u64> {
+                None
+            }
+            fn stream(&self) -> Option<&bool> {
+                None
+            }
+            fn top_p(&self) -> Option<&f32> {
+                None
+            }
+            fn top_k(&self) -> Option<&u32> {
+                None
+            }
+            fn tools(&self) -> Option<&[Tool]> {
+                None
+            }
+            fn tool_choice(&self) -> Option<&ToolChoice> {
+                None
+            }
+            fn embedding_encoding_format(&self) -> Option<&str> {
+                None
+            }
+            fn embedding_dimensions(&self) -> Option<&u32> {
+                None
+            }
+            fn json_schema(&self) -> Option<&StructuredOutputFormat> {
+                None
+            }
+        }
+
+        let cfg = Cfg {
+            base_url: Url::parse("https://api.openai.com/v1/").unwrap(),
+        };
+        let messages = vec![
+            ChatMessage::user().text("run tool").build(),
+            ChatMessage::assistant()
+                .thinking("need to run tool")
+                .tool_use("call_1", "run", serde_json::json!({}))
+                .build(),
+        ];
+
+        let request = openai_chat_request(&cfg, &messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let assistant = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m.get("tool_calls").is_some())
+            .unwrap();
+        assert_eq!(
+            assistant.get("reasoning_content").and_then(Value::as_str),
+            Some("need to run tool")
+        );
+    }
+
+    #[test]
+    fn chat_request_omits_reasoning_content_when_disabled() {
+        use super::{OpenAIProviderConfig, openai_chat_request};
+        use querymt::chat::{ChatMessage, StructuredOutputFormat, Tool, ToolChoice};
+        use serde_json::Value;
+        use url::Url;
+
+        struct Cfg {
+            base_url: Url,
+        }
+
+        impl OpenAIProviderConfig for Cfg {
+            fn api_key(&self) -> &str {
+                "test-key"
+            }
+            fn base_url(&self) -> &Url {
+                &self.base_url
+            }
+            fn model(&self) -> &str {
+                "gpt-test"
+            }
+            fn max_tokens(&self) -> Option<&u32> {
+                None
+            }
+            fn temperature(&self) -> Option<&f32> {
+                None
+            }
+            fn system(&self) -> &[String] {
+                &[]
+            }
+            fn timeout_seconds(&self) -> Option<&u64> {
+                None
+            }
+            fn stream(&self) -> Option<&bool> {
+                None
+            }
+            fn top_p(&self) -> Option<&f32> {
+                None
+            }
+            fn top_k(&self) -> Option<&u32> {
+                None
+            }
+            fn tools(&self) -> Option<&[Tool]> {
+                None
+            }
+            fn tool_choice(&self) -> Option<&ToolChoice> {
+                None
+            }
+            fn embedding_encoding_format(&self) -> Option<&str> {
+                None
+            }
+            fn embedding_dimensions(&self) -> Option<&u32> {
+                None
+            }
+            fn include_reasoning_content(&self) -> bool {
+                false
+            }
+            fn json_schema(&self) -> Option<&StructuredOutputFormat> {
+                None
+            }
+        }
+
+        let cfg = Cfg {
+            base_url: Url::parse("https://api.openai.com/v1/").unwrap(),
+        };
+        let messages = vec![
+            ChatMessage::user().text("run tool").build(),
+            ChatMessage::assistant()
+                .thinking("need to run tool")
+                .tool_use("call_1", "run", serde_json::json!({}))
+                .build(),
+        ];
+
+        let request = openai_chat_request(&cfg, &messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let assistant = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m.get("tool_calls").is_some())
+            .unwrap();
+        assert!(assistant.get("reasoning_content").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible SSE streaming to the Groq provider (`chat_stream_request`, `supports_streaming`, `GroqStreamParser`) so ACP/remote paths no longer fail with `Streaming Request Construction Not Supported`.
- Add `OpenAIProviderConfig::include_reasoning_content` (default `true` for DeepSeek/Kimi) and opt Groq out, fixing multi-step tool turns that reject `reasoning_content` on assistant input messages.
- Cover both behaviors with unit tests.

## Test plan
- [x] `cargo test -p qmt-groq --features api`
- [x] `cargo test -p qmt-openai --features api chat_request_`
- [x] Rebuild/republish Groq WASM (`oci://ghcr.io/querymt/groq:latest`) and verify ACP with a reasoning Groq model (e.g. `qwen/qwen3.6-27b`) through a tool-call loop