### PR TITLE
feat(error): add structured provider failures

### DIFF
--- a/crates/querymt/examples/google_embedding_example.rs
+++ b/crates/querymt/examples/google_embedding_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector = llm.embed(vec!["Hello world!".to_string()]).await?;
 
     // Print embedding statistics and data
-    println!("Data: {:?}", &vector);
+    println!("Data: {:?}", vector);
 
     Ok(())
 }

--- a/crates/querymt/examples/openai_embedding_example.rs
+++ b/crates/querymt/examples/openai_embedding_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector = llm.embed(vec!["Hello world!".to_string()]).await?;
 
     // Print embedding statistics and data
-    println!("Data: {:?}", &vector);
+    println!("Data: {:?}", vector);
 
     Ok(())
 }

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -15,6 +15,136 @@ pub enum TransportErrorKind {
     Other,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderErrorKind {
+    ServerOverloaded,
+    RateLimited,
+    QuotaExceeded,
+    ContextWindowExceeded,
+    Authentication,
+    InvalidRequest,
+    /// Unclassified vendor failure treated as transient (e.g. bare 5xx).
+    /// Retryability lives **only** on the kind — there is no parallel
+    /// `transient` flag that can disagree.
+    UnknownTransient,
+    /// Unclassified vendor failure treated as permanent.
+    #[serde(other)]
+    UnknownPermanent,
+}
+
+impl ProviderErrorKind {
+    /// Unified retry policy for provider failures.
+    ///
+    /// QueryMT product choice: overload is retried (upstream Codex marks it
+    /// non-retryable). Quota/context/auth/request failures never are.
+    /// [`Self::UnknownTransient`] / [`Self::UnknownPermanent`] cover unmapped
+    /// vendor envelopes without a second field.
+    pub fn is_retryable(self) -> bool {
+        matches!(
+            self,
+            Self::ServerOverloaded | Self::RateLimited | Self::UnknownTransient
+        )
+    }
+}
+
+/// Structured provider failure with retry semantics and vendor diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFailure {
+    message: String,
+    kind: ProviderErrorKind,
+    code: Option<String>,
+    error_type: Option<String>,
+    request_id: Option<String>,
+    retry_after_secs: Option<u64>,
+}
+
+impl ProviderFailure {
+    pub fn new(kind: ProviderErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            kind,
+            code: None,
+            error_type: None,
+            request_id: None,
+            retry_after_secs: None,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn kind(&self) -> ProviderErrorKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+
+    pub fn error_type(&self) -> Option<&str> {
+        self.error_type.as_deref()
+    }
+
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        self.retry_after_secs
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
+    }
+
+    pub fn with_code(mut self, code: Option<String>) -> Self {
+        self.code = code;
+        self
+    }
+
+    pub fn with_error_type(mut self, error_type: Option<String>) -> Self {
+        self.error_type = error_type;
+        self
+    }
+
+    pub fn with_request_id(mut self, request_id: Option<String>) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn with_retry_after_secs(mut self, retry_after_secs: Option<u64>) -> Self {
+        self.retry_after_secs = retry_after_secs;
+        self
+    }
+}
+
+impl std::fmt::Display for ProviderFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (kind={:?}", self.message, self.kind)?;
+        if let Some(code) = &self.code {
+            write!(f, ", code={code}")?;
+        }
+        if let Some(error_type) = &self.error_type {
+            write!(f, ", type={error_type}")?;
+        }
+        if let Some(request_id) = &self.request_id {
+            write!(f, ", request_id={request_id}")?;
+        }
+        if let Some(retry_after_secs) = self.retry_after_secs {
+            write!(f, ", retry_after_secs={retry_after_secs}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl From<ProviderFailure> for LLMError {
+    fn from(failure: ProviderFailure) -> Self {
+        Self::ProviderResponseError(Box::new(failure))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LLMErrorPayload {
@@ -23,6 +153,16 @@ pub enum LLMErrorPayload {
     },
     ProviderError {
         message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kind: Option<ProviderErrorKind>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_type: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_after_secs: Option<u64>,
     },
     AuthError {
         message: String,
@@ -88,6 +228,10 @@ pub enum LLMError {
     #[error("LLM Provider Error: {0}")]
     ProviderError(String),
 
+    /// A provider failure with structured classification metadata.
+    #[error("LLM Provider Error: {0}")]
+    ProviderResponseError(Box<ProviderFailure>),
+
     /// A wrapper for authentication/authorization errors.
     #[error("Auth Error: {0}")]
     AuthError(String),
@@ -152,12 +296,16 @@ pub enum LLMError {
     NotImplemented(String),
 
     /// Handles JSON serialization and deserialization errors.
+    ///
+    /// Stored as a string so wire payloads round-trip without changing retryability.
     #[error("JSON Error: {0}")]
-    JsonError(#[from] serde_json::Error),
+    JsonError(String),
 
     /// Handles errors from parsing URLs.
-    #[error("Invalid URL")]
-    InvalidUrl(#[from] url::ParseError),
+    ///
+    /// Stored as a string so wire payloads round-trip without changing retryability.
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
 
     /// Handles standard I/O errors.
     #[error("I/O Error")]
@@ -172,6 +320,19 @@ impl LLMError {
             },
             Self::ProviderError(message) => LLMErrorPayload::ProviderError {
                 message: message.clone(),
+                kind: None,
+                code: None,
+                error_type: None,
+                request_id: None,
+                retry_after_secs: None,
+            },
+            Self::ProviderResponseError(failure) => LLMErrorPayload::ProviderError {
+                message: failure.message.clone(),
+                kind: Some(failure.kind),
+                code: failure.code.clone(),
+                error_type: failure.error_type.clone(),
+                request_id: failure.request_id.clone(),
+                retry_after_secs: failure.retry_after_secs,
             },
             Self::AuthError(message) => LLMErrorPayload::AuthError {
                 message: message.clone(),
@@ -227,11 +388,11 @@ impl LLMError {
             Self::NotImplemented(message) => LLMErrorPayload::NotImplemented {
                 message: message.clone(),
             },
-            Self::JsonError(err) => LLMErrorPayload::JsonError {
-                message: err.to_string(),
+            Self::JsonError(message) => LLMErrorPayload::JsonError {
+                message: message.clone(),
             },
-            Self::InvalidUrl(err) => LLMErrorPayload::InvalidUrl {
-                message: err.to_string(),
+            Self::InvalidUrl(message) => LLMErrorPayload::InvalidUrl {
+                message: message.clone(),
             },
             Self::IoError(err) => LLMErrorPayload::IoError {
                 message: err.to_string(),
@@ -242,7 +403,23 @@ impl LLMError {
     pub fn from_payload(payload: LLMErrorPayload) -> Self {
         match payload {
             LLMErrorPayload::GenericError { message } => Self::GenericError(message),
-            LLMErrorPayload::ProviderError { message } => Self::ProviderError(message),
+            LLMErrorPayload::ProviderError {
+                message,
+                kind,
+                code,
+                error_type,
+                request_id,
+                retry_after_secs,
+            } => match kind {
+                Some(kind) => Self::ProviderResponseError(Box::new(
+                    ProviderFailure::new(kind, message)
+                        .with_code(code)
+                        .with_error_type(error_type)
+                        .with_request_id(request_id)
+                        .with_retry_after_secs(retry_after_secs),
+                )),
+                None => Self::ProviderError(message),
+            },
             LLMErrorPayload::AuthError { message } => Self::AuthError(message),
             LLMErrorPayload::ToolConfigError { message } => Self::ToolConfigError(message),
             LLMErrorPayload::PluginError { message } => Self::PluginError(message),
@@ -280,8 +457,12 @@ impl LLMError {
                 Self::RemoteStreamReconnected { message }
             }
             LLMErrorPayload::NotImplemented { message } => Self::NotImplemented(message),
-            LLMErrorPayload::JsonError { message } => Self::PluginError(message),
-            LLMErrorPayload::InvalidUrl { message } => Self::HttpError(message),
+            // Lossless: keep payload tags as distinct runtime variants so
+            // payload.is_retryable() == from_payload(p).is_retryable().
+            LLMErrorPayload::JsonError { message } => Self::JsonError(message),
+            LLMErrorPayload::InvalidUrl { message } => Self::InvalidUrl(message),
+            // Io has no dedicated runtime variant; Transport is the stable
+            // retryable home and matches payload IoError retryability.
             LLMErrorPayload::IoError { message } => Self::Transport {
                 kind: TransportErrorKind::Other,
                 message,
@@ -297,12 +478,51 @@ impl LLMError {
             | Self::HttpStatus {
                 retry_after_secs, ..
             } => *retry_after_secs,
+            Self::ProviderResponseError(failure) => failure.retry_after_secs(),
             _ => None,
         }
     }
 
-    pub fn is_retryable_setup_failure(&self) -> bool {
-        self.is_retryable()
+    /// Whether this error is a rate-limit failure (for UI events / wait messaging).
+    ///
+    /// Two representations exist on purpose:
+    /// - [`Self::RateLimited`] / bare HTTP 429: generic HTTP path
+    /// - [`Self::ProviderResponseError`] with [`ProviderErrorKind::RateLimited`]:
+    ///   classified chat path
+    ///
+    /// Callers must use this helper instead of matching one form only.
+    pub fn is_rate_limited(&self) -> bool {
+        match self {
+            Self::RateLimited { .. } => true,
+            Self::HttpStatus {
+                status_code: 429, ..
+            } => true,
+            Self::ProviderResponseError(failure) => {
+                failure.kind() == ProviderErrorKind::RateLimited
+            }
+            _ => false,
+        }
+    }
+
+    /// Message + retry-after when [`Self::is_rate_limited`] is true.
+    pub fn rate_limit_info(&self) -> Option<(String, Option<u64>)> {
+        match self {
+            Self::RateLimited {
+                message,
+                retry_after_secs,
+            } => Some((message.clone(), *retry_after_secs)),
+            Self::HttpStatus {
+                status_code: 429,
+                message,
+                retry_after_secs,
+            } => Some((message.clone(), *retry_after_secs)),
+            Self::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::RateLimited =>
+            {
+                Some((failure.message.clone(), failure.retry_after_secs()))
+            }
+            _ => None,
+        }
     }
 
     /// Whether this error is worth retrying (transient infrastructure error).
@@ -311,6 +531,9 @@ impl LLMError {
     /// on a second attempt. Only semantic/auth/validation errors are not retryable.
     /// The mesh-specific `RemoteStreamDisconnected`/`RemoteStreamReconnected` events
     /// are excluded — they have their own handling in the streaming loop.
+    ///
+    /// Retry policy is keyed off **unified** error kinds. Vendor code tables live
+    /// in providers; they map wire errors into these variants before core sees them.
     pub fn is_retryable(&self) -> bool {
         match self {
             // Always retry: transient infrastructure
@@ -323,6 +546,10 @@ impl LLMError {
             Self::PluginError(_) => true, // may be a transient WASM/HTTP issue
             Self::IoError { .. } => true,
 
+            // Structured provider failure: unified kind policy, including
+            // explicit UnknownTransient / UnknownPermanent fallback kinds.
+            Self::ProviderResponseError(failure) => failure.is_retryable(),
+
             // Never retry: semantic errors
             Self::AuthError(_) => false,
             Self::InvalidRequest(_) => false,
@@ -331,8 +558,8 @@ impl LLMError {
             Self::ResponseFormatError { .. } => false,
             Self::GenericError(_) => false,
             Self::Cancelled => false,
-            Self::JsonError { .. } => false,
-            Self::InvalidUrl { .. } => false,
+            Self::JsonError(_) => false,
+            Self::InvalidUrl(_) => false,
             Self::NotImplemented(_) => false,
 
             // Mesh transport events — handled by the existing continue logic
@@ -442,7 +669,9 @@ fn json_retry_after_value(v: &serde_json::Value) -> Option<u64> {
 /// Checks common locations where providers embed retry hints:
 /// - `error.retry_after` / `error.retry_after_secs`
 /// - top-level `retry_after` / `retry_after_secs`
-fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
+///
+/// Vendor-agnostic field lookup only — no error-code classification.
+pub fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
     [
         json.pointer("/error/retry_after"),
         json.pointer("/error/retry_after_secs"),
@@ -454,11 +683,63 @@ fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
     .find_map(json_retry_after_value)
 }
 
-pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
-    if status_code == 499 {
-        return LLMError::Cancelled;
+/// Parse `"try again in 11.054s"` style delays from a provider message.
+///
+/// Used by providers (e.g. OpenAI/Codex rate-limit messages) after they have
+/// already decided the failure is a rate limit from structured `code`/`type`.
+pub fn parse_retry_after_from_message(message: &str) -> Option<u64> {
+    // Mirror openai/codex: `(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)`
+    let lower = message.to_ascii_lowercase();
+    let marker = "try again in";
+    let rest = lower.split_once(marker)?.1.trim_start();
+    let mut num = String::new();
+    let mut chars = rest.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() || c == '.' {
+            num.push(c);
+            chars.next();
+        } else {
+            break;
+        }
     }
+    if num.is_empty() {
+        return None;
+    }
+    let value: f64 = num.parse().ok()?;
+    // skip whitespace
+    while matches!(chars.peek(), Some(c) if c.is_whitespace()) {
+        chars.next();
+    }
+    let unit: String = chars
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if unit == "ms" {
+        let millis = value as u64;
+        return Some(if millis == 0 && value > 0.0 {
+            1
+        } else {
+            duration_to_secs(Duration::from_millis(millis.max(1)))
+        });
+    }
+    if unit == "s" || unit.starts_with("second") {
+        return Some(if value <= 0.0 {
+            0
+        } else if value < 1.0 {
+            1
+        } else {
+            value.ceil() as u64
+        });
+    }
+    None
+}
 
+/// Extract the human-readable message and retry hint from an error response.
+fn status_message_and_retry(
+    status_code: u16,
+    headers: &http::HeaderMap,
+    body: &[u8],
+) -> (String, Option<u64>) {
     // Parse body JSON once; reuse for both retry-after and message extraction.
     let body_json = serde_json::from_slice::<serde_json::Value>(body).ok();
 
@@ -478,6 +759,40 @@ pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &
     } else {
         clean_message
     };
+    (message, retry_after_secs)
+}
+
+/// Classify a non-success HTTP status when the body carries no recognizable
+/// vendor error envelope.
+pub fn classify_status_only(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let (message, retry_after_secs) = status_message_and_retry(status_code, headers, body);
+    let kind = match status_code {
+        429 => ProviderErrorKind::RateLimited,
+        401 | 403 => ProviderErrorKind::Authentication,
+        400 | 422 => ProviderErrorKind::InvalidRequest,
+        408 | 425 | 500..=599 => ProviderErrorKind::UnknownTransient,
+        _ => ProviderErrorKind::UnknownPermanent,
+    };
+    ProviderFailure::new(kind, message)
+        .with_retry_after_secs(retry_after_secs)
+        .into()
+}
+
+/// Generic HTTP status classifier.
+///
+/// Rate limits stay on the legacy [`LLMError::RateLimited`] variant here so
+/// generic HTTP failures keep the stable wire payload shape. Chat provider
+/// classifiers use [`classify_status_only`] or a vendor envelope classifier.
+pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let (message, retry_after_secs) = status_message_and_retry(status_code, headers, body);
 
     match status_code {
         401 | 403 => LLMError::AuthError(message),
@@ -499,6 +814,18 @@ pub fn transport_error(kind: TransportErrorKind, message: impl Into<String>) -> 
     LLMError::Transport {
         kind,
         message: message.into(),
+    }
+}
+
+impl From<serde_json::Error> for LLMError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::JsonError(err.to_string())
+    }
+}
+
+impl From<url::ParseError> for LLMError {
+    fn from(err: url::ParseError) -> Self {
+        Self::InvalidUrl(err.to_string())
     }
 }
 
@@ -530,7 +857,7 @@ impl From<reqwest::Error> for LLMError {
 
 impl From<http::Error> for LLMError {
     fn from(err: http::Error) -> Self {
-        LLMError::HttpError(err.to_string())
+        LLMError::InvalidRequest(err.to_string())
     }
 }
 
@@ -756,5 +1083,396 @@ mod tests {
         let body = b"Server Error";
         let err = classify_http_status(503, &headers, body);
         assert_eq!(err.retry_after_secs(), Some(60));
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum LegacyPayload {
+        ProviderError { message: String },
+    }
+
+    #[test]
+    fn legacy_provider_payload_deserialization() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "legacy failure"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            payload,
+            LLMErrorPayload::ProviderError {
+                message: "legacy failure".to_owned(),
+                kind: None,
+                code: None,
+                error_type: None,
+                request_id: None,
+                retry_after_secs: None,
+            }
+        );
+        assert!(matches!(
+            LLMError::from_payload(payload),
+            LLMError::ProviderError(message) if message == "legacy failure"
+        ));
+    }
+
+    #[test]
+    fn classified_error_preserves_kind_and_metadata() {
+        let error = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_error_type(Some("server_error".into()))
+            .with_request_id(Some("req-1".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-1"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert!(failure.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn flat_structured_payload_is_preserved() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "plugin busy",
+            "kind": "server_overloaded",
+            "code": "server_is_overloaded",
+            "request_id": "req-plugin"
+        }))
+        .expect("structured plugin payload should deserialize");
+
+        let error = LLMError::from_payload(payload);
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "plugin busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn provider_failure_converts_directly_to_llm_error() {
+        let error = LLMError::from(ProviderFailure::new(ProviderErrorKind::RateLimited, "busy"));
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn structured_semantic_errors_round_trip_through_legacy_provider_tag() {
+        let overloaded: LLMError =
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+                .with_code(Some("server_is_overloaded".into()))
+                .with_request_id(Some("req-1".into()))
+                .into();
+        let payload = overloaded.to_payload();
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "provider_error");
+        assert_eq!(json["kind"], "server_overloaded");
+        assert_eq!(json["code"], "server_is_overloaded");
+        let legacy: LegacyPayload = serde_json::from_value(json.clone()).unwrap();
+        assert!(matches!(
+            legacy,
+            LegacyPayload::ProviderError { message } if message == "busy"
+        ));
+        let restored =
+            LLMError::from_payload(serde_json::from_value::<LLMErrorPayload>(json).unwrap());
+        assert!(matches!(
+            restored,
+            LLMError::ProviderResponseError(failure)
+                if failure.message() == "busy"
+                    && failure.kind() == ProviderErrorKind::ServerOverloaded
+                    && failure.code() == Some("server_is_overloaded")
+                    && restored.is_retryable()
+        ));
+
+        let quota: LLMError = ProviderFailure::new(ProviderErrorKind::QuotaExceeded, "no credits")
+            .with_code(Some("insufficient_quota".into()))
+            .into();
+        assert!(!quota.is_retryable());
+        assert!(matches!(
+            LLMError::from_payload(quota.to_payload()),
+            LLMError::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::QuotaExceeded
+        ));
+
+        let context: LLMError =
+            ProviderFailure::new(ProviderErrorKind::ContextWindowExceeded, "too long")
+                .with_code(Some("context_length_exceeded".into()))
+                .into();
+        assert!(!context.is_retryable());
+        assert!(matches!(
+            LLMError::from_payload(context.to_payload()),
+            LLMError::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::ContextWindowExceeded
+        ));
+    }
+
+    #[test]
+    fn payload_retryability_is_owned_by_kind_alone() {
+        let overloaded = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::ServerOverloaded,
+            "busy",
+        ));
+        assert!(overloaded.is_retryable());
+
+        let quota = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::QuotaExceeded,
+            "no credits",
+        ));
+        assert!(!quota.is_retryable());
+    }
+
+    #[test]
+    fn unknown_kinds_and_metadata_are_preserved() {
+        let transient = ProviderFailure::new(ProviderErrorKind::UnknownTransient, "maybe")
+            .with_code(Some("unknown".into()));
+        assert!(transient.is_retryable());
+        assert_eq!(transient.kind(), ProviderErrorKind::UnknownTransient);
+
+        let permanent = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "nope")
+            .with_code(Some("unknown".into()));
+        assert!(!permanent.is_retryable());
+        assert_eq!(permanent.kind(), ProviderErrorKind::UnknownPermanent);
+
+        let permanent_with_hint = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "busy")
+            .with_retry_after_secs(Some(60));
+        assert!(!permanent_with_hint.is_retryable());
+        assert_eq!(
+            LLMError::from(permanent_with_hint).retry_after_secs(),
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn provider_failure_conversion_preserves_metadata() {
+        let error = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_error_type(Some("server_error".into()))
+            .with_request_id(Some("req-1".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.error_type(), Some("server_error"));
+                assert_eq!(failure.request_id(), Some("req-1"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert!(failure.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn server_overloaded_is_retryable_by_kind() {
+        let err: LLMError = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "capacity")
+            .with_code(Some("server_is_overloaded".into()))
+            .into();
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn provider_response_error_honors_unknown_transient_kind() {
+        let transient: LLMError =
+            ProviderFailure::new(ProviderErrorKind::UnknownTransient, "maybe")
+                .with_code(Some("unknown".into()))
+                .with_retry_after_secs(Some(5))
+                .into();
+        assert!(transient.is_retryable());
+        assert_eq!(transient.retry_after_secs(), Some(5));
+
+        let permanent: LLMError = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "nope")
+            .with_code(Some("unknown".into()))
+            .into();
+        assert!(!permanent.is_retryable());
+    }
+
+    #[test]
+    fn unknown_payload_kind_falls_back_to_permanent() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "future failure",
+            "kind": "future_provider_kind",
+            "code": "future_code",
+            "retry_after_secs": 90
+        }))
+        .expect("future provider kind should remain readable");
+
+        let error = LLMError::from_payload(payload);
+        assert!(!error.is_retryable());
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownPermanent);
+                assert_eq!(failure.code(), Some("future_code"));
+                assert_eq!(failure.retry_after_secs(), Some(90));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_status_only_owns_client_cancellation() {
+        let error = classify_status_only(499, &http::HeaderMap::new(), b"cancelled");
+        assert!(matches!(error, LLMError::Cancelled));
+    }
+
+    #[test]
+    fn classify_status_only_maps_status_to_unified_kinds() {
+        let headers = http::HeaderMap::new();
+
+        let rate_limited =
+            classify_status_only(429, &headers, br#"{"error":{"message":"slow down"}}"#);
+        assert!(matches!(
+            rate_limited,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::RateLimited
+                    && failure.message() == "slow down"
+        ));
+        assert!(rate_limited.is_retryable());
+
+        let auth = classify_status_only(401, &headers, b"bad key");
+        assert!(matches!(
+            auth,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::Authentication
+        ));
+        assert!(!auth.is_retryable());
+
+        let invalid = classify_status_only(422, &headers, b"bad field");
+        assert!(matches!(
+            invalid,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::InvalidRequest
+        ));
+        assert!(!invalid.is_retryable());
+
+        // Timeout-style statuses and unknown 5xx are transient.
+        for status in [408, 425, 503] {
+            let transient = classify_status_only(status, &headers, b"temporary failure");
+            assert!(matches!(
+                transient,
+                LLMError::ProviderResponseError(ref failure)
+                    if failure.kind() == ProviderErrorKind::UnknownTransient
+            ));
+            assert!(transient.is_retryable());
+        }
+
+        // Unknown 4xx: unclassified and permanent.
+        let weird = classify_status_only(418, &headers, b"teapot");
+        assert!(matches!(
+            weird,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownPermanent
+        ));
+        assert!(!weird.is_retryable());
+
+        let permanent_with_hint = classify_status_only(
+            401,
+            &http::HeaderMap::from_iter([(
+                http::header::RETRY_AFTER,
+                http::HeaderValue::from_static("30"),
+            )]),
+            b"bad key",
+        );
+        assert_eq!(permanent_with_hint.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn request_builder_errors_are_permanent_invalid_requests() {
+        let error = http::Request::builder()
+            .uri("\n")
+            .body(Vec::<u8>::new())
+            .expect_err("invalid URI must fail");
+        let error = LLMError::from(error);
+        assert!(matches!(error, LLMError::InvalidRequest(_)));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn rate_limit_info_covers_legacy_and_structured_forms() {
+        let legacy = LLMError::RateLimited {
+            message: "slow".into(),
+            retry_after_secs: Some(3),
+        };
+        assert!(legacy.is_rate_limited());
+        assert_eq!(legacy.rate_limit_info(), Some(("slow".into(), Some(3))));
+
+        let structured: LLMError = ProviderFailure::new(ProviderErrorKind::RateLimited, "slow")
+            .with_retry_after_secs(Some(4))
+            .into();
+        assert!(structured.is_rate_limited());
+        assert_eq!(structured.rate_limit_info(), Some(("slow".into(), Some(4))));
+
+        let http_429 = LLMError::HttpStatus {
+            status_code: 429,
+            message: "too many".into(),
+            retry_after_secs: Some(1),
+        };
+        assert!(http_429.is_rate_limited());
+        assert_eq!(
+            http_429.rate_limit_info(),
+            Some(("too many".into(), Some(1)))
+        );
+
+        let other = LLMError::GenericError("nope".into());
+        assert!(!other.is_rate_limited());
+        assert!(other.rate_limit_info().is_none());
+    }
+
+    #[test]
+    fn display_includes_message_and_metadata_once() {
+        let error: LLMError = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_request_id(Some("req-9".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+        let rendered = error.to_string();
+        assert_eq!(rendered.matches("busy").count(), 1);
+        assert!(
+            rendered.contains("ServerOverloaded"),
+            "missing kind: {rendered}"
+        );
+        assert!(rendered.contains("server_is_overloaded"));
+        assert!(rendered.contains("req-9"));
+        assert!(rendered.contains("retry_after_secs=2"));
+    }
+
+    #[test]
+    fn parse_retry_after_from_message_matches_codex_style() {
+        assert_eq!(
+            parse_retry_after_from_message(
+                "Rate limit reached. Please try again in 11.054s. Visit docs."
+            ),
+            Some(12) // ceil
+        );
+        assert_eq!(
+            parse_retry_after_from_message("Please try again in 30 seconds."),
+            Some(30)
+        );
+        assert_eq!(
+            parse_retry_after_from_message("Please try again in 500ms"),
+            Some(1)
+        );
+        assert_eq!(parse_retry_after_from_message("no delay mentioned"), None);
     }
 }


### PR DESCRIPTION
## what changed

- add provider-neutral `ProviderErrorKind` retry semantics
- add one structured `ProviderFailure` type with vendor code/type, request id, and retry-after metadata
- add `LLMError::ProviderResponseError(Box<ProviderFailure>)`
- preserve released `provider_error` payload compatibility while adding optional flat metadata
- centralize status fallback, including http 499 cancellation

## review boundary

this is the foundation model only. it contains no provider attribution or classifier behavior.

## stack

`main` -> **#750** -> #751 -> #752 -> #754 -> #755 -> #765
