### PR TITLE
feat(errors): preserve typed errors across provider boundaries

### DIFF
--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -575,9 +575,7 @@ impl SessionProvider {
             ));
 
             // Generic path — works for Extism providers that implement set_key_resolver.
-            let mut provider = factory.from_config(&pruned_config_str).map_err(|e| {
-                LLMError::PluginError(format!("provider '{}': {}", provider_name, e))
-            })?;
+            let mut provider = factory.from_config(&pruned_config_str)?;
             provider.set_key_resolver(resolver.clone());
 
             if provider.key_resolver().is_some() {
@@ -592,10 +590,7 @@ impl SessionProvider {
             // Fallback for native HTTP providers: set the resolver on the inner
             // HTTPLLMProvider before it gets wrapped in Arc by the adapter.
             if let Some(http_factory) = factory.as_http() {
-                let mut http_provider =
-                    http_factory.from_config(&pruned_config_str).map_err(|e| {
-                        LLMError::PluginError(format!("provider '{}': {}", provider_name, e))
-                    })?;
+                let mut http_provider = http_factory.from_config(&pruned_config_str)?;
                 http_provider.set_key_resolver(resolver);
 
                 log::debug!(
@@ -617,9 +612,7 @@ impl SessionProvider {
             return Ok(Arc::from(provider));
         }
 
-        let provider = factory
-            .from_config(&pruned_config_str)
-            .map_err(|e| LLMError::PluginError(format!("provider '{}': {}", provider_name, e)))?;
+        let provider = factory.from_config(&pruned_config_str)?;
         Ok(Arc::from(provider))
     }
 }
@@ -1123,6 +1116,7 @@ pub mod tests {
     use querymt::chat::{ChatMessage, ChatResponse, FinishReason, StreamChunk};
     use querymt::completion::{CompletionRequest, CompletionResponse};
     use querymt::error::LLMError;
+    use querymt::plugin::LLMProviderFactory;
     use std::pin::Pin;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
@@ -1227,6 +1221,57 @@ pub mod tests {
     }
 
     impl LLMProvider for MockProvider {}
+
+    struct InvalidConfigFactory;
+
+    impl LLMProviderFactory for InvalidConfigFactory {
+        fn name(&self) -> &str {
+            "invalid-config"
+        }
+
+        fn config_schema(&self) -> String {
+            "{}".into()
+        }
+
+        fn from_config(&self, _cfg: &str) -> Result<Box<dyn LLMProvider>, LLMError> {
+            Err(LLMError::InvalidRequest("bad provider config".into()))
+        }
+
+        fn list_models<'a>(
+            &'a self,
+            _cfg: &str,
+        ) -> querymt::plugin::Fut<'a, Result<Vec<String>, LLMError>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn build_provider_preserves_typed_factory_error() {
+        use crate::session::sqlite_storage::SqliteStorage;
+
+        let registry = Arc::new(PluginRegistry::empty());
+        registry.register_static(Arc::new(InvalidConfigFactory));
+        let storage = Arc::new(
+            SqliteStorage::connect(":memory:".into())
+                .await
+                .expect("connect test storage"),
+        );
+        let provider = SessionProvider::new(registry, storage, LLMParams::new());
+
+        let error = match provider
+            .build_provider(ProviderRequest::new("invalid-config", "test-model"))
+            .await
+        {
+            Ok(_) => panic!("factory construction should fail"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            SessionError::ProviderError(LLMError::InvalidRequest(message))
+                if message == "bad provider config"
+        ));
+    }
 
     // ── resolve_api_key_with_preference tests ─────────────────────────────────
 

--- a/crates/providers/mrs/src/factory.rs
+++ b/crates/providers/mrs/src/factory.rs
@@ -47,8 +47,7 @@ impl LLMProviderFactory for MistralRSFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn querymt::LLMProvider>, LLMError> {
-        let cfg: MistralRSConfig = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("mistral.rs config error: {}", e)))?;
+        let cfg: MistralRSConfig = serde_json::from_str(cfg)?;
 
         let provider = MistralRS::new_with_cache(cfg, &self.model_cache)?;
         Ok(Box::new(provider))

--- a/crates/providers/mrs/src/tests.rs
+++ b/crates/providers/mrs/src/tests.rs
@@ -2,13 +2,12 @@ use querymt::LLMProvider;
 use querymt::chat::{ChatMessageBuilder, ChatRole};
 use querymt::completion::CompletionRequest;
 use querymt::error::LLMError;
-use querymt::plugin::LLMProviderFactory;
 
 use crate::config::MistralRSConfig;
-use crate::factory::MistralRSFactory;
+use crate::factory::create_factory;
 
 fn get_provider() -> Box<dyn LLMProvider> {
-    let factory = MistralRSFactory {};
+    let factory = create_factory();
     let cfg = MistralRSConfig {
         model: "microsoft/Phi-3.5-mini-instruct".to_string(),
         model_kind: None,
@@ -46,6 +45,17 @@ fn get_provider() -> Box<dyn LLMProvider> {
 
     let json_cfg = serde_json::to_string(&cfg).unwrap();
     factory.from_config(&json_cfg).unwrap()
+}
+
+#[test]
+fn malformed_config_is_non_retryable_json_error() {
+    let error = create_factory()
+        .from_config("{")
+        .err()
+        .expect("config should be rejected");
+
+    assert!(!error.is_retryable());
+    assert!(matches!(error, LLMError::JsonError(_)));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/querymt-extism-macros/src/lib.rs
+++ b/crates/querymt-extism-macros/src/lib.rs
@@ -207,13 +207,13 @@ macro_rules! impl_extism_http_plugin {
             Ok(s)
         }
 
-        // Validate the config inside WASM
+        // Validate the config inside WASM while preserving typed errors for the host.
         #[plugin_fn]
-        pub fn from_config(cfg: Json<$Config>) -> FnResult<Json<$Config>> {
-            // Try to deserialize into the config type
-            let native_cfg: $Config = cfg.0;
-
-            Ok(Json(native_cfg))
+        pub fn from_config(Json(cfg): Json<Value>) -> FnResult<Json<Value>> {
+            serde_json::from_value::<$Config>(cfg.clone())
+                .map_err(querymt::error::LLMError::from)
+                .map_err(llm_err_to_pdk)?;
+            Ok(Json(cfg))
         }
 
         // list models (new request/parse split)
@@ -268,6 +268,15 @@ macro_rules! impl_extism_http_plugin {
                 .chat_stream_request(&input.messages, input.tools.as_deref())
                 .map_err(llm_err_to_pdk)?;
             Ok(Json(querymt::plugin::extism_impl::SerializableHttpRequest { req }))
+        }
+
+        #[plugin_fn]
+        pub fn classify_chat_error(
+            Json(input): Json<querymt::plugin::extism_impl::ExtismChatParseRequest<$Config>>,
+        ) -> FnResult<Json<querymt::plugin::extism_impl::PluginError>> {
+            // Returning the payload keeps this optional export compatible with older hosts.
+            let error = input.cfg.classify_chat_error(&input.resp.resp);
+            Ok(Json(PluginError::from_llm_error(&error)))
         }
 
         #[plugin_fn]

--- a/crates/querymt/examples/google_embedding_example.rs
+++ b/crates/querymt/examples/google_embedding_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector = llm.embed(vec!["Hello world!".to_string()]).await?;
 
     // Print embedding statistics and data
-    println!("Data: {:?}", &vector);
+    println!("Data: {:?}", vector);
 
     Ok(())
 }

--- a/crates/querymt/examples/openai_embedding_example.rs
+++ b/crates/querymt/examples/openai_embedding_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector = llm.embed(vec!["Hello world!".to_string()]).await?;
 
     // Print embedding statistics and data
-    println!("Data: {:?}", &vector);
+    println!("Data: {:?}", vector);
 
     Ok(())
 }

--- a/crates/querymt/src/adapters.rs
+++ b/crates/querymt/src/adapters.rs
@@ -4,7 +4,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
-    outbound::{call_outbound, call_outbound_stream},
+    outbound::{OutboundStreamResult, call_outbound, call_outbound_raw, call_outbound_stream_raw},
     stt, tts,
 };
 use async_trait::async_trait;
@@ -42,12 +42,12 @@ impl LLMProviderFromHTTP {
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         self.ensure_credential_fresh().await?;
 
-        let req = self
-            .inner
-            .chat_request(messages, tools)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let req = self.inner.chat_request(messages, tools)?;
 
-        let resp = call_outbound(req).await?;
+        let resp = call_outbound_raw(req).await?;
+        if !resp.status().is_success() {
+            return Err(self.inner.classify_chat_error_async(&resp).await);
+        }
 
         self.inner.parse_chat(resp)
     }
@@ -89,17 +89,16 @@ impl ChatProvider for LLMProviderFromHTTP {
 
         self.ensure_credential_fresh().await?;
 
-        let req = self
-            .inner
-            .chat_stream_request(messages, tools)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let req = self.inner.chat_stream_request(messages, tools)?;
 
-        let stream = call_outbound_stream(req).await?;
-        let mut parser = self
-            .inner
-            .chat_stream_parser()
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let stream = match call_outbound_stream_raw(req).await? {
+            OutboundStreamResult::Failure { response } => {
+                return Err(self.inner.classify_chat_error_async(&response).await);
+            }
+            OutboundStreamResult::Success { stream } => stream,
+        };
 
+        let mut parser = self.inner.chat_stream_parser()?;
         let s = stream
             .map(move |res: reqwest::Result<bytes::Bytes>| res.map_err(LLMError::from))
             .chain(futures::stream::iter([
@@ -145,7 +144,9 @@ impl ChatProvider for LLMProviderFromHTTP {
                             *done = true;
                             match parser.finish() {
                                 Ok(mut tail) => chunks.append(&mut tail),
-                                Err(e) => return futures::future::ready(Some(Err(e))),
+                                Err(e) => {
+                                    return futures::future::ready(Some(Err(e)));
+                                }
                             }
                         }
 
@@ -176,12 +177,9 @@ impl EmbeddingProvider for LLMProviderFromHTTP {
     async fn embed(&self, inputs: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.embed_request(&inputs)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_embed(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        // call_outbound already classifies non-success statuses.
+        let resp = call_outbound(req).await?;
+        self.inner.parse_embed(resp)
     }
 }
 
@@ -194,12 +192,8 @@ impl CompletionProvider for LLMProviderFromHTTP {
     async fn complete(&self, req_obj: &CompletionRequest) -> Result<CompletionResponse, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.complete_request(req_obj)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_complete(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        let resp = call_outbound(req).await?;
+        self.inner.parse_complete(resp)
     }
 }
 
@@ -224,12 +218,8 @@ impl LLMProvider for LLMProviderFromHTTP {
     async fn transcribe(&self, req_obj: &stt::SttRequest) -> Result<stt::SttResponse, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.stt_request(req_obj)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_stt(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        let resp = call_outbound(req).await?;
+        self.inner.parse_stt(resp)
     }
 
     #[cfg_attr(
@@ -239,223 +229,11 @@ impl LLMProvider for LLMProviderFromHTTP {
     async fn speech(&self, req_obj: &tts::TtsRequest) -> Result<tts::TtsResponse, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.tts_request(req_obj)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_tts(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        let resp = call_outbound(req).await?;
+        self.inner.parse_tts(resp)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::auth::{ApiKeyResolver, static_key};
-    use crate::chat::http::{ChatStreamParser, HTTPChatProvider};
-    use crate::completion::http::HTTPCompletionProvider;
-    use crate::embedding::http::HTTPEmbeddingProvider;
-    use http::{Request, Response};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct DummyHttpProvider {
-        resolver: Option<Arc<dyn ApiKeyResolver>>,
-    }
-
-    #[derive(Debug)]
-    struct CountingResolver {
-        resolves: AtomicUsize,
-    }
-
-    impl CountingResolver {
-        fn new() -> Self {
-            Self {
-                resolves: AtomicUsize::new(0),
-            }
-        }
-
-        fn resolve_count(&self) -> usize {
-            self.resolves.load(Ordering::SeqCst)
-        }
-    }
-
-    impl ApiKeyResolver for CountingResolver {
-        fn resolve(&self) -> Pin<Box<dyn Future<Output = Result<(), LLMError>> + Send + '_>> {
-            self.resolves.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(()) })
-        }
-
-        fn current(&self) -> String {
-            if self.resolve_count() > 0 {
-                "resolved-token".to_string()
-            } else {
-                "stale-token".to_string()
-            }
-        }
-    }
-
-    struct ResolveAwareHttpProvider {
-        resolver: Arc<dyn ApiKeyResolver>,
-    }
-
-    impl HTTPChatProvider for DummyHttpProvider {
-        fn chat_request(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: Option<&[Tool]>,
-        ) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn supports_streaming(&self) -> bool {
-            false
-        }
-
-        fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPCompletionProvider for DummyHttpProvider {
-        fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPEmbeddingProvider for DummyHttpProvider {
-        fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPLLMProvider for DummyHttpProvider {
-        fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
-            self.resolver.as_ref()
-        }
-
-        fn set_key_resolver(&mut self, resolver: Arc<dyn ApiKeyResolver>) {
-            self.resolver = Some(resolver);
-        }
-    }
-
-    impl HTTPChatProvider for ResolveAwareHttpProvider {
-        fn chat_request(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: Option<&[Tool]>,
-        ) -> Result<Request<Vec<u8>>, LLMError> {
-            let token = self.resolver.current();
-            let req = Request::builder()
-                .method("POST")
-                .uri("https://example.invalid/chat")
-                .header("authorization", format!("Bearer {token}"))
-                .body(Vec::new())
-                .map_err(|e| LLMError::InvalidRequest(format!("failed building request: {e}")))?;
-            Ok(req)
-        }
-
-        fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn supports_streaming(&self) -> bool {
-            false
-        }
-
-        fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPCompletionProvider for ResolveAwareHttpProvider {
-        fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPEmbeddingProvider for ResolveAwareHttpProvider {
-        fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPLLMProvider for ResolveAwareHttpProvider {
-        fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
-            Some(&self.resolver)
-        }
-    }
-
-    #[test]
-    fn set_key_resolver_forwards_to_inner_provider() {
-        let inner: Box<dyn HTTPLLMProvider> = Box::new(DummyHttpProvider { resolver: None });
-        let mut adapter = LLMProviderFromHTTP::new(inner);
-        let resolver = static_key("resolver-token");
-
-        adapter.set_key_resolver(resolver.clone());
-
-        let forwarded = adapter
-            .key_resolver()
-            .expect("resolver should be set on wrapped provider");
-        assert_eq!(forwarded.current(), "resolver-token");
-    }
-
-    #[tokio::test]
-    async fn ensure_credential_fresh_resolves_before_request_building() {
-        let resolver = Arc::new(CountingResolver::new());
-        let inner: Box<dyn HTTPLLMProvider> = Box::new(ResolveAwareHttpProvider {
-            resolver: resolver.clone(),
-        });
-        let adapter = LLMProviderFromHTTP::new(inner);
-
-        assert_eq!(resolver.resolve_count(), 0);
-        assert_eq!(
-            adapter
-                .inner
-                .chat_request(&[], None)
-                .expect("request should build")
-                .headers()
-                .get("authorization")
-                .expect("auth header should exist"),
-            "Bearer stale-token"
-        );
-
-        adapter
-            .ensure_credential_fresh()
-            .await
-            .expect("resolver should succeed");
-
-        assert_eq!(resolver.resolve_count(), 1);
-        assert_eq!(
-            adapter
-                .inner
-                .chat_request(&[], None)
-                .expect("request should build")
-                .headers()
-                .get("authorization")
-                .expect("auth header should exist"),
-            "Bearer resolved-token"
-        );
-    }
-}
+#[path = "adapters/tests.rs"]
+mod tests;

--- a/crates/querymt/src/adapters/tests.rs
+++ b/crates/querymt/src/adapters/tests.rs
@@ -1,0 +1,481 @@
+use super::*;
+use crate::auth::{ApiKeyResolver, static_key};
+use crate::chat::ChatProvider;
+use crate::chat::http::{ChatStreamParser, HTTPChatProvider};
+use crate::completion::http::HTTPCompletionProvider;
+use crate::embedding::http::HTTPEmbeddingProvider;
+use crate::error::LLMError;
+use futures::StreamExt;
+use http::{Request, Response};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct DummyHttpProvider {
+    resolver: Option<Arc<dyn ApiKeyResolver>>,
+}
+
+#[derive(Debug)]
+struct CountingResolver {
+    resolves: AtomicUsize,
+}
+
+impl CountingResolver {
+    fn new() -> Self {
+        Self {
+            resolves: AtomicUsize::new(0),
+        }
+    }
+
+    fn resolve_count(&self) -> usize {
+        self.resolves.load(Ordering::SeqCst)
+    }
+}
+
+impl ApiKeyResolver for CountingResolver {
+    fn resolve(&self) -> Pin<Box<dyn Future<Output = Result<(), LLMError>> + Send + '_>> {
+        self.resolves.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn current(&self) -> String {
+        if self.resolve_count() > 0 {
+            "resolved-token".to_string()
+        } else {
+            "stale-token".to_string()
+        }
+    }
+}
+
+struct ResolveAwareHttpProvider {
+    resolver: Arc<dyn ApiKeyResolver>,
+}
+
+impl HTTPChatProvider for DummyHttpProvider {
+    fn chat_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPCompletionProvider for DummyHttpProvider {
+    fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPEmbeddingProvider for DummyHttpProvider {
+    fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPLLMProvider for DummyHttpProvider {
+    fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
+        self.resolver.as_ref()
+    }
+
+    fn set_key_resolver(&mut self, resolver: Arc<dyn ApiKeyResolver>) {
+        self.resolver = Some(resolver);
+    }
+}
+
+impl HTTPChatProvider for ResolveAwareHttpProvider {
+    fn chat_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        let token = self.resolver.current();
+        let req = Request::builder()
+            .method("POST")
+            .uri("https://example.invalid/chat")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Vec::new())
+            .map_err(|e| LLMError::InvalidRequest(format!("failed building request: {e}")))?;
+        Ok(req)
+    }
+
+    fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPCompletionProvider for ResolveAwareHttpProvider {
+    fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPEmbeddingProvider for ResolveAwareHttpProvider {
+    fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPLLMProvider for ResolveAwareHttpProvider {
+    fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
+        Some(&self.resolver)
+    }
+}
+
+#[test]
+fn set_key_resolver_forwards_to_inner_provider() {
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(DummyHttpProvider { resolver: None });
+    let mut adapter = LLMProviderFromHTTP::new(inner);
+    let resolver = static_key("resolver-token");
+
+    adapter.set_key_resolver(resolver.clone());
+
+    let forwarded = adapter
+        .key_resolver()
+        .expect("resolver should be set on wrapped provider");
+    assert_eq!(forwarded.current(), "resolver-token");
+}
+
+#[tokio::test]
+async fn ensure_credential_fresh_resolves_before_request_building() {
+    let resolver = Arc::new(CountingResolver::new());
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(ResolveAwareHttpProvider {
+        resolver: resolver.clone(),
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    assert_eq!(resolver.resolve_count(), 0);
+    assert_eq!(
+        adapter
+            .inner
+            .chat_request(&[], None)
+            .expect("request should build")
+            .headers()
+            .get("authorization")
+            .expect("auth header should exist"),
+        "Bearer stale-token"
+    );
+
+    adapter
+        .ensure_credential_fresh()
+        .await
+        .expect("resolver should succeed");
+
+    assert_eq!(resolver.resolve_count(), 1);
+    assert_eq!(
+        adapter
+            .inner
+            .chat_request(&[], None)
+            .expect("request should build")
+            .headers()
+            .get("authorization")
+            .expect("auth header should exist"),
+        "Bearer resolved-token"
+    );
+}
+
+/// One-shot HTTP/1.1 responder for adapter integration tests.
+async fn serve_once(status_line: &str, headers: &[(&str, &str)], body: &[u8]) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let body = body.to_vec();
+    let headers: Vec<(String, String)> = headers
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+        .collect();
+    let status_line = status_line.to_owned();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+        let mut buf = vec![0u8; 8192];
+        let _ = socket.read(&mut buf).await;
+        let mut response = format!("{status_line}\r\nContent-Length: {}\r\n", body.len());
+        for (k, v) in &headers {
+            response.push_str(&format!("{k}: {v}\r\n"));
+        }
+        response.push_str("Connection: close\r\n\r\n");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write hdr");
+        socket.write_all(&body).await.expect("write body");
+    });
+
+    format!("http://{addr}/chat")
+}
+
+/// Streaming HTTP provider that hits a fixed URI and classifies with a
+/// vendor-shaped kind so tests can prove the adapter path (not status-only).
+struct StreamTestProvider {
+    uri: String,
+    parser: StreamTestParserMode,
+}
+
+#[derive(Clone, Copy)]
+enum StreamTestParserMode {
+    /// Never reached on open-failure tests.
+    Unused,
+    /// `finish()` returns a classified permanent failure.
+    FinishClassified,
+    /// Non-empty lines classify as rate-limited.
+    ChunkClassified,
+}
+
+struct StreamTestParser {
+    mode: StreamTestParserMode,
+}
+
+impl ChatStreamParser for StreamTestParser {
+    fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, crate::error::LLMError> {
+        match self.mode {
+            StreamTestParserMode::ChunkClassified
+                if !chunk.iter().all(|b| b.is_ascii_whitespace()) =>
+            {
+                Err(crate::error::ProviderFailure::new(
+                    crate::error::ProviderErrorKind::RateLimited,
+                    "mid-stream boom",
+                )
+                .with_retry_after_secs(Some(3))
+                .into())
+            }
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamChunk>, crate::error::LLMError> {
+        match self.mode {
+            StreamTestParserMode::FinishClassified => Err(crate::error::ProviderFailure::new(
+                crate::error::ProviderErrorKind::QuotaExceeded,
+                "finish boom",
+            )
+            .into()),
+            _ => Ok(Vec::new()),
+        }
+    }
+}
+
+impl HTTPChatProvider for StreamTestProvider {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> crate::error::LLMError {
+        // Prove the adapter calls the provider classifier (not only status-only).
+        let body = String::from_utf8_lossy(response.body());
+        crate::error::ProviderFailure::new(
+            crate::error::ProviderErrorKind::RateLimited,
+            format!("classified:{body}"),
+        )
+        .with_retry_after_secs(Some(9))
+        .with_code(Some("vendor_rate".into()))
+        .into()
+    }
+
+    fn chat_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn chat_stream_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        Request::builder()
+            .method("POST")
+            .uri(&self.uri)
+            .body(Vec::new())
+            .map_err(|e| LLMError::InvalidRequest(e.to_string()))
+    }
+
+    fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Ok(Box::new(StreamTestParser { mode: self.parser }))
+    }
+}
+
+impl HTTPCompletionProvider for StreamTestProvider {
+    fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+}
+
+impl HTTPEmbeddingProvider for StreamTestProvider {
+    fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+}
+
+impl HTTPLLMProvider for StreamTestProvider {}
+
+#[tokio::test]
+async fn stream_open_non_success_preserves_classification() {
+    let uri = serve_once(
+        "HTTP/1.1 429 Too Many Requests",
+        &[("Retry-After", "5"), ("Content-Type", "application/json")],
+        br#"{"error":"vendor body"}"#,
+    )
+    .await;
+
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(StreamTestProvider {
+        uri,
+        parser: StreamTestParserMode::Unused,
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    let err = match adapter.chat_stream_with_tools(&[], None).await {
+        Ok(_) => panic!("non-success stream open must fail before yielding a stream"),
+        Err(e) => e,
+    };
+
+    match &err {
+        LLMError::ProviderResponseError(failure) => {
+            assert!(
+                failure.message().contains("classified:")
+                    && failure.message().contains("vendor body"),
+                "adapter must use provider classify_chat_error, got message={}",
+                failure.message()
+            );
+            assert_eq!(failure.kind(), crate::error::ProviderErrorKind::RateLimited);
+            assert_eq!(failure.code(), Some("vendor_rate"));
+            assert_eq!(failure.retry_after_secs(), Some(9));
+        }
+        other => panic!("expected ProviderResponseError, got {other}"),
+    }
+    assert!(err.is_retryable());
+    assert!(err.is_rate_limited());
+}
+
+#[tokio::test]
+async fn stream_parser_finish_failure_preserves_classification() {
+    let uri = serve_once(
+        "HTTP/1.1 200 OK",
+        &[("Content-Type", "text/event-stream")],
+        b"", // empty body; adapter still calls finish() on stream end
+    )
+    .await;
+
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(StreamTestProvider {
+        uri,
+        parser: StreamTestParserMode::FinishClassified,
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    let mut stream = adapter
+        .chat_stream_with_tools(&[], None)
+        .await
+        .expect("200 open should succeed");
+
+    let err = loop {
+        match stream.next().await {
+            Some(Err(e)) => break e,
+            Some(Ok(_)) => continue,
+            None => panic!("expected classified finish error before stream end"),
+        }
+    };
+
+    match &err {
+        LLMError::ProviderResponseError(failure) => {
+            assert_eq!(failure.message(), "finish boom");
+            assert_eq!(
+                failure.kind(),
+                crate::error::ProviderErrorKind::QuotaExceeded
+            );
+        }
+        other => panic!("expected ProviderResponseError, got {other}"),
+    }
+    assert!(!err.is_retryable());
+}
+
+#[tokio::test]
+async fn stream_parser_chunk_failure_preserves_classification() {
+    let uri = serve_once(
+        "HTTP/1.1 200 OK",
+        &[("Content-Type", "text/event-stream")],
+        b"data: nope\n",
+    )
+    .await;
+
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(StreamTestProvider {
+        uri,
+        parser: StreamTestParserMode::ChunkClassified,
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    let mut stream = adapter
+        .chat_stream_with_tools(&[], None)
+        .await
+        .expect("200 open should succeed");
+
+    let err = loop {
+        match stream.next().await {
+            Some(Err(e)) => break e,
+            Some(Ok(_)) => continue,
+            None => panic!("expected classified chunk error before stream end"),
+        }
+    };
+
+    match &err {
+        LLMError::ProviderResponseError(failure) => {
+            assert_eq!(failure.message(), "mid-stream boom");
+            assert_eq!(failure.kind(), crate::error::ProviderErrorKind::RateLimited);
+            assert_eq!(failure.retry_after_secs(), Some(3));
+        }
+        other => panic!("expected ProviderResponseError, got {other}"),
+    }
+    assert!(err.is_retryable());
+}

--- a/crates/querymt/src/chat/http.rs
+++ b/crates/querymt/src/chat/http.rs
@@ -1,9 +1,10 @@
 use crate::{
     Tool,
     chat::{ChatMessage, ChatResponse, StreamChunk},
-    error::LLMError,
+    error::{LLMError, classify_status_only},
 };
 use http::{Request, Response};
+use std::{future::Future, pin::Pin};
 
 pub trait ChatStreamParser: Send {
     fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, LLMError>;
@@ -14,6 +15,21 @@ pub trait ChatStreamParser: Send {
 }
 
 pub trait HTTPChatProvider: Send + Sync {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_status_only(
+            response.status().as_u16(),
+            response.headers(),
+            response.body(),
+        )
+    }
+
+    fn classify_chat_error_async<'a>(
+        &'a self,
+        response: &'a Response<Vec<u8>>,
+    ) -> Pin<Box<dyn Future<Output = LLMError> + Send + 'a>> {
+        Box::pin(async move { self.classify_chat_error(response) })
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -30,6 +46,11 @@ pub trait HTTPChatProvider: Send + Sync {
         ))
     }
 
+    /// Parse a **successful** chat HTTP body.
+    ///
+    /// The HTTP adapter only calls this after a success status. Non-success
+    /// responses go through [`Self::classify_chat_error`] instead — do not
+    /// re-check status here.
     fn parse_chat(&self, resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError>;
 
     fn supports_streaming(&self) -> bool {

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -15,6 +15,136 @@ pub enum TransportErrorKind {
     Other,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderErrorKind {
+    ServerOverloaded,
+    RateLimited,
+    QuotaExceeded,
+    ContextWindowExceeded,
+    Authentication,
+    InvalidRequest,
+    /// Unclassified vendor failure treated as transient (e.g. bare 5xx).
+    /// Retryability lives **only** on the kind — there is no parallel
+    /// `transient` flag that can disagree.
+    UnknownTransient,
+    /// Unclassified vendor failure treated as permanent.
+    #[serde(other)]
+    UnknownPermanent,
+}
+
+impl ProviderErrorKind {
+    /// Unified retry policy for provider failures.
+    ///
+    /// QueryMT product choice: overload is retried (upstream Codex marks it
+    /// non-retryable). Quota/context/auth/request failures never are.
+    /// [`Self::UnknownTransient`] / [`Self::UnknownPermanent`] cover unmapped
+    /// vendor envelopes without a second field.
+    pub fn is_retryable(self) -> bool {
+        matches!(
+            self,
+            Self::ServerOverloaded | Self::RateLimited | Self::UnknownTransient
+        )
+    }
+}
+
+/// Structured provider failure with retry semantics and vendor diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFailure {
+    message: String,
+    kind: ProviderErrorKind,
+    code: Option<String>,
+    error_type: Option<String>,
+    request_id: Option<String>,
+    retry_after_secs: Option<u64>,
+}
+
+impl ProviderFailure {
+    pub fn new(kind: ProviderErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            kind,
+            code: None,
+            error_type: None,
+            request_id: None,
+            retry_after_secs: None,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn kind(&self) -> ProviderErrorKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+
+    pub fn error_type(&self) -> Option<&str> {
+        self.error_type.as_deref()
+    }
+
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        self.retry_after_secs
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
+    }
+
+    pub fn with_code(mut self, code: Option<String>) -> Self {
+        self.code = code;
+        self
+    }
+
+    pub fn with_error_type(mut self, error_type: Option<String>) -> Self {
+        self.error_type = error_type;
+        self
+    }
+
+    pub fn with_request_id(mut self, request_id: Option<String>) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn with_retry_after_secs(mut self, retry_after_secs: Option<u64>) -> Self {
+        self.retry_after_secs = retry_after_secs;
+        self
+    }
+}
+
+impl std::fmt::Display for ProviderFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (kind={:?}", self.message, self.kind)?;
+        if let Some(code) = &self.code {
+            write!(f, ", code={code}")?;
+        }
+        if let Some(error_type) = &self.error_type {
+            write!(f, ", type={error_type}")?;
+        }
+        if let Some(request_id) = &self.request_id {
+            write!(f, ", request_id={request_id}")?;
+        }
+        if let Some(retry_after_secs) = self.retry_after_secs {
+            write!(f, ", retry_after_secs={retry_after_secs}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl From<ProviderFailure> for LLMError {
+    fn from(failure: ProviderFailure) -> Self {
+        Self::ProviderResponseError(Box::new(failure))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LLMErrorPayload {
@@ -23,6 +153,16 @@ pub enum LLMErrorPayload {
     },
     ProviderError {
         message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kind: Option<ProviderErrorKind>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_type: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_after_secs: Option<u64>,
     },
     AuthError {
         message: String,
@@ -88,6 +228,10 @@ pub enum LLMError {
     #[error("LLM Provider Error: {0}")]
     ProviderError(String),
 
+    /// A provider failure with structured classification metadata.
+    #[error("LLM Provider Error: {0}")]
+    ProviderResponseError(Box<ProviderFailure>),
+
     /// A wrapper for authentication/authorization errors.
     #[error("Auth Error: {0}")]
     AuthError(String),
@@ -152,12 +296,16 @@ pub enum LLMError {
     NotImplemented(String),
 
     /// Handles JSON serialization and deserialization errors.
+    ///
+    /// Stored as a string so wire payloads round-trip without changing retryability.
     #[error("JSON Error: {0}")]
-    JsonError(#[from] serde_json::Error),
+    JsonError(String),
 
     /// Handles errors from parsing URLs.
-    #[error("Invalid URL")]
-    InvalidUrl(#[from] url::ParseError),
+    ///
+    /// Stored as a string so wire payloads round-trip without changing retryability.
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
 
     /// Handles standard I/O errors.
     #[error("I/O Error")]
@@ -172,6 +320,19 @@ impl LLMError {
             },
             Self::ProviderError(message) => LLMErrorPayload::ProviderError {
                 message: message.clone(),
+                kind: None,
+                code: None,
+                error_type: None,
+                request_id: None,
+                retry_after_secs: None,
+            },
+            Self::ProviderResponseError(failure) => LLMErrorPayload::ProviderError {
+                message: failure.message.clone(),
+                kind: Some(failure.kind),
+                code: failure.code.clone(),
+                error_type: failure.error_type.clone(),
+                request_id: failure.request_id.clone(),
+                retry_after_secs: failure.retry_after_secs,
             },
             Self::AuthError(message) => LLMErrorPayload::AuthError {
                 message: message.clone(),
@@ -227,11 +388,11 @@ impl LLMError {
             Self::NotImplemented(message) => LLMErrorPayload::NotImplemented {
                 message: message.clone(),
             },
-            Self::JsonError(err) => LLMErrorPayload::JsonError {
-                message: err.to_string(),
+            Self::JsonError(message) => LLMErrorPayload::JsonError {
+                message: message.clone(),
             },
-            Self::InvalidUrl(err) => LLMErrorPayload::InvalidUrl {
-                message: err.to_string(),
+            Self::InvalidUrl(message) => LLMErrorPayload::InvalidUrl {
+                message: message.clone(),
             },
             Self::IoError(err) => LLMErrorPayload::IoError {
                 message: err.to_string(),
@@ -242,7 +403,23 @@ impl LLMError {
     pub fn from_payload(payload: LLMErrorPayload) -> Self {
         match payload {
             LLMErrorPayload::GenericError { message } => Self::GenericError(message),
-            LLMErrorPayload::ProviderError { message } => Self::ProviderError(message),
+            LLMErrorPayload::ProviderError {
+                message,
+                kind,
+                code,
+                error_type,
+                request_id,
+                retry_after_secs,
+            } => match kind {
+                Some(kind) => Self::ProviderResponseError(Box::new(
+                    ProviderFailure::new(kind, message)
+                        .with_code(code)
+                        .with_error_type(error_type)
+                        .with_request_id(request_id)
+                        .with_retry_after_secs(retry_after_secs),
+                )),
+                None => Self::ProviderError(message),
+            },
             LLMErrorPayload::AuthError { message } => Self::AuthError(message),
             LLMErrorPayload::ToolConfigError { message } => Self::ToolConfigError(message),
             LLMErrorPayload::PluginError { message } => Self::PluginError(message),
@@ -280,8 +457,12 @@ impl LLMError {
                 Self::RemoteStreamReconnected { message }
             }
             LLMErrorPayload::NotImplemented { message } => Self::NotImplemented(message),
-            LLMErrorPayload::JsonError { message } => Self::PluginError(message),
-            LLMErrorPayload::InvalidUrl { message } => Self::HttpError(message),
+            // Lossless: keep payload tags as distinct runtime variants so
+            // payload.is_retryable() == from_payload(p).is_retryable().
+            LLMErrorPayload::JsonError { message } => Self::JsonError(message),
+            LLMErrorPayload::InvalidUrl { message } => Self::InvalidUrl(message),
+            // Io has no dedicated runtime variant; Transport is the stable
+            // retryable home and matches payload IoError retryability.
             LLMErrorPayload::IoError { message } => Self::Transport {
                 kind: TransportErrorKind::Other,
                 message,
@@ -297,12 +478,51 @@ impl LLMError {
             | Self::HttpStatus {
                 retry_after_secs, ..
             } => *retry_after_secs,
+            Self::ProviderResponseError(failure) => failure.retry_after_secs(),
             _ => None,
         }
     }
 
-    pub fn is_retryable_setup_failure(&self) -> bool {
-        self.is_retryable()
+    /// Whether this error is a rate-limit failure (for UI events / wait messaging).
+    ///
+    /// Two representations exist on purpose:
+    /// - [`Self::RateLimited`] / bare HTTP 429: generic HTTP path
+    /// - [`Self::ProviderResponseError`] with [`ProviderErrorKind::RateLimited`]:
+    ///   classified chat path
+    ///
+    /// Callers must use this helper instead of matching one form only.
+    pub fn is_rate_limited(&self) -> bool {
+        match self {
+            Self::RateLimited { .. } => true,
+            Self::HttpStatus {
+                status_code: 429, ..
+            } => true,
+            Self::ProviderResponseError(failure) => {
+                failure.kind() == ProviderErrorKind::RateLimited
+            }
+            _ => false,
+        }
+    }
+
+    /// Message + retry-after when [`Self::is_rate_limited`] is true.
+    pub fn rate_limit_info(&self) -> Option<(String, Option<u64>)> {
+        match self {
+            Self::RateLimited {
+                message,
+                retry_after_secs,
+            } => Some((message.clone(), *retry_after_secs)),
+            Self::HttpStatus {
+                status_code: 429,
+                message,
+                retry_after_secs,
+            } => Some((message.clone(), *retry_after_secs)),
+            Self::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::RateLimited =>
+            {
+                Some((failure.message.clone(), failure.retry_after_secs()))
+            }
+            _ => None,
+        }
     }
 
     /// Whether this error is worth retrying (transient infrastructure error).
@@ -311,6 +531,9 @@ impl LLMError {
     /// on a second attempt. Only semantic/auth/validation errors are not retryable.
     /// The mesh-specific `RemoteStreamDisconnected`/`RemoteStreamReconnected` events
     /// are excluded — they have their own handling in the streaming loop.
+    ///
+    /// Retry policy is keyed off **unified** error kinds. Vendor code tables live
+    /// in providers; they map wire errors into these variants before core sees them.
     pub fn is_retryable(&self) -> bool {
         match self {
             // Always retry: transient infrastructure
@@ -323,6 +546,10 @@ impl LLMError {
             Self::PluginError(_) => true, // may be a transient WASM/HTTP issue
             Self::IoError { .. } => true,
 
+            // Structured provider failure: unified kind policy, including
+            // explicit UnknownTransient / UnknownPermanent fallback kinds.
+            Self::ProviderResponseError(failure) => failure.is_retryable(),
+
             // Never retry: semantic errors
             Self::AuthError(_) => false,
             Self::InvalidRequest(_) => false,
@@ -331,8 +558,8 @@ impl LLMError {
             Self::ResponseFormatError { .. } => false,
             Self::GenericError(_) => false,
             Self::Cancelled => false,
-            Self::JsonError { .. } => false,
-            Self::InvalidUrl { .. } => false,
+            Self::JsonError(_) => false,
+            Self::InvalidUrl(_) => false,
             Self::NotImplemented(_) => false,
 
             // Mesh transport events — handled by the existing continue logic
@@ -442,7 +669,9 @@ fn json_retry_after_value(v: &serde_json::Value) -> Option<u64> {
 /// Checks common locations where providers embed retry hints:
 /// - `error.retry_after` / `error.retry_after_secs`
 /// - top-level `retry_after` / `retry_after_secs`
-fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
+///
+/// Vendor-agnostic field lookup only — no error-code classification.
+pub fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
     [
         json.pointer("/error/retry_after"),
         json.pointer("/error/retry_after_secs"),
@@ -454,11 +683,63 @@ fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
     .find_map(json_retry_after_value)
 }
 
-pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
-    if status_code == 499 {
-        return LLMError::Cancelled;
+/// Parse `"try again in 11.054s"` style delays from a provider message.
+///
+/// Used by providers (e.g. OpenAI/Codex rate-limit messages) after they have
+/// already decided the failure is a rate limit from structured `code`/`type`.
+pub fn parse_retry_after_from_message(message: &str) -> Option<u64> {
+    // Mirror openai/codex: `(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)`
+    let lower = message.to_ascii_lowercase();
+    let marker = "try again in";
+    let rest = lower.split_once(marker)?.1.trim_start();
+    let mut num = String::new();
+    let mut chars = rest.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() || c == '.' {
+            num.push(c);
+            chars.next();
+        } else {
+            break;
+        }
     }
+    if num.is_empty() {
+        return None;
+    }
+    let value: f64 = num.parse().ok()?;
+    // skip whitespace
+    while matches!(chars.peek(), Some(c) if c.is_whitespace()) {
+        chars.next();
+    }
+    let unit: String = chars
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if unit == "ms" {
+        let millis = value as u64;
+        return Some(if millis == 0 && value > 0.0 {
+            1
+        } else {
+            duration_to_secs(Duration::from_millis(millis.max(1)))
+        });
+    }
+    if unit == "s" || unit.starts_with("second") {
+        return Some(if value <= 0.0 {
+            0
+        } else if value < 1.0 {
+            1
+        } else {
+            value.ceil() as u64
+        });
+    }
+    None
+}
 
+/// Extract the human-readable message and retry hint from an error response.
+fn status_message_and_retry(
+    status_code: u16,
+    headers: &http::HeaderMap,
+    body: &[u8],
+) -> (String, Option<u64>) {
     // Parse body JSON once; reuse for both retry-after and message extraction.
     let body_json = serde_json::from_slice::<serde_json::Value>(body).ok();
 
@@ -478,6 +759,40 @@ pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &
     } else {
         clean_message
     };
+    (message, retry_after_secs)
+}
+
+/// Classify a non-success HTTP status when the body carries no recognizable
+/// vendor error envelope.
+pub fn classify_status_only(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let (message, retry_after_secs) = status_message_and_retry(status_code, headers, body);
+    let kind = match status_code {
+        429 => ProviderErrorKind::RateLimited,
+        401 | 403 => ProviderErrorKind::Authentication,
+        400 | 422 => ProviderErrorKind::InvalidRequest,
+        408 | 425 | 500..=599 => ProviderErrorKind::UnknownTransient,
+        _ => ProviderErrorKind::UnknownPermanent,
+    };
+    ProviderFailure::new(kind, message)
+        .with_retry_after_secs(retry_after_secs)
+        .into()
+}
+
+/// Generic HTTP status classifier.
+///
+/// Rate limits stay on the legacy [`LLMError::RateLimited`] variant here so
+/// generic HTTP failures keep the stable wire payload shape. Chat provider
+/// classifiers use [`classify_status_only`] or a vendor envelope classifier.
+pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let (message, retry_after_secs) = status_message_and_retry(status_code, headers, body);
 
     match status_code {
         401 | 403 => LLMError::AuthError(message),
@@ -499,6 +814,18 @@ pub fn transport_error(kind: TransportErrorKind, message: impl Into<String>) -> 
     LLMError::Transport {
         kind,
         message: message.into(),
+    }
+}
+
+impl From<serde_json::Error> for LLMError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::JsonError(err.to_string())
+    }
+}
+
+impl From<url::ParseError> for LLMError {
+    fn from(err: url::ParseError) -> Self {
+        Self::InvalidUrl(err.to_string())
     }
 }
 
@@ -530,7 +857,7 @@ impl From<reqwest::Error> for LLMError {
 
 impl From<http::Error> for LLMError {
     fn from(err: http::Error) -> Self {
-        LLMError::HttpError(err.to_string())
+        LLMError::InvalidRequest(err.to_string())
     }
 }
 
@@ -756,5 +1083,396 @@ mod tests {
         let body = b"Server Error";
         let err = classify_http_status(503, &headers, body);
         assert_eq!(err.retry_after_secs(), Some(60));
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum LegacyPayload {
+        ProviderError { message: String },
+    }
+
+    #[test]
+    fn legacy_provider_payload_deserialization() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "legacy failure"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            payload,
+            LLMErrorPayload::ProviderError {
+                message: "legacy failure".to_owned(),
+                kind: None,
+                code: None,
+                error_type: None,
+                request_id: None,
+                retry_after_secs: None,
+            }
+        );
+        assert!(matches!(
+            LLMError::from_payload(payload),
+            LLMError::ProviderError(message) if message == "legacy failure"
+        ));
+    }
+
+    #[test]
+    fn classified_error_preserves_kind_and_metadata() {
+        let error = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_error_type(Some("server_error".into()))
+            .with_request_id(Some("req-1".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-1"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert!(failure.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn flat_structured_payload_is_preserved() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "plugin busy",
+            "kind": "server_overloaded",
+            "code": "server_is_overloaded",
+            "request_id": "req-plugin"
+        }))
+        .expect("structured plugin payload should deserialize");
+
+        let error = LLMError::from_payload(payload);
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "plugin busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn provider_failure_converts_directly_to_llm_error() {
+        let error = LLMError::from(ProviderFailure::new(ProviderErrorKind::RateLimited, "busy"));
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn structured_semantic_errors_round_trip_through_legacy_provider_tag() {
+        let overloaded: LLMError =
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+                .with_code(Some("server_is_overloaded".into()))
+                .with_request_id(Some("req-1".into()))
+                .into();
+        let payload = overloaded.to_payload();
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "provider_error");
+        assert_eq!(json["kind"], "server_overloaded");
+        assert_eq!(json["code"], "server_is_overloaded");
+        let legacy: LegacyPayload = serde_json::from_value(json.clone()).unwrap();
+        assert!(matches!(
+            legacy,
+            LegacyPayload::ProviderError { message } if message == "busy"
+        ));
+        let restored =
+            LLMError::from_payload(serde_json::from_value::<LLMErrorPayload>(json).unwrap());
+        assert!(matches!(
+            restored,
+            LLMError::ProviderResponseError(failure)
+                if failure.message() == "busy"
+                    && failure.kind() == ProviderErrorKind::ServerOverloaded
+                    && failure.code() == Some("server_is_overloaded")
+                    && restored.is_retryable()
+        ));
+
+        let quota: LLMError = ProviderFailure::new(ProviderErrorKind::QuotaExceeded, "no credits")
+            .with_code(Some("insufficient_quota".into()))
+            .into();
+        assert!(!quota.is_retryable());
+        assert!(matches!(
+            LLMError::from_payload(quota.to_payload()),
+            LLMError::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::QuotaExceeded
+        ));
+
+        let context: LLMError =
+            ProviderFailure::new(ProviderErrorKind::ContextWindowExceeded, "too long")
+                .with_code(Some("context_length_exceeded".into()))
+                .into();
+        assert!(!context.is_retryable());
+        assert!(matches!(
+            LLMError::from_payload(context.to_payload()),
+            LLMError::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::ContextWindowExceeded
+        ));
+    }
+
+    #[test]
+    fn payload_retryability_is_owned_by_kind_alone() {
+        let overloaded = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::ServerOverloaded,
+            "busy",
+        ));
+        assert!(overloaded.is_retryable());
+
+        let quota = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::QuotaExceeded,
+            "no credits",
+        ));
+        assert!(!quota.is_retryable());
+    }
+
+    #[test]
+    fn unknown_kinds_and_metadata_are_preserved() {
+        let transient = ProviderFailure::new(ProviderErrorKind::UnknownTransient, "maybe")
+            .with_code(Some("unknown".into()));
+        assert!(transient.is_retryable());
+        assert_eq!(transient.kind(), ProviderErrorKind::UnknownTransient);
+
+        let permanent = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "nope")
+            .with_code(Some("unknown".into()));
+        assert!(!permanent.is_retryable());
+        assert_eq!(permanent.kind(), ProviderErrorKind::UnknownPermanent);
+
+        let permanent_with_hint = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "busy")
+            .with_retry_after_secs(Some(60));
+        assert!(!permanent_with_hint.is_retryable());
+        assert_eq!(
+            LLMError::from(permanent_with_hint).retry_after_secs(),
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn provider_failure_conversion_preserves_metadata() {
+        let error = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_error_type(Some("server_error".into()))
+            .with_request_id(Some("req-1".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.error_type(), Some("server_error"));
+                assert_eq!(failure.request_id(), Some("req-1"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert!(failure.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn server_overloaded_is_retryable_by_kind() {
+        let err: LLMError = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "capacity")
+            .with_code(Some("server_is_overloaded".into()))
+            .into();
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn provider_response_error_honors_unknown_transient_kind() {
+        let transient: LLMError =
+            ProviderFailure::new(ProviderErrorKind::UnknownTransient, "maybe")
+                .with_code(Some("unknown".into()))
+                .with_retry_after_secs(Some(5))
+                .into();
+        assert!(transient.is_retryable());
+        assert_eq!(transient.retry_after_secs(), Some(5));
+
+        let permanent: LLMError = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "nope")
+            .with_code(Some("unknown".into()))
+            .into();
+        assert!(!permanent.is_retryable());
+    }
+
+    #[test]
+    fn unknown_payload_kind_falls_back_to_permanent() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "future failure",
+            "kind": "future_provider_kind",
+            "code": "future_code",
+            "retry_after_secs": 90
+        }))
+        .expect("future provider kind should remain readable");
+
+        let error = LLMError::from_payload(payload);
+        assert!(!error.is_retryable());
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownPermanent);
+                assert_eq!(failure.code(), Some("future_code"));
+                assert_eq!(failure.retry_after_secs(), Some(90));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_status_only_owns_client_cancellation() {
+        let error = classify_status_only(499, &http::HeaderMap::new(), b"cancelled");
+        assert!(matches!(error, LLMError::Cancelled));
+    }
+
+    #[test]
+    fn classify_status_only_maps_status_to_unified_kinds() {
+        let headers = http::HeaderMap::new();
+
+        let rate_limited =
+            classify_status_only(429, &headers, br#"{"error":{"message":"slow down"}}"#);
+        assert!(matches!(
+            rate_limited,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::RateLimited
+                    && failure.message() == "slow down"
+        ));
+        assert!(rate_limited.is_retryable());
+
+        let auth = classify_status_only(401, &headers, b"bad key");
+        assert!(matches!(
+            auth,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::Authentication
+        ));
+        assert!(!auth.is_retryable());
+
+        let invalid = classify_status_only(422, &headers, b"bad field");
+        assert!(matches!(
+            invalid,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::InvalidRequest
+        ));
+        assert!(!invalid.is_retryable());
+
+        // Timeout-style statuses and unknown 5xx are transient.
+        for status in [408, 425, 503] {
+            let transient = classify_status_only(status, &headers, b"temporary failure");
+            assert!(matches!(
+                transient,
+                LLMError::ProviderResponseError(ref failure)
+                    if failure.kind() == ProviderErrorKind::UnknownTransient
+            ));
+            assert!(transient.is_retryable());
+        }
+
+        // Unknown 4xx: unclassified and permanent.
+        let weird = classify_status_only(418, &headers, b"teapot");
+        assert!(matches!(
+            weird,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownPermanent
+        ));
+        assert!(!weird.is_retryable());
+
+        let permanent_with_hint = classify_status_only(
+            401,
+            &http::HeaderMap::from_iter([(
+                http::header::RETRY_AFTER,
+                http::HeaderValue::from_static("30"),
+            )]),
+            b"bad key",
+        );
+        assert_eq!(permanent_with_hint.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn request_builder_errors_are_permanent_invalid_requests() {
+        let error = http::Request::builder()
+            .uri("\n")
+            .body(Vec::<u8>::new())
+            .expect_err("invalid URI must fail");
+        let error = LLMError::from(error);
+        assert!(matches!(error, LLMError::InvalidRequest(_)));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn rate_limit_info_covers_legacy_and_structured_forms() {
+        let legacy = LLMError::RateLimited {
+            message: "slow".into(),
+            retry_after_secs: Some(3),
+        };
+        assert!(legacy.is_rate_limited());
+        assert_eq!(legacy.rate_limit_info(), Some(("slow".into(), Some(3))));
+
+        let structured: LLMError = ProviderFailure::new(ProviderErrorKind::RateLimited, "slow")
+            .with_retry_after_secs(Some(4))
+            .into();
+        assert!(structured.is_rate_limited());
+        assert_eq!(structured.rate_limit_info(), Some(("slow".into(), Some(4))));
+
+        let http_429 = LLMError::HttpStatus {
+            status_code: 429,
+            message: "too many".into(),
+            retry_after_secs: Some(1),
+        };
+        assert!(http_429.is_rate_limited());
+        assert_eq!(
+            http_429.rate_limit_info(),
+            Some(("too many".into(), Some(1)))
+        );
+
+        let other = LLMError::GenericError("nope".into());
+        assert!(!other.is_rate_limited());
+        assert!(other.rate_limit_info().is_none());
+    }
+
+    #[test]
+    fn display_includes_message_and_metadata_once() {
+        let error: LLMError = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_request_id(Some("req-9".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+        let rendered = error.to_string();
+        assert_eq!(rendered.matches("busy").count(), 1);
+        assert!(
+            rendered.contains("ServerOverloaded"),
+            "missing kind: {rendered}"
+        );
+        assert!(rendered.contains("server_is_overloaded"));
+        assert!(rendered.contains("req-9"));
+        assert!(rendered.contains("retry_after_secs=2"));
+    }
+
+    #[test]
+    fn parse_retry_after_from_message_matches_codex_style() {
+        assert_eq!(
+            parse_retry_after_from_message(
+                "Rate limit reached. Please try again in 11.054s. Visit docs."
+            ),
+            Some(12) // ceil
+        );
+        assert_eq!(
+            parse_retry_after_from_message("Please try again in 30 seconds."),
+            Some(30)
+        );
+        assert_eq!(
+            parse_retry_after_from_message("Please try again in 500ms"),
+            Some(1)
+        );
+        assert_eq!(parse_retry_after_from_message("no delay mentioned"), None);
     }
 }

--- a/crates/querymt/src/outbound.rs
+++ b/crates/querymt/src/outbound.rs
@@ -1,7 +1,22 @@
+/// Outcome of a streaming outbound HTTP call before provider classification.
+///
+/// Success and failure are distinct variants so callers cannot treat an HTTP
+/// error status as a normal byte stream (the old `(Response<()>, stream)` pair
+/// returned `Ok` for both).
+pub enum OutboundStreamResult {
+    Success {
+        stream:
+            std::pin::Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>>,
+    },
+    /// Non-success status with the full error body already buffered.
+    Failure { response: http::Response<Vec<u8>> },
+}
+
 mod http_client {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod imp {
         use crate::error::{LLMError, classify_http_status};
+        use crate::outbound::OutboundStreamResult;
         use http::{Request, Response};
         use once_cell::sync::Lazy;
         use reqwest::Client;
@@ -102,14 +117,19 @@ mod http_client {
             truncate_preview(value.to_string(), max_len)
         }
 
-        pub async fn call_outbound(req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+        /// Send an HTTP request and preserve the response status, headers, and body.
+        ///
+        /// Provider adapters use this to apply provider-specific error classification.
+        pub async fn call_outbound_raw(
+            req: Request<Vec<u8>>,
+        ) -> Result<Response<Vec<u8>>, LLMError> {
             let client = &*CLIENT;
 
             let method = req
                 .method()
                 .as_str()
                 .parse::<reqwest::Method>()
-                .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
 
             #[cfg(debug_assertions)]
             {
@@ -134,7 +154,7 @@ mod http_client {
             for (name, value) in req.headers().iter() {
                 let val_str = value
                     .to_str()
-                    .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                    .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
                 rb = rb.header(name.as_str(), val_str);
             }
 
@@ -171,7 +191,6 @@ mod http_client {
                         .and_then(|v| v.to_str().ok())
                         .unwrap_or("<missing>")
                 );
-                return Err(classify_http_status(status.as_u16(), &headers, &bytes));
             }
 
             let mut builder = Response::builder().status(status.as_u16());
@@ -181,16 +200,20 @@ mod http_client {
             Ok(builder.body(bytes).unwrap())
         }
 
-        pub async fn call_outbound_stream(
+        /// Send a streaming HTTP request.
+        ///
+        /// Returns [`OutboundStreamResult`] so callers cannot mistake an HTTP
+        /// error body for a successful byte stream.
+        pub async fn call_outbound_stream_raw(
             req: Request<Vec<u8>>,
-        ) -> Result<impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>, LLMError> {
+        ) -> Result<OutboundStreamResult, LLMError> {
             let client = &*CLIENT;
 
             let method = req
                 .method()
                 .as_str()
                 .parse::<reqwest::Method>()
-                .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
 
             #[cfg(debug_assertions)]
             {
@@ -215,7 +238,7 @@ mod http_client {
             for (name, value) in req.headers().iter() {
                 let val_str = value
                     .to_str()
-                    .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                    .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
                 rb = rb.header(name.as_str(), val_str);
             }
 
@@ -251,9 +274,32 @@ mod http_client {
                         .and_then(|v| v.to_str().ok())
                         .unwrap_or("<missing>")
                 );
-                return Err(classify_http_status(status.as_u16(), &headers, &bytes));
+                let mut builder = Response::builder().status(status.as_u16());
+                for (name, value) in headers.iter() {
+                    builder = builder.header(name.as_str(), value.as_bytes());
+                }
+                return Ok(OutboundStreamResult::Failure {
+                    response: builder.body(bytes).unwrap(),
+                });
             }
-            Ok(resp.bytes_stream())
+
+            Ok(OutboundStreamResult::Success {
+                stream: Box::pin(resp.bytes_stream()),
+            })
+        }
+
+        /// Send an HTTP request using the generic status classifier.
+        pub async fn call_outbound(req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+            let response = call_outbound_raw(req).await?;
+            if response.status().is_success() {
+                return Ok(response);
+            }
+
+            Err(classify_http_status(
+                response.status().as_u16(),
+                response.headers(),
+                response.body(),
+            ))
         }
     }
 
@@ -262,16 +308,26 @@ mod http_client {
         use crate::error::LLMError;
         use http::{Request, Response};
 
-        pub async fn call_outbound(_req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+        pub async fn call_outbound_raw(
+            _req: Request<Vec<u8>>,
+        ) -> Result<Response<Vec<u8>>, LLMError> {
             Err(LLMError::InvalidRequest("".into()))
         }
 
-        pub async fn call_outbound_stream(
+        pub async fn call_outbound_stream_raw(
             _req: Request<Vec<u8>>,
-        ) -> Result<futures::stream::Empty<reqwest::Result<bytes::Bytes>>, LLMError> {
+        ) -> Result<crate::outbound::OutboundStreamResult, LLMError> {
+            Err(LLMError::InvalidRequest("".into()))
+        }
+
+        pub async fn call_outbound(_req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
             Err(LLMError::InvalidRequest("".into()))
         }
     }
 }
 
-pub use http_client::imp::{call_outbound, call_outbound_stream};
+pub use http_client::imp::{call_outbound, call_outbound_raw, call_outbound_stream_raw};
+
+#[cfg(test)]
+#[path = "outbound/tests.rs"]
+mod tests;

--- a/crates/querymt/src/outbound/tests.rs
+++ b/crates/querymt/src/outbound/tests.rs
@@ -1,0 +1,116 @@
+use super::{OutboundStreamResult, call_outbound_stream_raw};
+use http::Request;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// One-shot HTTP/1.1 responder on a random localhost port.
+async fn serve_once(status_line: &str, headers: &[(&str, &str)], body: &[u8]) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let body = body.to_vec();
+    let headers: Vec<(String, String)> = headers
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+        .collect();
+    let status_line = status_line.to_owned();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+        let mut buf = vec![0u8; 8192];
+        let _ = socket.read(&mut buf).await;
+        let mut response = format!("{status_line}\r\nContent-Length: {}\r\n", body.len());
+        for (k, v) in &headers {
+            response.push_str(&format!("{k}: {v}\r\n"));
+        }
+        response.push_str("Connection: close\r\n\r\n");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write hdr");
+        socket.write_all(&body).await.expect("write body");
+    });
+
+    format!("http://{addr}/stream")
+}
+
+#[tokio::test]
+async fn stream_raw_non_success_is_failure_with_status_headers_body() {
+    let uri = serve_once(
+        "HTTP/1.1 429 Too Many Requests",
+        &[
+            ("Retry-After", "11"),
+            ("x-request-id", "req-stream-1"),
+            ("Content-Type", "application/json"),
+        ],
+        br#"{"error":{"message":"slow down","type":"rate_limit_error"}}"#,
+    )
+    .await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(&uri)
+        .body(Vec::new())
+        .expect("request");
+
+    let result = call_outbound_stream_raw(req)
+        .await
+        .expect("transport should succeed");
+
+    match result {
+        OutboundStreamResult::Failure { response } => {
+            assert_eq!(response.status().as_u16(), 429);
+            assert_eq!(
+                response
+                    .headers()
+                    .get("retry-after")
+                    .and_then(|v| v.to_str().ok()),
+                Some("11")
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get("x-request-id")
+                    .and_then(|v| v.to_str().ok()),
+                Some("req-stream-1")
+            );
+            assert!(
+                std::str::from_utf8(response.body())
+                    .unwrap_or_default()
+                    .contains("slow down"),
+                "body should be preserved: {:?}",
+                String::from_utf8_lossy(response.body())
+            );
+        }
+        OutboundStreamResult::Success { .. } => {
+            panic!("non-success status must not open a success stream")
+        }
+    }
+}
+
+#[tokio::test]
+async fn stream_raw_success_returns_stream_variant() {
+    let uri = serve_once(
+        "HTTP/1.1 200 OK",
+        &[("Content-Type", "text/event-stream")],
+        b"data: {\"ok\":true}\n\n",
+    )
+    .await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(&uri)
+        .body(Vec::new())
+        .expect("request");
+
+    let result = call_outbound_stream_raw(req)
+        .await
+        .expect("transport should succeed");
+
+    match result {
+        OutboundStreamResult::Success { stream: _ } => {}
+        OutboundStreamResult::Failure { response } => {
+            panic!("expected Success, got Failure status={}", response.status())
+        }
+    }
+}

--- a/crates/querymt/src/plugin/adapters.rs
+++ b/crates/querymt/src/plugin/adapters.rs
@@ -32,11 +32,7 @@ impl LLMProviderFactory for HTTPFactoryAdapter {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn LLMProvider>, LLMError> {
-        let sync_provider = self
-            .inner
-            .from_config(cfg)
-            .map_err(|e| LLMError::PluginError(format!("{:#}", e)))?;
-
+        let sync_provider = self.inner.from_config(cfg)?;
         let adapter = LLMProviderFromHTTP::new(sync_provider);
         Ok(Box::new(adapter))
     }
@@ -54,10 +50,99 @@ impl LLMProviderFactory for HTTPFactoryAdapter {
             let req: Request<Vec<u8>> = inner.list_models_request(&cloned_cfg)?;
             let resp: Response<Vec<u8>> = call_outbound(req).await?;
 
-            inner
-                .parse_list_models(resp)
-                .map_err(|e| LLMError::PluginError(format!("{:#}", e)))
+            inner.parse_list_models(resp)
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    struct ErrorFactory {
+        list_models_uri: Option<String>,
+    }
+
+    impl ErrorFactory {
+        fn new(list_models_uri: Option<String>) -> Self {
+            Self { list_models_uri }
+        }
+    }
+
+    impl HTTPLLMProviderFactory for ErrorFactory {
+        fn name(&self) -> &str {
+            "error-factory"
+        }
+
+        fn config_schema(&self) -> String {
+            "{}".into()
+        }
+
+        fn list_models_request(&self, _cfg: &str) -> Result<Request<Vec<u8>>, LLMError> {
+            let uri = self
+                .list_models_uri
+                .as_deref()
+                .ok_or_else(|| LLMError::NotImplemented("unused".into()))?;
+            Request::get(uri)
+                .body(Vec::new())
+                .map_err(|error| LLMError::InvalidRequest(error.to_string()))
+        }
+
+        fn parse_list_models(&self, _resp: Response<Vec<u8>>) -> Result<Vec<String>, LLMError> {
+            Err(LLMError::JsonError("bad models response".into()))
+        }
+
+        fn from_config(&self, _cfg: &str) -> Result<Box<dyn crate::HTTPLLMProvider>, LLMError> {
+            Err(LLMError::InvalidRequest("bad provider config".into()))
+        }
+    }
+
+    async fn serve_once() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut request = [0; 1024];
+            let _ = socket.read(&mut request).await;
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+                .await
+                .expect("write response");
+        });
+
+        format!("http://{addr}/models")
+    }
+
+    #[test]
+    fn from_config_preserves_typed_error() {
+        let adapter = HTTPFactoryAdapter::new(Arc::new(ErrorFactory::new(None)));
+        let error = adapter.from_config("{}").err().expect("config should fail");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(
+            error,
+            LLMError::InvalidRequest(message) if message == "bad provider config"
+        ));
+    }
+
+    #[tokio::test]
+    async fn parse_list_models_preserves_typed_error() {
+        let adapter =
+            HTTPFactoryAdapter::new(Arc::new(ErrorFactory::new(Some(serve_once().await))));
+        let error = adapter
+            .list_models("{}")
+            .await
+            .expect_err("response parsing should fail");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(
+            error,
+            LLMError::JsonError(message) if message == "bad models response"
+        ));
     }
 }

--- a/crates/querymt/src/plugin/extism_impl/host/mod.rs
+++ b/crates/querymt/src/plugin/extism_impl/host/mod.rs
@@ -57,6 +57,10 @@ fn decode_plugin_error(e: extism::Error, code: i32) -> LLMError {
     PluginError::decode(code, &raw)
 }
 
+fn parse_config_json(cfg: &str) -> Result<Value, LLMError> {
+    serde_json::from_str(cfg).map_err(LLMError::from)
+}
+
 #[cfg(debug_assertions)]
 fn header_token_hint(value: Option<&http::HeaderValue>) -> String {
     let Some(value) = value else {
@@ -81,6 +85,10 @@ fn decode_stream_item(item: Result<Vec<u8>, LLMError>) -> Result<StreamChunk, LL
             .map_err(|e| LLMError::PluginError(format!("Failed to deserialize chunk: {}", e))),
         Err(llm_err) => Err(llm_err),
     }
+}
+
+fn decode_classified_plugin_error(error: PluginError) -> LLMError {
+    LLMError::from_payload(error.payload)
 }
 
 macro_rules! with_host_functions {
@@ -337,6 +345,14 @@ impl ExtismFactory {
     fn validate_runtime_base_url(&self, cfg: &Value) -> Result<(), LLMError> {
         validate_runtime_base_url(&self.name, &self.allowed_hosts, cfg)
     }
+
+    fn validate_plugin_config(&self, cfg: &Value) -> Result<(), LLMError> {
+        let mut plug = self.plugin.lock().unwrap();
+        let _: Json<Value> = plug
+            .call_get_error_code("from_config", Json(cfg.clone()))
+            .map_err(|(e, code)| decode_plugin_error(e, code))?;
+        Ok(())
+    }
 }
 
 fn validate_runtime_base_url(
@@ -385,13 +401,10 @@ impl LLMProviderFactory for ExtismFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn LLMProvider>, LLMError> {
-        let cfg_value: Value = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("Invalid JSON config: {:#}", e)))?;
+        let cfg_value = parse_config_json(cfg)?;
         self.validate_runtime_base_url(&cfg_value)?;
 
-        let _from_cfg = self
-            .call("from_config", &cfg_value)
-            .map_err(|e| LLMError::PluginError(format!("{:#}", e)))?;
+        self.validate_plugin_config(&cfg_value)?;
 
         let provider = ExtismProvider {
             plugin: self.plugin.clone(),
@@ -411,16 +424,9 @@ impl LLMProviderFactory for ExtismFactory {
     fn list_models<'a>(&'a self, cfg: &str) -> Fut<'a, Result<Vec<String>, LLMError>> {
         // list_models can do host HTTP calls, so run the Extism VM call off the Tokio runtime
         // thread to avoid deadlocks on current-thread runtimes.
-        let cfg_value: Value = match serde_json::from_str(cfg) {
-            Ok(v) => v,
-            Err(e) => {
-                return Box::pin(async move {
-                    Err(LLMError::PluginError(format!(
-                        "Invalid JSON config: {:#}",
-                        e
-                    )))
-                });
-            }
+        let cfg_value = match parse_config_json(cfg) {
+            Ok(value) => value,
+            Err(error) => return Box::pin(async move { Err(error) }),
         };
 
         if self.supports_http_adapter_abi() {
@@ -501,13 +507,10 @@ impl HTTPLLMProviderFactory for ExtismFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn crate::HTTPLLMProvider>, LLMError> {
-        let cfg_value: Value = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("Invalid JSON config: {:#}", e)))?;
+        let cfg_value = parse_config_json(cfg)?;
         self.validate_runtime_base_url(&cfg_value)?;
 
-        let _from_cfg = self
-            .call("from_config", &cfg_value)
-            .map_err(|e| LLMError::PluginError(format!("{:#}", e)))?;
+        self.validate_plugin_config(&cfg_value)?;
 
         let provider = ExtismProvider {
             plugin: self.plugin.clone(),
@@ -519,14 +522,9 @@ impl HTTPLLMProviderFactory for ExtismFactory {
     }
 
     fn list_models_static(&self, cfg: &str) -> Option<Result<Vec<String>, LLMError>> {
-        let cfg_value: Value = match serde_json::from_str(cfg) {
-            Ok(v) => v,
-            Err(e) => {
-                return Some(Err(LLMError::PluginError(format!(
-                    "Invalid JSON config: {:#}",
-                    e
-                ))));
-            }
+        let cfg_value = match parse_config_json(cfg) {
+            Ok(value) => value,
+            Err(error) => return Some(Err(error)),
         };
 
         let mut plug = self.plugin.lock().unwrap();
@@ -548,8 +546,7 @@ impl HTTPLLMProviderFactory for ExtismFactory {
     }
 
     fn list_models_request(&self, cfg: &str) -> Result<http::Request<Vec<u8>>, LLMError> {
-        let cfg_value: Value = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("Invalid JSON config: {:#}", e)))?;
+        let cfg_value = parse_config_json(cfg)?;
         self.validate_runtime_base_url(&cfg_value)?;
 
         let mut plug = self.plugin.lock().unwrap();
@@ -613,8 +610,11 @@ impl ExtismProvider {
     where
         F: FnOnce(&mut Plugin) -> Result<T, LLMError>,
     {
-        let mut plug = self.plugin.lock().unwrap();
-        f(&mut plug).map_err(|e| LLMError::PluginError(format!("Extism {op} failed: {:#}", e)))
+        let mut plug = self
+            .plugin
+            .lock()
+            .map_err(|_| LLMError::PluginError(format!("Extism {op} mutex poisoned")))?;
+        f(&mut plug)
     }
 
     async fn call_blocking_with_cancel<T, F>(&self, op: &'static str, f: F) -> Result<T, LLMError>
@@ -1177,6 +1177,51 @@ impl ChatStreamParser for ExtismStreamParser {
 }
 
 impl HTTPChatProvider for ExtismProvider {
+    fn classify_chat_error_async<'a>(
+        &'a self,
+        response: &'a http::Response<Vec<u8>>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = LLMError> + Send + 'a>> {
+        Box::pin(async move {
+            {
+                let plug = match self.plugin.lock() {
+                    Ok(plug) => plug,
+                    Err(_) => {
+                        return LLMError::PluginError(
+                            "Extism classify_chat_error mutex poisoned".into(),
+                        );
+                    }
+                };
+                if !plug.function_exists("classify_chat_error") {
+                    return self.classify_chat_error(response);
+                }
+            }
+
+            let cfg = match self.effective_config() {
+                Ok(cfg) => cfg,
+                Err(error) => return error,
+            };
+            let response = response.clone();
+            match self
+                .call_blocking_with_cancel("classify_chat_error", move |plug| {
+                    let error: Json<PluginError> = plug
+                        .call_get_error_code(
+                            "classify_chat_error",
+                            Json(ExtismChatParseRequest {
+                                cfg,
+                                resp: SerializableHttpResponse { resp: response },
+                            }),
+                        )
+                        .map_err(|(e, code)| decode_plugin_error(e, code))?;
+                    Ok(error.0)
+                })
+                .await
+            {
+                Ok(error) => decode_classified_plugin_error(error),
+                Err(error) => error,
+            }
+        })
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -1384,6 +1429,14 @@ mod tests {
     use crate::chat::StreamChunk;
 
     #[test]
+    fn malformed_config_is_json_error() {
+        let error = parse_config_json("{").expect_err("config should be rejected");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(error, LLMError::JsonError(_)));
+    }
+
+    #[test]
     fn build_allowed_hosts_prefers_configured_base_url_over_plugin_default() {
         let config = Some(HashMap::from([(
             "base_url".to_string(),
@@ -1475,5 +1528,33 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn decode_classified_plugin_error_preserves_structured_context() {
+        let error = crate::error::ProviderFailure::new(
+            crate::error::ProviderErrorKind::ServerOverloaded,
+            "plugin busy",
+        )
+        .with_code(Some("server_is_overloaded".into()))
+        .with_request_id(Some("req-plugin".into()))
+        .with_retry_after_secs(Some(2))
+        .into();
+
+        let decoded = decode_classified_plugin_error(PluginError::from_llm_error(&error));
+
+        match decoded {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "plugin busy");
+                assert_eq!(
+                    failure.kind(),
+                    crate::error::ProviderErrorKind::ServerOverloaded
+                );
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
     }
 }

--- a/crates/querymt/src/plugin/extism_impl/interface.rs
+++ b/crates/querymt/src/plugin/extism_impl/interface.rs
@@ -67,6 +67,35 @@ impl PluginError {
     }
 }
 
+#[cfg(test)]
+mod plugin_error_tests {
+    use super::*;
+    use crate::error::{ProviderErrorKind, ProviderFailure};
+
+    #[test]
+    fn structured_provider_error_round_trips_across_plugin_boundary() {
+        let error = LLMError::from(
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "plugin busy")
+                .with_code(Some("server_is_overloaded".into()))
+                .with_request_id(Some("req-plugin".into()))
+                .with_retry_after_secs(Some(2)),
+        );
+
+        let (json, code) = PluginError::encode(&error);
+        let decoded = PluginError::decode(code, &json);
+
+        match decoded {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+}
+
 // ============================================================================
 // HTTP streaming result type
 // ============================================================================

--- a/crates/querymt/src/plugin/http.rs
+++ b/crates/querymt/src/plugin/http.rs
@@ -38,6 +38,14 @@ pub trait HTTPLLMProviderFactory: Send + Sync {
 #[allow(improper_ctypes_definitions)]
 pub type HTTPFactoryCtor = unsafe extern "C" fn() -> *mut dyn HTTPLLMProviderFactory;
 
+/// Classify a non-success HTTP response with the **generic** status classifier
+/// (legacy [`crate::error::LLMError`] variants).
+///
+/// Use this on paths the HTTP adapter does **not** pre-classify — e.g.
+/// completions, embeddings, STT/TTS, list-models.
+///
+/// **Do not** use on chat `parse_chat` / stream parsers. Chat non-success is
+/// owned by [`crate::chat::http::HTTPChatProvider::classify_chat_error`].
 #[macro_export]
 macro_rules! handle_http_error {
     ($resp:expr) => {{


### PR DESCRIPTION
## what changed

- preserve typed `LLMError` values through http adapters, stream parsers, factories, session initialization, and outbound callers
- preserve structured errors through extism/wasm while keeping old plugins compatible
- preserve malformed config as non-retryable `JsonError`
- add adapter, outbound, extism, and provider-init regressions

## review boundary

this pr transports #750's final types. it does not classify provider-specific payloads.

## stack

#750 -> **#751** -> #752 -> #754 -> #755 -> #765
