### PR TITLE
feat(agent): add bounded provider retry policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11100,6 +11100,7 @@ dependencies = [
  "querymt-provider-common",
  "querymt-remote",
  "querymt-utils",
+ "rand 0.9.4",
  "rapidhash",
  "rayon",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10781,6 +10781,7 @@ dependencies = [
  "base64 0.22.1",
  "extism-pdk",
  "http 1.4.2",
+ "log",
  "querymt",
  "querymt-extism-macros",
  "schemars 1.2.1",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -56,6 +56,7 @@ rusqlite = { version = "0.40", features = ["bundled", "uuid", "time"] }
 time = { version = "0.3", features = ["serde", "formatting", "macros", "local-offset"] }
 uuid = { version = "1.18", features = ["v4", "v7"] }
 rapidhash = "4.2"
+rand = "0.9"
 ignore = "0.4.25"
 notify = "8"
 glob = "0.3"

--- a/crates/agent/src/agent/execution/llm_retry.rs
+++ b/crates/agent/src/agent/execution/llm_retry.rs
@@ -1,12 +1,12 @@
 //! LLM retry logic with rate limit handling
 //!
-//! This module handles retrying LLM calls with exponential backoff when rate limits are hit.
+//! This module handles retrying transient LLM failures with configurable backoff.
 
 use crate::agent::agent_config::AgentConfig;
 use crate::agent::utils::u32_from_usize;
 use crate::events::AgentEventKind;
-use futures_util::Stream;
-use log::{debug, info};
+use futures_util::{Stream, StreamExt};
+use log::{info, warn};
 use querymt::chat::StreamChunk;
 use querymt::error::LLMError;
 use std::future::Future;
@@ -14,34 +14,45 @@ use std::pin::Pin;
 use tokio_util::sync::CancellationToken;
 use tracing::{Span, instrument};
 
-/// Call an LLM with automatic retry on rate limit errors.
+/// Call an LLM with automatic retry for transient provider and transport errors.
 ///
-/// This function wraps any LLM call and automatically retries with exponential backoff
-/// when rate limit errors are detected. It respects cancellation via the `cancel_rx` channel.
+/// Uses provider hints or exponential backoff and respects cancellation via the token.
 #[instrument(
     name = "agent.llm.call_with_retry",
     skip(config, cancel_token, call_fn),
-    fields(session_id = %session_id, attempt = tracing::field::Empty, rate_limited = tracing::field::Empty)
+    fields(session_id = %session_id, attempt = tracing::field::Empty, retrying = tracing::field::Empty)
 )]
-pub(super) async fn call_llm_with_retry<F, Fut>(
+pub(super) async fn call_with_retry<T, F, Fut>(
+    config: &AgentConfig,
+    session_id: &str,
+    cancel_token: &CancellationToken,
+    call_fn: F,
+) -> Result<T, LLMError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, LLMError>>,
+{
+    call_with_retry_mode(config, session_id, cancel_token, call_fn).await
+}
+
+async fn call_with_retry_mode<T, F, Fut>(
     config: &AgentConfig,
     session_id: &str,
     cancel_token: &CancellationToken,
     mut call_fn: F,
-) -> Result<Box<dyn querymt::chat::ChatResponse>, anyhow::Error>
+) -> Result<T, LLMError>
 where
     F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<Box<dyn querymt::chat::ChatResponse>, LLMError>>,
+    Fut: Future<Output = Result<T, LLMError>>,
 {
-    let max_retries = config.execution_policy.rate_limit.max_retries;
+    let max_attempts = config.execution_policy.rate_limit.max_attempts();
     let mut attempt = 0;
-    Span::current().record("rate_limited", false);
+    Span::current().record("retrying", false);
 
     loop {
         attempt += 1;
-
         if cancel_token.is_cancelled() {
-            return Err(anyhow::anyhow!("Cancelled"));
+            return Err(LLMError::Cancelled);
         }
 
         match call_fn().await {
@@ -49,244 +60,354 @@ where
                 Span::current().record("attempt", attempt);
                 return Ok(response);
             }
-            Err(e) => {
-                if let Some((message, retry_after)) = extract_rate_limit_info(&e) {
-                    Span::current().record("rate_limited", true);
-                    if attempt >= max_retries {
-                        return Err(anyhow::anyhow!(
-                            "Rate limit exceeded after {} attempts: {}",
-                            max_retries,
-                            message
-                        ));
-                    }
-
-                    let wait_secs = calculate_rate_limit_wait(config, retry_after, attempt);
-                    let started_at = time::OffsetDateTime::now_utc().unix_timestamp();
-
-                    info!(
-                        "Session {} rate limited, attempt {}/{}, waiting {}s",
-                        session_id, attempt, max_retries, wait_secs
-                    );
-
-                    config.emit_event(
-                        session_id,
-                        AgentEventKind::RateLimited {
-                            message: message.clone(),
-                            wait_secs,
-                            started_at,
-                            attempt: u32_from_usize(attempt, "attempt", Some(session_id)),
-                            max_attempts: u32_from_usize(
-                                max_retries,
-                                "max_retries",
-                                Some(session_id),
-                            ),
-                        },
-                    );
-
-                    let cancelled = wait_with_cancellation(wait_secs, cancel_token).await;
-                    if cancelled {
-                        debug!(
-                            "Rate limit wait cancelled for session {} during attempt {}",
-                            session_id, attempt
-                        );
-                        return Err(anyhow::anyhow!("Cancelled during rate limit wait"));
-                    }
-
-                    info!(
-                        "Session {} resuming after rate limit wait, attempt {}",
-                        session_id,
-                        attempt + 1
-                    );
-
-                    config.emit_event(
-                        session_id,
-                        AgentEventKind::RateLimitResume {
-                            attempt: u32_from_usize(
-                                attempt.saturating_add(1),
-                                "attempt + 1",
-                                Some(session_id),
-                            ),
-                        },
-                    );
-
-                    continue;
-                } else if is_transient_error(&e) && attempt < max_retries {
-                    Span::current().record("rate_limited", false);
-                    let wait_secs =
-                        calculate_rate_limit_wait(config, e.retry_after_secs(), attempt);
-                    debug!(
-                        "Session {} transient setup error on attempt {}, retrying in {}s: {}",
-                        session_id, attempt, wait_secs, e
-                    );
-                    let cancelled = wait_with_cancellation(wait_secs, cancel_token).await;
-                    if cancelled {
-                        return Err(anyhow::anyhow!("Cancelled during retry wait"));
-                    }
-                    continue;
-                } else {
-                    Span::current().record("rate_limited", false);
-                    return Err(anyhow::Error::from(e));
+            Err(error) => {
+                Span::current().record("attempt", attempt);
+                if !error.is_retryable() || attempt >= max_attempts {
+                    return Err(error);
                 }
+
+                Span::current().record("retrying", true);
+                wait_for_retry(
+                    config,
+                    session_id,
+                    &error,
+                    RetryWait {
+                        attempt,
+                        max_attempts,
+                        wait_secs: retry_delay_secs(config, &error, attempt),
+                    },
+                    cancel_token,
+                )
+                .await?;
             }
         }
     }
 }
 
-/// Calculate how long to wait before retrying after a rate limit.
-fn calculate_rate_limit_wait(
+/// Calculate a bounded retry delay, preferring a provider hint when present.
+///
+/// Provider hints are diagnostic input, not authority over the local policy:
+/// every delay is capped by `rate_limit.max_wait_secs`.
+pub(super) fn retry_delay_secs(
     config: &AgentConfig,
-    retry_after: Option<u64>,
-    attempt: usize,
+    error: &LLMError,
+    retry_ordinal: usize,
 ) -> u64 {
-    match retry_after {
-        Some(secs) => secs,
-        None => {
-            let base = config.execution_policy.rate_limit.default_wait_secs as f64;
-            let multiplier = config.execution_policy.rate_limit.backoff_multiplier;
-            (base * multiplier.powi((attempt - 1) as i32)) as u64
+    let policy = &config.execution_policy.rate_limit;
+    if let Some(secs) = error.retry_after_secs() {
+        let bounded = secs.min(policy.max_wait_secs);
+        if bounded != secs {
+            info!(
+                "provider retry hint {}s capped to rate_limit.max_wait_secs={}s",
+                secs, bounded
+            );
         }
+        return bounded;
     }
+
+    let base = policy.default_wait_secs as f64;
+    let multiplier = policy.backoff_multiplier;
+    let calculated = base * multiplier.powi(retry_ordinal.saturating_sub(1) as i32);
+    apply_jitter(calculated, policy.jitter_ratio, jitter_sample()).min(policy.max_wait_secs)
 }
 
-/// Wait for a duration with support for cancellation.
-///
-/// Returns `true` if cancelled, `false` if the wait completed normally.
-#[instrument(name = "agent.llm.rate_limit_wait", skip(cancel_token), fields(wait_secs = wait_secs))]
-async fn wait_with_cancellation(wait_secs: u64, cancel_token: &CancellationToken) -> bool {
-    tokio::select! {
-        _ = tokio::time::sleep(std::time::Duration::from_secs(wait_secs)) => {
-            false
-        }
-        _ = cancel_token.cancelled() => {
-            true
-        }
-    }
-}
-
-/// Extract rate limit information from an error.
-///
-/// Returns `Some((message, retry_after_seconds))` if the error is a rate limit error.
-fn extract_rate_limit_info(error: &LLMError) -> Option<(String, Option<u64>)> {
-    match error {
-        LLMError::RateLimited {
-            message,
-            retry_after_secs,
-        } => Some((message.clone(), *retry_after_secs)),
-        LLMError::HttpStatus {
-            status_code,
-            message,
-            retry_after_secs,
-        } if *status_code == 429 => Some((message.clone(), *retry_after_secs)),
-        _ => None,
-    }
-}
-
-/// Create a streaming connection with retry logic for rate limits and transient errors.
-///
-/// Unlike `call_llm_with_retry` which retries the entire request including consuming the
-/// response, this only retries stream *creation*. Once the stream yields its first chunk
-/// we are committed — tokens may already have been sent to the UI and we cannot roll back.
-pub(super) async fn create_stream_with_retry<F, Fut>(
+/// Log and emit a generic LLM retry event before waiting.
+async fn emit_retry_wait(
     config: &AgentConfig,
     session_id: &str,
-    cancel_token: &CancellationToken,
-    create_stream: F,
-) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>, anyhow::Error>
-where
-    F: Fn() -> Fut,
-    Fut: Future<
-        Output = Result<
-            Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>,
-            LLMError,
-        >,
-    >,
-{
-    let max_retries = config.execution_policy.rate_limit.max_retries;
-    let mut attempt = 0;
+    error: &LLMError,
+    attempt: usize,
+    max_attempts: usize,
+    wait_secs: u64,
+) {
+    let message = error
+        .rate_limit_info()
+        .map(|(m, _)| m)
+        .unwrap_or_else(|| error.to_string());
+    let started_at = time::OffsetDateTime::now_utc().unix_timestamp();
 
-    loop {
-        attempt += 1;
-
-        if cancel_token.is_cancelled() {
-            return Err(anyhow::anyhow!("Cancelled"));
+    info!(
+        "Session {} LLM retry wait, attempt {}/{}, waiting {}s: {}",
+        session_id, attempt, max_attempts, wait_secs, message
+    );
+    let attempt = u32_from_usize(attempt, "attempt", Some(session_id));
+    let max_attempts = u32_from_usize(max_attempts, "max_attempts", Some(session_id));
+    let kind = if error.is_rate_limited() {
+        AgentEventKind::RateLimited {
+            message,
+            wait_secs,
+            started_at,
+            attempt,
+            max_attempts,
         }
+    } else {
+        AgentEventKind::LlmRetryWait {
+            message,
+            wait_secs,
+            started_at,
+            attempt,
+            max_attempts,
+        }
+    };
+    if let Err(error) = config.emit_event_persisted(session_id, kind).await {
+        warn!("failed to emit LLM retry wait event for session {session_id}: {error}");
+    }
+}
 
-        match create_stream().await {
-            Ok(stream) => return Ok(stream),
+async fn emit_retry_resume(
+    config: &AgentConfig,
+    session_id: &str,
+    next_attempt: usize,
+    rate_limited: bool,
+) {
+    info!(
+        "Session {} resuming after LLM retry wait, attempt {}",
+        session_id, next_attempt
+    );
+    let attempt = u32_from_usize(next_attempt, "attempt + 1", Some(session_id));
+    let kind = if rate_limited {
+        AgentEventKind::RateLimitResume { attempt }
+    } else {
+        AgentEventKind::LlmRetryResume { attempt }
+    };
+    if let Err(error) = config.emit_event_persisted(session_id, kind).await {
+        warn!("failed to emit LLM retry resume event for session {session_id}: {error}");
+    }
+}
 
-            Err(e) => {
-                if let Some((message, retry_after)) = extract_rate_limit_info(&e) {
-                    if attempt >= max_retries {
-                        return Err(anyhow::anyhow!(
-                            "Rate limit exceeded after {} attempts: {}",
-                            max_retries,
-                            message
-                        ));
-                    }
+#[derive(Clone, Copy)]
+pub(super) struct RetryWait {
+    pub(super) attempt: usize,
+    pub(super) max_attempts: usize,
+    pub(super) wait_secs: u64,
+}
 
-                    let wait_secs = calculate_rate_limit_wait(config, retry_after, attempt);
-                    let started_at = time::OffsetDateTime::now_utc().unix_timestamp();
+/// Emit the shared retry events around a cancellation-aware delay.
+pub(super) async fn wait_for_retry(
+    config: &AgentConfig,
+    session_id: &str,
+    error: &LLMError,
+    retry: RetryWait,
+    cancel_token: &CancellationToken,
+) -> Result<(), LLMError> {
+    let rate_limited = error.is_rate_limited();
+    emit_retry_wait(
+        config,
+        session_id,
+        error,
+        retry.attempt,
+        retry.max_attempts,
+        retry.wait_secs,
+    )
+    .await;
+    wait_for_retry_delay(retry.wait_secs, cancel_token).await?;
+    emit_retry_resume(
+        config,
+        session_id,
+        retry.attempt.saturating_add(1),
+        rate_limited,
+    )
+    .await;
+    Ok(())
+}
 
-                    info!(
-                        "Session {} rate limited (streaming), attempt {}/{}, waiting {}s",
-                        session_id, attempt, max_retries, wait_secs
-                    );
+fn apply_jitter(delay_secs: f64, ratio: f64, sample: f64) -> u64 {
+    let ratio = ratio.clamp(0.0, 1.0);
+    let sample = sample.clamp(0.0, 1.0);
+    let factor = 1.0 - ratio + (2.0 * ratio * sample);
+    (delay_secs * factor).round().max(0.0) as u64
+}
 
-                    config.emit_event(
-                        session_id,
-                        AgentEventKind::RateLimited {
-                            message: message.clone(),
-                            wait_secs,
-                            started_at,
-                            attempt: u32_from_usize(attempt, "attempt", Some(session_id)),
-                            max_attempts: u32_from_usize(
-                                max_retries,
-                                "max_retries",
-                                Some(session_id),
-                            ),
-                        },
-                    );
+fn jitter_sample() -> f64 {
+    rand::random::<f64>()
+}
 
-                    let cancelled = wait_with_cancellation(wait_secs, cancel_token).await;
-                    if cancelled {
-                        return Err(anyhow::anyhow!("Cancelled during rate limit wait"));
-                    }
-
-                    config.emit_event(
-                        session_id,
-                        AgentEventKind::RateLimitResume {
-                            attempt: u32_from_usize(
-                                attempt.saturating_add(1),
-                                "attempt + 1",
-                                Some(session_id),
-                            ),
-                        },
-                    );
-
-                    continue;
-                } else if is_transient_error(&e) && attempt < max_retries {
-                    let wait_secs =
-                        calculate_rate_limit_wait(config, e.retry_after_secs(), attempt);
-                    debug!(
-                        "Session {} transient stream error on attempt {}, retrying in {}s: {}",
-                        session_id, attempt, wait_secs, e
-                    );
-                    let cancelled = wait_with_cancellation(wait_secs, cancel_token).await;
-                    if cancelled {
-                        return Err(anyhow::anyhow!("Cancelled during retry wait"));
-                    }
-                    continue;
-                } else {
-                    return Err(anyhow::Error::from(e));
-                }
+/// Wait for a retry delay, returning a typed cancellation error if interrupted.
+#[instrument(name = "agent.llm.retry_wait", skip(cancel_token), fields(wait_secs = wait_secs))]
+pub(super) async fn wait_for_retry_delay(
+    wait_secs: u64,
+    cancel_token: &CancellationToken,
+) -> Result<(), LLMError> {
+    tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => Err(LLMError::Cancelled),
+        _ = tokio::time::sleep(std::time::Duration::from_secs(wait_secs)) => {
+            if cancel_token.is_cancelled() {
+                Err(LLMError::Cancelled)
+            } else {
+                Ok(())
             }
         }
     }
 }
 
-/// Returns true for setup errors that are worth retrying.
-fn is_transient_error(e: &LLMError) -> bool {
-    e.is_retryable()
+pub(super) async fn next_stream_chunk(
+    stream: &mut Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>,
+    cancel_token: &CancellationToken,
+) -> Result<StreamChunk, LLMError> {
+    tokio::select! {
+        item = stream.next() => item.unwrap_or_else(|| Err(LLMError::Transport {
+            kind: querymt::error::TransportErrorKind::ConnectionClosed,
+            message: "LLM stream ended before a completion marker".to_string(),
+        })),
+        _ = cancel_token.cancelled() => Err(LLMError::Cancelled),
+    }
+}
+
+pub(super) fn stream_chunk_commits_output(chunk: &StreamChunk) -> bool {
+    match chunk {
+        StreamChunk::Text(text) | StreamChunk::Thinking(text) => !text.is_empty(),
+        StreamChunk::ThinkingSignature(_) => true,
+        StreamChunk::ToolUseStart { .. } | StreamChunk::ToolUseComplete { .. } => true,
+        StreamChunk::ToolUseInputDelta { partial_json, .. } => !partial_json.is_empty(),
+        StreamChunk::Usage(_) | StreamChunk::Done { .. } => false,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct StreamRetryDecision {
+    pub(super) retry_ordinal: usize,
+    pub(super) completed_attempt: usize,
+    pub(super) semantic_output_seen: bool,
+}
+
+pub(super) struct StreamRetryBudget {
+    retries_used: usize,
+    max_stream_retries: usize,
+    attempts_used: usize,
+    max_attempts: usize,
+}
+
+impl StreamRetryBudget {
+    pub(super) fn new(max_stream_retries: usize, max_attempts: usize) -> Self {
+        Self {
+            retries_used: 0,
+            max_stream_retries,
+            attempts_used: 0,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub(super) fn reserve_attempt(&mut self) -> Option<usize> {
+        if self.attempts_used >= self.max_attempts {
+            return None;
+        }
+        self.attempts_used += 1;
+        Some(self.attempts_used)
+    }
+
+    pub(super) fn begin_retry(
+        &mut self,
+        error: &LLMError,
+        semantic_output_seen: bool,
+        cancelled: bool,
+    ) -> Option<StreamRetryDecision> {
+        if cancelled
+            || !error.is_retryable()
+            || self.retries_used >= self.max_stream_retries
+            || self.attempts_used >= self.max_attempts
+        {
+            return None;
+        }
+
+        self.retries_used += 1;
+        Some(StreamRetryDecision {
+            retry_ordinal: self.retries_used,
+            completed_attempt: self.attempts_used,
+            semantic_output_seen,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum StreamFailureAction {
+    Retry,
+    Cancelled,
+    Terminal(LLMError),
+}
+
+pub(super) async fn handle_stream_failure(
+    config: &AgentConfig,
+    session_id: &str,
+    error: LLMError,
+    budget: &mut StreamRetryBudget,
+    semantic_output_seen: bool,
+    message_id: Option<String>,
+    cancel_token: &CancellationToken,
+) -> StreamFailureAction {
+    if matches!(error, LLMError::Cancelled) || cancel_token.is_cancelled() {
+        return StreamFailureAction::Cancelled;
+    }
+
+    let Some(retry) = budget.begin_retry(&error, semantic_output_seen, false) else {
+        return StreamFailureAction::Terminal(error);
+    };
+
+    match wait_for_stream_retry(
+        config,
+        session_id,
+        &error,
+        retry,
+        budget.max_stream_retries,
+        message_id,
+        cancel_token,
+    )
+    .await
+    {
+        Ok(()) => StreamFailureAction::Retry,
+        Err(LLMError::Cancelled) => StreamFailureAction::Cancelled,
+        Err(error) => StreamFailureAction::Terminal(error),
+    }
+}
+
+pub(super) async fn wait_for_stream_retry(
+    config: &AgentConfig,
+    session_id: &str,
+    error: &LLMError,
+    retry: StreamRetryDecision,
+    max_stream_retries: usize,
+    message_id: Option<String>,
+    cancel_token: &CancellationToken,
+) -> Result<(), LLMError> {
+    if retry.semantic_output_seen {
+        // TODO(stream-retry-safety): replace already-emitted attempt deltas once
+        // clients support attempt-scoped rollback/replacement.
+        warn!(
+            "Session {}: retrying stream after semantic output; the replacement request may duplicate visible output (request attempt {}/{}, stream recreation {}/{})",
+            session_id,
+            retry.completed_attempt,
+            config.execution_policy.rate_limit.max_attempts(),
+            retry.retry_ordinal,
+            max_stream_retries,
+        );
+    }
+
+    config.emit_event(
+        session_id,
+        AgentEventKind::StreamRecovering {
+            message: error.to_string(),
+            attempt: u32_from_usize(retry.retry_ordinal, "stream_retries_used", Some(session_id)),
+            max_attempts: u32_from_usize(
+                max_stream_retries,
+                "max_stream_retries",
+                Some(session_id),
+            ),
+            message_id,
+        },
+    );
+
+    wait_for_retry(
+        config,
+        session_id,
+        error,
+        RetryWait {
+            attempt: retry.completed_attempt,
+            max_attempts: config.execution_policy.rate_limit.max_attempts(),
+            wait_secs: retry_delay_secs(config, error, retry.completed_attempt),
+        },
+        cancel_token,
+    )
+    .await
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -300,16 +421,17 @@ mod tests {
     use crate::agent::agent_config_builder::AgentConfigBuilder;
     use crate::agent::core::ToolPolicy;
     use crate::config::RuntimeExecutionPolicy;
+    use crate::events::AgentEventKind;
     use crate::test_utils::{
         MockLlmProvider, MockSessionStore, SharedLlmProvider, TestProviderFactory, mock_llm_config,
         mock_plugin_registry, mock_session,
     };
     use querymt::LLMParams;
-    use querymt::chat::ChatResponse;
-    use querymt::error::LLMError;
+    use querymt::chat::{ChatResponse, FinishReason, StreamChunk};
+    use querymt::error::{LLMError, ProviderErrorKind, ProviderFailure};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, broadcast};
     use tokio_util::sync::CancellationToken;
 
     // ── Fixture ──────────────────────────────────────────────────────────────
@@ -360,15 +482,33 @@ mod tests {
         (config, temp_dir)
     }
 
-    // ── extract_rate_limit_info tests ────────────────────────────────────────
+    async fn recv_event(
+        rx: &mut broadcast::Receiver<crate::events::EventEnvelope>,
+    ) -> crate::events::EventEnvelope {
+        tokio::time::timeout(tokio::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for retry event")
+            .expect("retry event channel closed")
+    }
+
+    async fn assert_no_event(rx: &mut broadcast::Receiver<crate::events::EventEnvelope>) {
+        assert!(
+            tokio::time::timeout(tokio::time::Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "unexpected retry event"
+        );
+    }
+
+    // ── rate_limit_info (dual-form) tests ────────────────────────────────────
 
     #[test]
-    fn test_extract_rate_limit_info_rate_limited_with_retry_after() {
+    fn test_rate_limit_info_rate_limited_with_retry_after() {
         let err = LLMError::RateLimited {
             message: "Too many requests".to_string(),
             retry_after_secs: Some(30),
         };
-        let info = extract_rate_limit_info(&err);
+        let info = err.rate_limit_info();
         assert!(info.is_some());
         let (msg, retry_after) = info.unwrap();
         assert_eq!(msg, "Too many requests");
@@ -376,12 +516,12 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_rate_limit_info_rate_limited_no_retry_after() {
+    fn test_rate_limit_info_rate_limited_no_retry_after() {
         let err = LLMError::RateLimited {
             message: "Quota exceeded".to_string(),
             retry_after_secs: None,
         };
-        let info = extract_rate_limit_info(&err);
+        let info = err.rate_limit_info();
         assert!(info.is_some());
         let (msg, retry_after) = info.unwrap();
         assert_eq!(msg, "Quota exceeded");
@@ -389,131 +529,211 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_rate_limit_info_non_rate_limit_returns_none() {
+    fn test_rate_limit_info_non_rate_limit_returns_none() {
         let err = LLMError::GenericError("something broke".to_string());
-        assert!(extract_rate_limit_info(&err).is_none());
+        assert!(err.rate_limit_info().is_none());
 
         let err = LLMError::HttpError("connection refused".to_string());
-        assert!(extract_rate_limit_info(&err).is_none());
+        assert!(err.rate_limit_info().is_none());
     }
-
-    // ── calculate_rate_limit_wait tests ─────────────────────────────────────
-
-    #[tokio::test]
-    async fn test_calculate_rate_limit_wait_uses_retry_after() {
-        let (config, _temp) = make_config().await;
-        let wait = calculate_rate_limit_wait(&config, Some(60), 1);
-        assert_eq!(wait, 60, "should use retry_after_secs directly");
-    }
-
-    #[tokio::test]
-    async fn test_calculate_rate_limit_wait_exponential_backoff_no_retry_after() {
-        let (config, _temp) = make_config().await;
-        // attempt=1: base * 2^0 = 1 * 1.0 = 1s
-        let w1 = calculate_rate_limit_wait(&config, None, 1);
-        // attempt=2: base * 2^1 = 1 * 2.0 = 2s
-        let w2 = calculate_rate_limit_wait(&config, None, 2);
-        // attempt=3: base * 2^2 = 1 * 4.0 = 4s
-        let w3 = calculate_rate_limit_wait(&config, None, 3);
-        assert!(w2 >= w1, "wait should grow with attempt");
-        assert!(w3 >= w2, "wait should grow with attempt");
-    }
-
-    // ── is_transient_error tests ─────────────────────────────────────────────
 
     #[test]
-    fn test_is_transient_error_http_error() {
+    fn test_rate_limit_info_unified_rate_limited_kind() {
+        let err = LLMError::RateLimited {
+            message: "Rate limit reached".to_string(),
+            retry_after_secs: Some(12),
+        };
+        let info = err.rate_limit_info().expect("RateLimited should extract");
+        assert_eq!(info.0, "Rate limit reached");
+        assert_eq!(info.1, Some(12));
+
+        // Catch-all provider errors are not rate-limit UI events even if retryable.
+        let non_rate = LLMError::from(
+            ProviderFailure::new(ProviderErrorKind::UnknownTransient, "server broke")
+                .with_code(Some("server_error".to_string()))
+                .with_error_type(Some("api_error".to_string())),
+        );
+        assert!(non_rate.rate_limit_info().is_none());
+
+        let overloaded = LLMError::from(
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+                .with_code(Some("server_is_overloaded".into())),
+        );
+        assert!(overloaded.rate_limit_info().is_none());
+        assert!(overloaded.is_retryable());
+    }
+
+    // ── retry delay tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_retry_delay_uses_retry_after() {
+        let (config, _temp) = make_config().await;
+        let error = LLMError::HttpStatus {
+            status_code: 503,
+            message: "unavailable".to_string(),
+            retry_after_secs: Some(60),
+        };
+        assert_eq!(retry_delay_secs(&config, &error, 1), 60);
+    }
+
+    #[tokio::test]
+    async fn test_retry_delay_uses_retry_ordinal_for_exponential_backoff() {
+        let (config, _temp) = make_config().await;
+        let error = LLMError::HttpStatus {
+            status_code: 503,
+            message: "unavailable".to_string(),
+            retry_after_secs: None,
+        };
+        for (ordinal, expected) in [(1, 1), (2, 2), (3, 4)] {
+            let actual = retry_delay_secs(&config, &error, ordinal);
+            assert!(
+                actual.abs_diff(expected) <= 1,
+                "ordinal {ordinal}: expected jitter near {expected}, got {actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_calculated_jitter_is_bounded_and_deterministic() {
+        assert_eq!(apply_jitter(100.0, 0.2, 0.0), 80);
+        assert_eq!(apply_jitter(100.0, 0.2, 0.5), 100);
+        assert_eq!(apply_jitter(100.0, 0.2, 1.0), 120);
+    }
+
+    #[tokio::test]
+    async fn test_calculated_retry_delay_does_not_exceed_max_wait() {
+        let (mut config, _temp) = make_config().await;
+        let config = Arc::get_mut(&mut config).expect("config is uniquely owned");
+        config.execution_policy.rate_limit.default_wait_secs = 1_000;
+        config.execution_policy.rate_limit.max_wait_secs = 10;
+        config.execution_policy.rate_limit.jitter_ratio = 1.0;
+
+        let error = LLMError::HttpStatus {
+            status_code: 503,
+            message: "unavailable".to_string(),
+            retry_after_secs: None,
+        };
+        assert!(retry_delay_secs(config, &error, 1) <= 10);
+    }
+
+    #[tokio::test]
+    async fn test_provider_retry_hint_is_capped_by_max_wait() {
+        let (mut config, _temp) = make_config().await;
+        let config = Arc::get_mut(&mut config).expect("config is uniquely owned");
+        config.execution_policy.rate_limit.max_wait_secs = 10;
+
+        let error = LLMError::HttpStatus {
+            status_code: 503,
+            message: "unavailable".to_string(),
+            retry_after_secs: Some(60),
+        };
+        assert_eq!(retry_delay_secs(config, &error, 1), 10);
+    }
+
+    // ── is_retryable tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_retryable_transport() {
         let err = LLMError::Transport {
             kind: querymt::error::TransportErrorKind::ConnectionReset,
             message: "connection reset".to_string(),
         };
-        assert!(is_transient_error(&err));
+        assert!(err.is_retryable());
     }
 
     #[test]
-    fn test_is_transient_error_http_error_generic() {
+    fn test_is_retryable_http_error_generic() {
         // HttpError (previously "error decoding response body" fell through here)
         let err = LLMError::HttpError("error decoding response body".to_string());
-        assert!(is_transient_error(&err));
+        assert!(err.is_retryable());
     }
 
     #[test]
-    fn test_is_transient_error_plugin_error() {
-        let err = LLMError::PluginError("wasm stream failed".to_string());
-        assert!(is_transient_error(&err));
+    fn test_is_retryable_plugin_error() {
+        let err = LLMError::PluginError("WASM runtime temporary failure".to_string());
+        assert!(err.is_retryable());
     }
 
     #[test]
-    fn test_is_transient_error_transport_body() {
+    fn deterministic_request_errors_are_not_retryable() {
+        assert!(!LLMError::InvalidUrl("bad base url".into()).is_retryable());
+        assert!(!LLMError::InvalidRequest("invalid header".into()).is_retryable());
+        assert!(
+            !LLMError::ResponseFormatError {
+                message: "invalid json".into(),
+                raw_response: "not json".into(),
+            }
+            .is_retryable()
+        );
+    }
+
+    #[test]
+    fn test_is_retryable_transport_body() {
         // The new typed path for reqwest is_body() errors
         let err = LLMError::Transport {
             kind: querymt::error::TransportErrorKind::Other,
             message: "error decoding response body".to_string(),
         };
-        assert!(is_transient_error(&err));
+        assert!(err.is_retryable());
     }
 
     #[test]
-    fn test_is_transient_error_http_status_503() {
+    fn test_is_retryable_http_status_503() {
         let err = LLMError::HttpStatus {
             status_code: 503,
             message: "upstream unavailable".to_string(),
             retry_after_secs: None,
         };
-        assert!(is_transient_error(&err));
+        assert!(err.is_retryable());
     }
 
     #[test]
-    fn test_is_transient_error_non_transient() {
-        assert!(!is_transient_error(&LLMError::GenericError(
-            "oops".to_string()
-        )));
+    fn test_is_retryable_non_transient() {
+        assert!(!LLMError::GenericError("oops".to_string()).is_retryable());
     }
 
-    // ── wait_with_cancellation tests ─────────────────────────────────────────
+    // ── cancellation-aware wait tests ────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_wait_with_cancellation_completes_normally() {
+    async fn test_wait_for_retry_delay_completes_normally() {
         let token = CancellationToken::new();
-        // Very short wait (0s) should complete normally
-        let cancelled = wait_with_cancellation(0, &token).await;
-        assert!(
-            !cancelled,
-            "wait should complete normally, not be cancelled"
-        );
+        assert!(wait_for_retry_delay(0, &token).await.is_ok());
     }
 
     #[tokio::test]
-    async fn test_wait_with_cancellation_cancelled_early() {
+    async fn test_wait_for_retry_delay_cancelled_early() {
         let token = CancellationToken::new();
-        token.cancel(); // cancel before waiting
-        let cancelled = wait_with_cancellation(60, &token).await;
-        assert!(cancelled, "should return true when already cancelled");
+        token.cancel();
+        assert!(matches!(
+            wait_for_retry_delay(60, &token).await,
+            Err(LLMError::Cancelled)
+        ));
     }
 
     #[tokio::test]
-    async fn test_wait_with_cancellation_cancel_during_wait() {
+    async fn test_wait_for_retry_delay_cancelled_during_wait() {
         let token = CancellationToken::new();
         let token_clone = token.clone();
-        // Cancel after 10ms while waiting for 60s
         tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
             token_clone.cancel();
         });
-        let cancelled = wait_with_cancellation(60, &token).await;
-        assert!(cancelled, "should be cancelled by background task");
+        assert!(matches!(
+            wait_for_retry_delay(60, &token).await,
+            Err(LLMError::Cancelled)
+        ));
     }
 
-    // ── call_llm_with_retry tests ────────────────────────────────────────────
+    // ── call_with_retry tests ───────────────────────────────────────────────
 
     #[tokio::test]
-    async fn test_call_llm_with_retry_succeeds_first_attempt() {
+    async fn test_call_with_retry_succeeds_first_attempt() {
         let (config, _temp) = make_config().await;
         let token = CancellationToken::new();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count2 = call_count.clone();
 
-        let result = call_llm_with_retry(&config, "test-session", &token, || {
+        let result = call_with_retry(&config, "test-session", &token, || {
             let count = call_count2.clone();
             async move {
                 count.fetch_add(1, Ordering::SeqCst);
@@ -529,27 +749,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_call_llm_with_retry_fails_non_rate_limit() {
+    async fn generic_call_with_retry_supports_provider_initialization() {
         let (config, _temp) = make_config().await;
         let token = CancellationToken::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+        let provider: Arc<dyn querymt::LLMProvider> = Arc::new(MockLlmProvider::new());
 
-        let result = call_llm_with_retry(&config, "test-session", &token, || async {
-            Err::<Box<dyn ChatResponse>, _>(LLMError::GenericError("fatal error".to_string()))
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            let provider = Arc::clone(&provider);
+            async move {
+                if count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(LLMError::Transport {
+                        kind: querymt::error::TransportErrorKind::ConnectionRefused,
+                        message: "registry temporarily unavailable".into(),
+                    })
+                } else {
+                    Ok(provider)
+                }
+            }
         })
         .await;
 
-        // Non-rate-limit errors should fail immediately without retrying
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
-    async fn test_call_llm_with_retry_retries_transient_setup_errors() {
+    async fn test_call_with_retry_fails_non_rate_limit() {
         let (config, _temp) = make_config().await;
         let token = CancellationToken::new();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count2 = call_count.clone();
 
-        let result = call_llm_with_retry(&config, "test-session", &token, || {
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Err::<Box<dyn ChatResponse>, _>(LLMError::GenericError("fatal error".to_string()))
+            }
+        })
+        .await;
+
+        // Non-rate-limit errors should fail immediately without retrying
+        assert!(result.is_err());
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_retries_transient_setup_errors() {
+        let (config, _temp) = make_config().await;
+        let token = CancellationToken::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+
+        let result = call_with_retry(&config, "test-session", &token, || {
             let count = call_count2.clone();
             async move {
                 let attempt = count.fetch_add(1, Ordering::SeqCst);
@@ -573,36 +828,198 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_call_llm_with_retry_cancelled_before_start() {
+    async fn test_call_with_retry_cancelled_before_start() {
         let (config, _temp) = make_config().await;
         let token = CancellationToken::new();
         token.cancel();
 
-        let result = call_llm_with_retry(&config, "test-session", &token, || async {
+        let result = call_with_retry(&config, "test-session", &token, || async {
             Ok::<Box<dyn ChatResponse>, _>(Box::new(crate::test_utils::MockChatResponse::text_only(
                 "should not get here",
             )) as Box<dyn ChatResponse>)
         })
         .await;
 
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
+        assert!(matches!(result, Err(LLMError::Cancelled)));
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_cancellation_during_delay_starts_no_retry() {
+        let (config, _temp) = make_config().await;
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            token_clone.cancel();
+        });
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Err::<Box<dyn ChatResponse>, _>(LLMError::HttpStatus {
+                    status_code: 503,
+                    message: "unavailable".to_string(),
+                    retry_after_secs: Some(60),
+                })
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(LLMError::Cancelled)));
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_wait_event_uses_clamped_provider_hint() {
+        let (mut config, _temp) = make_config().await;
+        Arc::get_mut(&mut config)
+            .expect("config is uniquely owned")
+            .execution_policy
+            .rate_limit
+            .max_wait_secs = 0;
+        let mut events = config.subscribe_events();
+        let token = CancellationToken::new();
+        let attempt_count = Arc::new(AtomicUsize::new(0));
+        let attempt_count_for_call = Arc::clone(&attempt_count);
+
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let attempt_count = Arc::clone(&attempt_count_for_call);
+            async move {
+                if attempt_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err::<Box<dyn ChatResponse>, _>(LLMError::RateLimited {
+                        message: "rate limited".into(),
+                        retry_after_secs: Some(60),
+                    })
+                } else {
+                    Ok::<Box<dyn ChatResponse>, _>(Box::new(
+                        crate::test_utils::MockChatResponse::text_only("ok"),
+                    ) as Box<dyn ChatResponse>)
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        let wait = recv_event(&mut events).await;
+        assert!(wait.is_durable());
+        assert!(matches!(
+            wait.kind(),
+            AgentEventKind::RateLimited { wait_secs: 0, .. }
+        ));
+        let resume = recv_event(&mut events).await;
+        assert!(resume.is_durable());
+        assert!(matches!(
+            resume.kind(),
+            AgentEventKind::RateLimitResume { attempt: 2 }
+        ));
         assert!(
-            msg.contains("Cancelled"),
-            "expected Cancelled, got: {}",
-            msg
+            resume.seq() > wait.seq(),
+            "resume must be persisted after wait"
         );
     }
 
     #[tokio::test]
-    async fn test_call_llm_with_retry_rate_limit_exhausted() {
+    async fn test_retryable_overload_emits_wait_and_resume_events_in_order() {
+        let (config, _temp) = make_config().await;
+        let mut events = config.subscribe_events();
+        let token = CancellationToken::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            async move {
+                if count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err::<Box<dyn ChatResponse>, _>(LLMError::from(
+                        ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+                            .with_retry_after_secs(Some(0)),
+                    ))
+                } else {
+                    Ok::<Box<dyn ChatResponse>, _>(Box::new(
+                        crate::test_utils::MockChatResponse::text_only("ok"),
+                    ) as Box<dyn ChatResponse>)
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        let wait = recv_event(&mut events).await;
+        assert!(wait.is_durable());
+        assert!(matches!(
+            wait.kind(),
+            AgentEventKind::LlmRetryWait {
+                wait_secs: 0,
+                attempt: 1,
+                max_attempts: 3,
+                ..
+            }
+        ));
+        let resume = recv_event(&mut events).await;
+        assert!(resume.is_durable());
+        assert!(matches!(
+            resume.kind(),
+            AgentEventKind::LlmRetryResume { attempt: 2 }
+        ));
+        assert!(
+            resume.seq() > wait.seq(),
+            "resume must be persisted after wait"
+        );
+        assert_no_event(&mut events).await;
+    }
+
+    #[tokio::test]
+    async fn permanent_error_emits_no_retry_events() {
+        let (config, _temp) = make_config().await;
+        let mut events = config.subscribe_events();
+        let token = CancellationToken::new();
+
+        let result = call_with_retry(&config, "test-session", &token, || async {
+            Err::<Box<dyn ChatResponse>, _>(LLMError::AuthError("bad key".into()))
+        })
+        .await;
+
+        assert!(matches!(result, Err(LLMError::AuthError(_))));
+        assert_no_event(&mut events).await;
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_generic_retry_wait_emits_no_resume_event() {
+        let (config, _temp) = make_config().await;
+        let mut events = config.subscribe_events();
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            token_clone.cancel();
+        });
+        let result = call_with_retry(&config, "test-session", &token, || async {
+            Err::<Box<dyn ChatResponse>, _>(LLMError::from(
+                ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+                    .with_retry_after_secs(Some(60)),
+            ))
+        })
+        .await;
+
+        assert!(matches!(result, Err(LLMError::Cancelled)));
+        let wait = recv_event(&mut events).await;
+        assert!(matches!(wait.kind(), AgentEventKind::LlmRetryWait { .. }));
+        assert_no_event(&mut events).await;
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_rate_limit_exhausted() {
         let (config, _temp) = make_config().await;
         // max_retries = 3
         let token = CancellationToken::new();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count2 = call_count.clone();
 
-        let result = call_llm_with_retry(&config, "test-session", &token, || {
+        let result = call_with_retry(&config, "test-session", &token, || {
             let count = call_count2.clone();
             async move {
                 count.fetch_add(1, Ordering::SeqCst);
@@ -614,14 +1031,333 @@ mod tests {
         })
         .await;
 
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("Rate limit exceeded"),
-            "unexpected error: {}",
-            msg
-        );
-        // Should have tried max_retries times
+        assert!(matches!(
+            result,
+            Err(LLMError::RateLimited {
+                message,
+                retry_after_secs: Some(0),
+            }) if message == "rate limited"
+        ));
+        // max_retries is the total number of setup attempts.
         assert_eq!(call_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn stream_budget_reserves_only_configured_attempts() {
+        let mut budget = StreamRetryBudget::new(2, 3);
+
+        assert_eq!(budget.reserve_attempt(), Some(1));
+        assert_eq!(budget.reserve_attempt(), Some(2));
+        assert_eq!(budget.reserve_attempt(), Some(3));
+        assert_eq!(budget.reserve_attempt(), None);
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_permanent_quota_is_called_exactly_once() {
+        let (config, _temp) = make_config().await;
+        let token = CancellationToken::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Err::<Box<dyn ChatResponse>, _>(LLMError::from(
+                    ProviderFailure::new(
+                        ProviderErrorKind::QuotaExceeded,
+                        "You have hit your usage limit.",
+                    )
+                    .with_code(Some("usage_limit_reached".into()))
+                    .with_error_type(Some("usage_limit_reached".into())),
+                ))
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(LLMError::ProviderResponseError(failure))
+                if failure.kind() == querymt::error::ProviderErrorKind::QuotaExceeded
+        ));
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "permanent quota must not be retried"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_auth_error_is_called_exactly_once() {
+        let (config, _temp) = make_config().await;
+        let token = CancellationToken::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count2 = call_count.clone();
+
+        let result = call_with_retry(&config, "test-session", &token, || {
+            let count = call_count2.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Err::<Box<dyn ChatResponse>, _>(LLMError::AuthError("bad key".into()))
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(LLMError::AuthError(_))));
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exhausted_stream_budget_returns_the_original_typed_error() {
+        let (config, _temp) = make_config().await;
+        let token = CancellationToken::new();
+        let mut budget = StreamRetryBudget::new(2, 1);
+        assert_eq!(budget.reserve_attempt(), Some(1));
+        assert_eq!(budget.reserve_attempt(), None);
+        let error = overloaded_error(Some(7));
+
+        let action = handle_stream_failure(
+            &config,
+            "test-session",
+            error,
+            &mut budget,
+            false,
+            None,
+            &token,
+        )
+        .await;
+
+        assert!(matches!(
+            action,
+            StreamFailureAction::Terminal(LLMError::ProviderResponseError(failure))
+                if failure.kind() == ProviderErrorKind::ServerOverloaded
+                    && failure.code() == Some("server_is_overloaded")
+                    && failure.request_id() == Some("request-3")
+                    && failure.retry_after_secs() == Some(7)
+        ));
+    }
+
+    #[tokio::test]
+    async fn stream_setup_and_parser_failures_share_one_physical_request_budget() {
+        let (mut config, _temp) = make_config().await;
+        let config_mut = Arc::get_mut(&mut config).expect("config uniquely owned");
+        config_mut.execution_policy.rate_limit.default_wait_secs = 0;
+        let token = CancellationToken::new();
+        let mut budget = StreamRetryBudget::new(2, 3);
+
+        assert_eq!(budget.reserve_attempt(), Some(1));
+        let setup_error = LLMError::HttpStatus {
+            status_code: 503,
+            message: "setup failed".into(),
+            retry_after_secs: Some(0),
+        };
+        assert!(matches!(
+            handle_stream_failure(
+                &config,
+                "test-session",
+                setup_error,
+                &mut budget,
+                false,
+                None,
+                &token,
+            )
+            .await,
+            StreamFailureAction::Retry
+        ));
+
+        assert_eq!(budget.reserve_attempt(), Some(2));
+        let parser_error = overloaded_error(Some(0));
+        assert!(matches!(
+            handle_stream_failure(
+                &config,
+                "test-session",
+                parser_error,
+                &mut budget,
+                true,
+                None,
+                &token,
+            )
+            .await,
+            StreamFailureAction::Retry
+        ));
+
+        assert_eq!(budget.reserve_attempt(), Some(3));
+        assert_eq!(budget.reserve_attempt(), None);
+    }
+
+    #[tokio::test]
+    async fn two_parser_overloads_can_use_the_full_shared_request_budget() {
+        let (mut config, _temp) = make_config().await;
+        let config_mut = Arc::get_mut(&mut config).expect("config uniquely owned");
+        config_mut.execution_policy.rate_limit.default_wait_secs = 0;
+        let token = CancellationToken::new();
+        let mut budget = StreamRetryBudget::new(2, 3);
+
+        for attempt in 1..=3 {
+            assert_eq!(budget.reserve_attempt(), Some(attempt));
+            if attempt < 3 {
+                assert!(matches!(
+                    handle_stream_failure(
+                        &config,
+                        "test-session",
+                        overloaded_error(Some(0)),
+                        &mut budget,
+                        false,
+                        None,
+                        &token,
+                    )
+                    .await,
+                    StreamFailureAction::Retry
+                ));
+            }
+        }
+
+        assert_eq!(budget.reserve_attempt(), None);
+        assert_eq!(budget.retries_used, 2);
+    }
+
+    #[test]
+    fn explicit_stream_retry_cap_still_limits_recreations() {
+        let error = overloaded_error(Some(0));
+        let mut budget = StreamRetryBudget::new(1, 3);
+        assert_eq!(budget.reserve_attempt(), Some(1));
+
+        assert!(budget.begin_retry(&error, false, false).is_some());
+        assert_eq!(budget.reserve_attempt(), Some(2));
+        assert_eq!(budget.begin_retry(&error, false, false), None);
+    }
+
+    #[test]
+    fn malformed_terminal_can_consume_the_same_stream_retry_budget() {
+        let error = LLMError::from(
+            ProviderFailure::new(
+                ProviderErrorKind::UnknownTransient,
+                "tool_calls without completed calls",
+            )
+            .with_code(Some("empty_tool_calls_terminal".into())),
+        );
+        let mut budget = StreamRetryBudget::new(2, 3);
+        assert_eq!(budget.reserve_attempt(), Some(1));
+
+        assert!(budget.begin_retry(&error, true, false).is_some());
+        assert_eq!(budget.retries_used, 1);
+    }
+
+    #[test]
+    fn any_stage_stream_retry_is_allowed_but_reported_as_post_output() {
+        let error = overloaded_error(Some(0));
+        let mut budget = StreamRetryBudget::new(2, 3);
+        assert_eq!(budget.reserve_attempt(), Some(1));
+
+        let retry = budget
+            .begin_retry(&error, true, false)
+            .expect("main-compatible retries remain allowed after output");
+        assert_eq!(retry.retry_ordinal, 1);
+        assert_eq!(retry.completed_attempt, 1);
+        assert!(retry.semantic_output_seen);
+    }
+
+    #[tokio::test]
+    async fn parser_retry_uses_ordered_wait_and_resume_events() {
+        let (mut config, _temp) = make_config().await;
+        let config_mut = Arc::get_mut(&mut config).expect("config uniquely owned");
+        config_mut.execution_policy.rate_limit.default_wait_secs = 0;
+        config_mut.execution_policy.rate_limit.max_stream_retries = 2;
+        let mut events = config.subscribe_events();
+        let token = CancellationToken::new();
+        let mut budget = StreamRetryBudget::new(2, 3);
+        assert_eq!(budget.reserve_attempt(), Some(1));
+
+        let action = handle_stream_failure(
+            &config,
+            "test-session",
+            overloaded_error(Some(0)),
+            &mut budget,
+            true,
+            None,
+            &token,
+        )
+        .await;
+        assert!(matches!(action, StreamFailureAction::Retry));
+
+        let recovering = recv_event(&mut events).await;
+        assert!(matches!(
+            recovering.kind(),
+            AgentEventKind::StreamRecovering {
+                attempt: 1,
+                max_attempts: 2,
+                ..
+            }
+        ));
+        let wait = recv_event(&mut events).await;
+        assert!(matches!(
+            wait.kind(),
+            AgentEventKind::LlmRetryWait {
+                attempt: 1,
+                max_attempts: 3,
+                ..
+            }
+        ));
+        let resume = recv_event(&mut events).await;
+        assert!(matches!(
+            resume.kind(),
+            AgentEventKind::LlmRetryResume { attempt: 2 }
+        ));
+        assert!(resume.seq() > wait.seq());
+    }
+
+    #[tokio::test]
+    async fn next_stream_chunk_turns_unexpected_eof_into_retryable_error() {
+        let mut empty: Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>> =
+            Box::pin(futures_util::stream::empty());
+        let error = next_stream_chunk(&mut empty, &CancellationToken::new())
+            .await
+            .expect_err("missing Done must be an error");
+
+        assert!(matches!(
+            error,
+            LLMError::Transport {
+                kind: querymt::error::TransportErrorKind::ConnectionClosed,
+                ..
+            }
+        ));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn stream_chunk_commit_policy_tracks_main_compatibility_warning_boundary() {
+        assert!(!stream_chunk_commits_output(&StreamChunk::Text(
+            String::new()
+        )));
+        assert!(stream_chunk_commits_output(&StreamChunk::Text("x".into())));
+        assert!(stream_chunk_commits_output(&StreamChunk::Thinking(
+            "x".into()
+        )));
+        assert!(stream_chunk_commits_output(
+            &StreamChunk::ThinkingSignature(String::new())
+        ));
+        assert!(stream_chunk_commits_output(&StreamChunk::ToolUseStart {
+            index: 0,
+            id: "call-1".into(),
+            name: "read".into(),
+        }));
+        assert!(stream_chunk_commits_output(
+            &StreamChunk::ToolUseInputDelta {
+                index: 0,
+                partial_json: "{".into(),
+            }
+        ));
+        assert!(!stream_chunk_commits_output(&StreamChunk::Done {
+            finish_reason: FinishReason::Stop,
+        }));
+    }
+
+    fn overloaded_error(retry_after_secs: Option<u64>) -> LLMError {
+        LLMError::from(
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "overloaded")
+                .with_code(Some("server_is_overloaded".into()))
+                .with_request_id(Some("request-3".into()))
+                .with_retry_after_secs(retry_after_secs),
+        )
     }
 }

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -53,11 +53,27 @@ pub(super) async fn transition_before_llm_call(
         return Ok(ExecutionState::Cancelled);
     }
 
-    let provider = exec_ctx
-        .session_handle
-        .provider()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to build provider: {}", e))?;
+    let provider = match super::llm_retry::call_with_retry(
+        config,
+        &exec_ctx.session_id,
+        &exec_ctx.cancellation_token,
+        || {
+            let session_handle = exec_ctx.session_handle.clone();
+            let cancel = exec_ctx.cancellation_token.clone();
+            async move {
+                tokio::select! {
+                    result = session_handle.provider() => result.map_err(LLMError::from),
+                    _ = cancel.cancelled() => Err(LLMError::Cancelled),
+                }
+            }
+        },
+    )
+    .await
+    {
+        Ok(provider) => provider,
+        Err(LLMError::Cancelled) => return Ok(ExecutionState::Cancelled),
+        Err(error) => return Err(contextualize_llm_error(error, "provider initialization")),
+    };
 
     let tools = config.collect_tools(
         provider,
@@ -111,6 +127,41 @@ pub(super) fn apply_cache_breakpoints(messages: &[ChatMessage]) -> Vec<ChatMessa
             m
         })
         .collect()
+}
+
+fn contextualize_llm_error(error: LLMError, operation: &'static str) -> anyhow::Error {
+    let source_message = error.to_string();
+    anyhow::Error::new(error).context(format!("LLM {operation} error: {source_message}"))
+}
+
+/// Map a failed LLM setup/call into either `Cancelled` or a contextualized error.
+///
+/// Cancel must never bubble as `Err`; it is an execution state, not a provider failure.
+fn map_failed_llm_call(error: LLMError, streaming: bool) -> Result<ExecutionState, anyhow::Error> {
+    match error {
+        LLMError::Cancelled => Ok(ExecutionState::Cancelled),
+        error => Err(contextualize_llm_error(
+            error,
+            if streaming { "streaming" } else { "chat" },
+        )),
+    }
+}
+
+fn validate_stream_terminal(
+    finish_reason: FinishReason,
+    tool_calls: &[ToolCall],
+) -> Result<FinishReason, LLMError> {
+    if finish_reason == FinishReason::ToolCalls && tool_calls.is_empty() {
+        return Err(LLMError::from(
+            querymt::error::ProviderFailure::new(
+                querymt::error::ProviderErrorKind::UnknownTransient,
+                "provider ended with tool_calls but emitted no completed tool calls",
+            )
+            .with_code(Some("empty_tool_calls_terminal".into())),
+        ));
+    }
+
+    Ok(finish_reason)
 }
 
 /// Transition from CallLlm to AfterLlm.
@@ -175,7 +226,7 @@ pub(super) async fn transition_call_llm(
     ) = if tools.is_empty() {
         // No tools — always use the non-streaming simple submit path.
         let cancel = exec_ctx.cancellation_token.clone();
-        let resp = super::llm_retry::call_llm_with_retry(
+        let resp = match super::llm_retry::call_with_retry(
             config,
             session_id,
             &exec_ctx.cancellation_token,
@@ -194,7 +245,11 @@ pub(super) async fn transition_call_llm(
                 }
             },
         )
-        .await?;
+        .await
+        {
+            Ok(resp) => resp,
+            Err(e) => return map_failed_llm_call(e, false),
+        };
 
         (
             resp.text().unwrap_or_default(),
@@ -205,10 +260,29 @@ pub(super) async fn transition_call_llm(
             resp.finish_reason(),
         )
     } else {
-        let provider = session_handle
-            .provider()
-            .await
-            .map_err(|e| anyhow::Error::from(e).context("Failed to build provider"))?;
+        let provider = match super::llm_retry::call_with_retry(
+            config,
+            session_id,
+            &exec_ctx.cancellation_token,
+            || {
+                let session_handle = session_handle.clone();
+                let cancel = exec_ctx.cancellation_token.clone();
+                async move {
+                    tokio::select! {
+                        result = session_handle.provider() => result.map_err(LLMError::from),
+                        _ = cancel.cancelled() => Err(LLMError::Cancelled),
+                    }
+                }
+            },
+        )
+        .await
+        {
+            Ok(provider) => provider,
+            Err(LLMError::Cancelled) => return Ok(ExecutionState::Cancelled),
+            Err(error) => {
+                return Err(contextualize_llm_error(error, "provider initialization"));
+            }
+        };
 
         if provider.supports_streaming() {
             // === STREAMING PATH (all capable providers) ===
@@ -219,7 +293,7 @@ pub(super) async fn transition_call_llm(
 
             // Accumulators live outside the retry loop so the post-stream
             // processing below can read them regardless of how many attempts
-            // were needed.  On each retry they are reset to empty.
+            // were needed. On each retry they are reset to empty.
             let mut text = String::new();
             let mut thinking = String::new();
             // Initial values are always overwritten inside the retry loop below
@@ -286,11 +360,16 @@ pub(super) async fn transition_call_llm(
             }
 
             // ── Outer retry loop ─────────────────────────────────────────────
-            // On transient mid-stream errors we discard accumulated text and
-            // re-create the stream.  The provider treats it as a fresh request.
-            let mut stream_attempt = 0;
+            // Preserve main's any-stage recreation behavior while enforcing one
+            // shared physical-request budget across setup and parser failures.
+            // TODO(stream-retry-safety): once clients can atomically replace or
+            // roll back attempt-scoped deltas, eliminate possible duplicate output.
+            let mut retry_budget = super::llm_retry::StreamRetryBudget::new(
+                max_stream_retries,
+                config.execution_policy.rate_limit.max_attempts(),
+            );
             'stream: loop {
-                stream_attempt += 1;
+                let mut semantic_output_seen = false;
 
                 // Reset accumulators on retry so we start fresh.
                 text.clear();
@@ -299,40 +378,56 @@ pub(super) async fn transition_call_llm(
                 stream_tool_calls.clear();
                 tool_call_ids.clear();
                 usage = None;
-                stream_finish_reason = None;
                 text_buffer.clear();
                 thinking_buffer.clear();
                 last_flush = Instant::now();
 
-                let mut stream = super::llm_retry::create_stream_with_retry(
-                    config,
+                let attempt = retry_budget
+                    .reserve_attempt()
+                    .expect("a retry is accepted only when another attempt is available");
+                debug!(
+                    "Session {}: starting physical stream request attempt {}/{}",
                     session_id,
-                    &exec_ctx.cancellation_token,
-                    || {
-                        let provider = &provider;
-                        let messages_with_cache = &messages_with_cache;
-                        let tools_slice = tools.as_ref();
-                        async move {
-                            provider
-                                .chat_stream_with_tools(messages_with_cache, Some(tools_slice))
-                                .await
+                    attempt,
+                    config.execution_policy.rate_limit.max_attempts(),
+                );
+                if exec_ctx.cancellation_token.is_cancelled() {
+                    return Ok(ExecutionState::Cancelled);
+                }
+
+                let mut stream = match provider
+                    .chat_stream_with_tools(&messages_with_cache, Some(tools.as_ref()))
+                    .await
+                {
+                    Ok(stream) => stream,
+                    Err(error) => match super::llm_retry::handle_stream_failure(
+                        config,
+                        session_id,
+                        error,
+                        &mut retry_budget,
+                        false,
+                        Some(message_id.clone()),
+                        &exec_ctx.cancellation_token,
+                    )
+                    .await
+                    {
+                        super::llm_retry::StreamFailureAction::Retry => continue 'stream,
+                        super::llm_retry::StreamFailureAction::Cancelled => {
+                            return Ok(ExecutionState::Cancelled);
+                        }
+                        super::llm_retry::StreamFailureAction::Terminal(error) => {
+                            return map_failed_llm_call(error, true);
                         }
                     },
-                )
-                .await?;
+                };
 
                 // ── Inner consume loop ───────────────────────────────────────
                 loop {
-                    let item = tokio::select! {
-                        item = stream.next() => item,
-                        _ = exec_ctx.cancellation_token.cancelled() => {
-                            return Ok(ExecutionState::Cancelled);
-                        }
-                    };
-
-                    let Some(item) = item else {
-                        break 'stream;
-                    };
+                    let item = super::llm_retry::next_stream_chunk(
+                        &mut stream,
+                        &exec_ctx.cancellation_token,
+                    )
+                    .await;
 
                     let chunk = match item {
                         Ok(chunk) => chunk,
@@ -357,33 +452,28 @@ pub(super) async fn transition_call_llm(
                             );
                             continue;
                         }
-                        Err(e) if e.is_retryable() && stream_attempt <= max_stream_retries => {
-                            debug!(
-                                "Session {}: retryable mid-stream error on attempt {}/{}: {}",
-                                session_id, stream_attempt, max_stream_retries, e
-                            );
-                            flush_buffers!(true);
-                            config.emit_event(
-                                session_id,
-                                AgentEventKind::StreamRecovering {
-                                    message: e.to_string(),
-                                    attempt: u32_from_usize(
-                                        stream_attempt,
-                                        "stream_attempt",
-                                        Some(session_id),
-                                    ),
-                                    max_attempts: u32_from_usize(
-                                        max_stream_retries,
-                                        "max_stream_retries",
-                                        Some(session_id),
-                                    ),
-                                    message_id: Some(message_id.clone()),
-                                },
-                            );
-                            continue 'stream; // retry with fresh stream + accumulators
-                        }
-                        Err(e) => return Err(anyhow::Error::from(e).context("LLM streaming error")),
+                        Err(error) => match super::llm_retry::handle_stream_failure(
+                            config,
+                            session_id,
+                            error,
+                            &mut retry_budget,
+                            semantic_output_seen,
+                            Some(message_id.clone()),
+                            &exec_ctx.cancellation_token,
+                        )
+                        .await
+                        {
+                            super::llm_retry::StreamFailureAction::Retry => continue 'stream,
+                            super::llm_retry::StreamFailureAction::Cancelled => {
+                                return Ok(ExecutionState::Cancelled);
+                            }
+                            super::llm_retry::StreamFailureAction::Terminal(error) => {
+                                return Err(contextualize_llm_error(error, "streaming"));
+                            }
+                        },
                     };
+
+                    semantic_output_seen |= super::llm_retry::stream_chunk_commits_output(&chunk);
 
                     match chunk {
                         StreamChunk::Text(delta) => {
@@ -446,7 +536,6 @@ pub(super) async fn transition_call_llm(
                             });
                         }
                         StreamChunk::Done { finish_reason } => {
-                            stream_finish_reason = Some(finish_reason);
                             trace!(
                                 "stream chunk: session={} message_id={} type=done finish_reason={:?}",
                                 session_id, message_id, finish_reason
@@ -478,7 +567,34 @@ pub(super) async fn transition_call_llm(
                                     Err(_) | Ok(_) => break,
                                 }
                             }
-                            break 'stream;
+
+                            match validate_stream_terminal(finish_reason, &stream_tool_calls) {
+                                Ok(finish_reason) => {
+                                    stream_finish_reason = Some(finish_reason);
+                                    break 'stream;
+                                }
+                                Err(error) => match super::llm_retry::handle_stream_failure(
+                                    config,
+                                    session_id,
+                                    error,
+                                    &mut retry_budget,
+                                    semantic_output_seen,
+                                    Some(message_id.clone()),
+                                    &exec_ctx.cancellation_token,
+                                )
+                                .await
+                                {
+                                    super::llm_retry::StreamFailureAction::Retry => {
+                                        continue 'stream;
+                                    }
+                                    super::llm_retry::StreamFailureAction::Cancelled => {
+                                        return Ok(ExecutionState::Cancelled);
+                                    }
+                                    super::llm_retry::StreamFailureAction::Terminal(error) => {
+                                        return Err(contextualize_llm_error(error, "streaming"));
+                                    }
+                                },
+                            }
                         }
                         _ => {}
                     }
@@ -512,16 +628,10 @@ pub(super) async fn transition_call_llm(
                 return Ok(ExecutionState::Cancelled);
             }
 
-            // Use the provider-mapped finish_reason from the Done chunk.
-            // Fall back to a tool-call heuristic when the stream ended
-            // without a Done chunk (e.g. unexpected EOF).
-            let finish_reason = stream_finish_reason.or({
-                if stream_tool_calls.is_empty() {
-                    Some(FinishReason::Stop)
-                } else {
-                    Some(FinishReason::ToolCalls)
-                }
-            });
+            let finish_reason = Some(
+                stream_finish_reason
+                    .expect("successful stream loop exits only after an explicit Done chunk"),
+            );
 
             // Stash message_id in response so transition_after_llm reuses it
             // (see LlmResponse::with_message_id)
@@ -542,7 +652,7 @@ pub(super) async fn transition_call_llm(
         } else {
             // === NON-STREAMING FALLBACK ===
             let cancel = exec_ctx.cancellation_token.clone();
-            let resp = super::llm_retry::call_llm_with_retry(
+            let resp = match super::llm_retry::call_with_retry(
                 config,
                 session_id,
                 &exec_ctx.cancellation_token,
@@ -563,7 +673,11 @@ pub(super) async fn transition_call_llm(
                     }
                 },
             )
-            .await?;
+            .await
+            {
+                Ok(resp) => resp,
+                Err(e) => return map_failed_llm_call(e, false),
+            };
 
             (
                 resp.text().unwrap_or_default(),
@@ -1042,6 +1156,56 @@ mod tests {
             content: vec![Content::text(content)],
             cache: None,
         }
+    }
+
+    // ── map_failed_llm_call ───────────────────────────────────────────────────
+
+    #[test]
+    fn setup_cancel_maps_to_cancelled_not_error() {
+        let non_stream =
+            map_failed_llm_call(LLMError::Cancelled, false).expect("cancel must be Ok(Cancelled)");
+        assert!(matches!(non_stream, ExecutionState::Cancelled));
+
+        let stream = map_failed_llm_call(LLMError::Cancelled, true)
+            .expect("stream setup cancel must be Ok(Cancelled)");
+        assert!(matches!(stream, ExecutionState::Cancelled));
+    }
+
+    #[test]
+    fn tool_calls_finish_without_completed_calls_is_rejected() {
+        let error = validate_stream_terminal(FinishReason::ToolCalls, &[])
+            .expect_err("tool_calls without completed calls must not become success");
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == querymt::error::ProviderErrorKind::UnknownTransient
+        ));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn setup_failures_add_operation_context_without_erasing_source() {
+        let chat_err =
+            map_failed_llm_call(LLMError::InvalidRequest("missing api_key".into()), false)
+                .expect_err("non-stream failure is Err");
+        assert!(chat_err.to_string().contains("LLM chat error"));
+        assert!(
+            chat_err
+                .to_string()
+                .contains("Invalid Request: missing api_key")
+        );
+        assert!(matches!(
+            chat_err.downcast_ref::<LLMError>(),
+            Some(LLMError::InvalidRequest(message)) if message == "missing api_key"
+        ));
+
+        let stream_err = map_failed_llm_call(LLMError::GenericError("boom".into()), true)
+            .expect_err("stream failure is Err");
+        assert!(stream_err.to_string().contains("LLM streaming error"));
+        assert!(matches!(
+            stream_err.downcast_ref::<LLMError>(),
+            Some(LLMError::GenericError(message)) if message == "boom"
+        ));
     }
 
     // ── apply_cache_breakpoints ───────────────────────────────────────────────

--- a/crates/agent/src/config/execution.rs
+++ b/crates/agent/src/config/execution.rs
@@ -201,7 +201,7 @@ impl Default for CompactionConfig {
 // Rate Limit Configuration
 // ============================================================================
 
-/// Default maximum retry attempts for rate limiting
+/// Default total request-attempt budget, including the initial request
 pub const DEFAULT_RATE_LIMIT_MAX_RETRIES: usize = 3;
 
 /// Default wait time in seconds if no retry-after header
@@ -210,8 +210,14 @@ pub const DEFAULT_RATE_LIMIT_WAIT_SECS: u64 = 60;
 /// Default backoff multiplier for rate limiting
 pub const DEFAULT_RATE_LIMIT_BACKOFF_MULTIPLIER: f64 = 2.0;
 
-/// Default max retries for mid-stream transport failures
-pub const DEFAULT_STREAM_MAX_RETRIES: usize = 1;
+/// Default stream-recreation cap within the shared request-attempt budget.
+pub const DEFAULT_STREAM_MAX_RETRIES: usize = 2;
+
+/// Default proportional jitter applied to calculated backoff delays
+pub const DEFAULT_RATE_LIMIT_JITTER_RATIO: f64 = 0.2;
+
+/// Default upper bound for calculated retry delays
+pub const DEFAULT_RATE_LIMIT_MAX_WAIT_SECS: u64 = 300;
 
 fn default_rate_limit_max_retries() -> usize {
     DEFAULT_RATE_LIMIT_MAX_RETRIES
@@ -229,11 +235,19 @@ fn default_stream_max_retries() -> usize {
     DEFAULT_STREAM_MAX_RETRIES
 }
 
+fn default_rate_limit_jitter_ratio() -> f64 {
+    DEFAULT_RATE_LIMIT_JITTER_RATIO
+}
+
+fn default_rate_limit_max_wait_secs() -> u64 {
+    DEFAULT_RATE_LIMIT_MAX_WAIT_SECS
+}
+
 /// Configuration for rate limit retry behavior
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RateLimitConfig {
-    /// Maximum number of retry attempts (default: 3)
+    /// Total request-attempt budget, including the initial request (default: 3)
     #[serde(default = "default_rate_limit_max_retries")]
     pub max_retries: usize,
 
@@ -243,13 +257,63 @@ pub struct RateLimitConfig {
 
     /// Backoff multiplier when no retry-after header (default: 2.0)
     /// Wait time increases exponentially: default_wait_secs * multiplier^(attempt-1)
+    /// Must be finite and `> 0`.
     #[serde(default = "default_rate_limit_backoff_multiplier")]
     pub backoff_multiplier: f64,
 
-    /// Max retries for mid-stream transport failures (default: 1).
-    /// On each retry, accumulated text is discarded and the stream is re-created.
+    /// Maximum stream recreations within the shared request-attempt budget (default: 2).
+    /// Each recreation restarts the provider request and also consumes `max_retries`.
     #[serde(default = "default_stream_max_retries")]
     pub max_stream_retries: usize,
+
+    /// Proportional jitter for calculated delays (`0.0..=1.0`). Provider retry
+    /// hints are not jittered.
+    ///
+    /// Runtime-only for now: not written into `session_execution_configs` so older
+    /// qmtcode builds (strict `deny_unknown_fields`) can still open sessions.
+    /// TODO(session-compat): drop `skip_serializing` and persist once older readers
+    /// are retired, or gate behind a session config migration.
+    #[serde(default = "default_rate_limit_jitter_ratio", skip_serializing)]
+    pub jitter_ratio: f64,
+
+    /// Upper bound for every retry delay (`>= 1`).
+    ///
+    /// Provider `Retry-After` / message hints are clamped by this field before
+    /// sleeping or emitting retry-wait events.
+    ///
+    /// Runtime-only for now — same session-compat rationale as `jitter_ratio`.
+    /// TODO(session-compat): persist with `jitter_ratio` when ready.
+    #[serde(default = "default_rate_limit_max_wait_secs", skip_serializing)]
+    pub max_wait_secs: u64,
+}
+
+impl RateLimitConfig {
+    /// Total request-attempt budget, clamped to at least one attempt.
+    /// This is the single clamp site — call `max_attempts()`, never
+    /// `max_retries.max(1)` inline.
+    pub fn max_attempts(&self) -> usize {
+        self.max_retries.max(1)
+    }
+
+    /// Validate numeric ranges. Used by deserialize and for programmatic configs.
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.backoff_multiplier.is_finite() || self.backoff_multiplier <= 0.0 {
+            return Err(format!(
+                "rate_limit.backoff_multiplier must be finite and > 0, got {}",
+                self.backoff_multiplier
+            ));
+        }
+        if !self.jitter_ratio.is_finite() || !(0.0..=1.0).contains(&self.jitter_ratio) {
+            return Err(format!(
+                "rate_limit.jitter_ratio must be finite and in 0.0..=1.0, got {}",
+                self.jitter_ratio
+            ));
+        }
+        if self.max_wait_secs == 0 {
+            return Err("rate_limit.max_wait_secs must be >= 1".into());
+        }
+        Ok(())
+    }
 }
 
 impl Default for RateLimitConfig {
@@ -259,7 +323,45 @@ impl Default for RateLimitConfig {
             default_wait_secs: DEFAULT_RATE_LIMIT_WAIT_SECS,
             backoff_multiplier: DEFAULT_RATE_LIMIT_BACKOFF_MULTIPLIER,
             max_stream_retries: DEFAULT_STREAM_MAX_RETRIES,
+            jitter_ratio: DEFAULT_RATE_LIMIT_JITTER_RATIO,
+            max_wait_secs: DEFAULT_RATE_LIMIT_MAX_WAIT_SECS,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for RateLimitConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Raw {
+            #[serde(default = "default_rate_limit_max_retries")]
+            max_retries: usize,
+            #[serde(default = "default_rate_limit_wait_secs")]
+            default_wait_secs: u64,
+            #[serde(default = "default_rate_limit_backoff_multiplier")]
+            backoff_multiplier: f64,
+            #[serde(default = "default_stream_max_retries")]
+            max_stream_retries: usize,
+            #[serde(default = "default_rate_limit_jitter_ratio")]
+            jitter_ratio: f64,
+            #[serde(default = "default_rate_limit_max_wait_secs")]
+            max_wait_secs: u64,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let cfg = Self {
+            max_retries: raw.max_retries,
+            default_wait_secs: raw.default_wait_secs,
+            backoff_multiplier: raw.backoff_multiplier,
+            max_stream_retries: raw.max_stream_retries,
+            jitter_ratio: raw.jitter_ratio,
+            max_wait_secs: raw.max_wait_secs,
+        };
+        cfg.validate().map_err(serde::de::Error::custom)?;
+        Ok(cfg)
     }
 }
 
@@ -462,3 +564,127 @@ impl From<&ExecutionPolicy> for RuntimeExecutionPolicy {
 }
 
 // ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rate_limit_default_allows_two_stream_recreations() {
+        let config = RateLimitConfig::default();
+        assert_eq!(config.max_attempts(), 3);
+        assert_eq!(config.max_stream_retries, 2);
+    }
+
+    #[test]
+    fn rate_limit_config_omits_runtime_only_fields_on_serialize() {
+        let cfg = RateLimitConfig {
+            jitter_ratio: 0.9,
+            max_wait_secs: 42,
+            ..Default::default()
+        };
+
+        let value = serde_json::to_value(&cfg).expect("serialize");
+        let obj = value.as_object().expect("object");
+
+        assert!(
+            !obj.contains_key("jitter_ratio"),
+            "jitter_ratio must stay runtime-only until session-compat is ready: {value}"
+        );
+        assert!(
+            !obj.contains_key("max_wait_secs"),
+            "max_wait_secs must stay runtime-only until session-compat is ready: {value}"
+        );
+
+        // Stable keys older qmtcode already understands.
+        for key in [
+            "max_retries",
+            "default_wait_secs",
+            "backoff_multiplier",
+            "max_stream_retries",
+        ] {
+            assert!(obj.contains_key(key), "missing expected key {key}: {value}");
+        }
+    }
+
+    #[test]
+    fn rate_limit_config_deserializes_missing_runtime_only_fields_to_defaults() {
+        let cfg: RateLimitConfig = serde_json::from_value(json!({
+            "max_retries": 5,
+            "default_wait_secs": 30,
+            "backoff_multiplier": 1.5,
+            "max_stream_retries": 2,
+        }))
+        .expect("deserialize without runtime-only fields");
+        assert!((cfg.jitter_ratio - DEFAULT_RATE_LIMIT_JITTER_RATIO).abs() < f64::EPSILON);
+        assert_eq!(cfg.max_wait_secs, DEFAULT_RATE_LIMIT_MAX_WAIT_SECS);
+    }
+
+    #[test]
+    fn rate_limit_config_still_deserializes_runtime_only_fields_when_present() {
+        // Blobs already written by earlier builds of this branch should still load.
+        let cfg: RateLimitConfig = serde_json::from_value(json!({
+            "max_retries": 5,
+            "default_wait_secs": 30,
+            "backoff_multiplier": 2.0,
+            "max_stream_retries": 2,
+            "jitter_ratio": 0.5,
+            "max_wait_secs": 120,
+        }))
+        .expect("deserialize with runtime-only fields");
+        assert!((cfg.jitter_ratio - 0.5).abs() < f64::EPSILON);
+        assert_eq!(cfg.max_wait_secs, 120);
+    }
+
+    #[test]
+    fn rate_limit_config_rejects_jitter_ratio_out_of_range() {
+        let err = serde_json::from_value::<RateLimitConfig>(json!({
+            "jitter_ratio": 20.0,
+        }))
+        .expect_err("jitter_ratio > 1 must fail at parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("jitter_ratio"),
+            "error should name the field: {msg}"
+        );
+    }
+
+    #[test]
+    fn rate_limit_config_rejects_negative_jitter_ratio() {
+        let err = serde_json::from_value::<RateLimitConfig>(json!({
+            "jitter_ratio": -0.1,
+        }))
+        .expect_err("negative jitter_ratio must fail at parse");
+        assert!(err.to_string().contains("jitter_ratio"));
+    }
+
+    #[test]
+    fn rate_limit_config_rejects_non_positive_backoff_multiplier() {
+        let err = serde_json::from_value::<RateLimitConfig>(json!({
+            "backoff_multiplier": 0.0,
+        }))
+        .expect_err("backoff_multiplier <= 0 must fail at parse");
+        assert!(err.to_string().contains("backoff_multiplier"));
+    }
+
+    #[test]
+    fn rate_limit_config_rejects_zero_max_wait_secs() {
+        let err = serde_json::from_value::<RateLimitConfig>(json!({
+            "max_wait_secs": 0,
+        }))
+        .expect_err("max_wait_secs == 0 must fail at parse");
+        assert!(err.to_string().contains("max_wait_secs"));
+    }
+
+    #[test]
+    fn rate_limit_config_accepts_boundary_jitter_ratio() {
+        for ratio in [0.0, 1.0] {
+            let cfg: RateLimitConfig = serde_json::from_value(json!({
+                "jitter_ratio": ratio,
+            }))
+            .unwrap_or_else(|e| panic!("jitter_ratio={ratio} should be valid: {e}"));
+            assert!((cfg.jitter_ratio - ratio).abs() < f64::EPSILON);
+        }
+    }
+}

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -197,8 +197,8 @@ pub enum AgentEventKind {
         #[serde(skip_serializing_if = "Option::is_none")]
         message_id: Option<String>,
     },
-    /// Ephemeral signal emitted when mid-stream transport error is detected.
-    /// Accumulated text is discarded and a new stream is being created.
+    /// Ephemeral signal emitted when a retryable mid-stream error recreates the stream.
+    /// Accumulated server-side state is discarded before the fresh request.
     StreamRecovering {
         /// Human-readable error message that triggered the retry
         message: String,
@@ -416,7 +416,8 @@ pub enum AgentEventKind {
         #[typeshare(serialized_as = "string")]
         mode: crate::agent::core::AgentMode,
     },
-    /// LLM request was rate limited, execution is paused and waiting
+    /// LLM request was rate limited, execution is paused and waiting.
+    /// Retained as a stable wire event for rate-limit-specific UI behavior.
     RateLimited {
         /// Human-readable message from the provider
         message: String,
@@ -431,8 +432,28 @@ pub enum AgentEventKind {
         /// Maximum retry attempts configured
         max_attempts: u32,
     },
-    /// Rate limit wait completed, resuming execution
+    /// Rate limit wait completed, resuming execution.
     RateLimitResume {
+        /// Which attempt is now being made
+        attempt: u32,
+    },
+    /// A non-rate-limit retryable LLM failure is waiting before the next attempt.
+    LlmRetryWait {
+        /// Human-readable error that triggered the retry
+        message: String,
+        /// Seconds until retry will be attempted
+        #[typeshare(serialized_as = "number")]
+        wait_secs: u64,
+        /// When the wait started (Unix timestamp in seconds)
+        #[typeshare(serialized_as = "number")]
+        started_at: i64,
+        /// Current retry attempt (1-indexed)
+        attempt: u32,
+        /// Maximum retry attempts configured
+        max_attempts: u32,
+    },
+    /// Non-rate-limit LLM retry wait completed, resuming execution.
+    LlmRetryResume {
         /// Which attempt is now being made
         attempt: u32,
     },

--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -575,9 +575,7 @@ impl SessionProvider {
             ));
 
             // Generic path — works for Extism providers that implement set_key_resolver.
-            let mut provider = factory.from_config(&pruned_config_str).map_err(|e| {
-                LLMError::PluginError(format!("provider '{}': {}", provider_name, e))
-            })?;
+            let mut provider = factory.from_config(&pruned_config_str)?;
             provider.set_key_resolver(resolver.clone());
 
             if provider.key_resolver().is_some() {
@@ -592,10 +590,7 @@ impl SessionProvider {
             // Fallback for native HTTP providers: set the resolver on the inner
             // HTTPLLMProvider before it gets wrapped in Arc by the adapter.
             if let Some(http_factory) = factory.as_http() {
-                let mut http_provider =
-                    http_factory.from_config(&pruned_config_str).map_err(|e| {
-                        LLMError::PluginError(format!("provider '{}': {}", provider_name, e))
-                    })?;
+                let mut http_provider = http_factory.from_config(&pruned_config_str)?;
                 http_provider.set_key_resolver(resolver);
 
                 log::debug!(
@@ -617,9 +612,7 @@ impl SessionProvider {
             return Ok(Arc::from(provider));
         }
 
-        let provider = factory
-            .from_config(&pruned_config_str)
-            .map_err(|e| LLMError::PluginError(format!("provider '{}': {}", provider_name, e)))?;
+        let provider = factory.from_config(&pruned_config_str)?;
         Ok(Arc::from(provider))
     }
 }
@@ -1123,6 +1116,7 @@ pub mod tests {
     use querymt::chat::{ChatMessage, ChatResponse, FinishReason, StreamChunk};
     use querymt::completion::{CompletionRequest, CompletionResponse};
     use querymt::error::LLMError;
+    use querymt::plugin::LLMProviderFactory;
     use std::pin::Pin;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
@@ -1227,6 +1221,57 @@ pub mod tests {
     }
 
     impl LLMProvider for MockProvider {}
+
+    struct InvalidConfigFactory;
+
+    impl LLMProviderFactory for InvalidConfigFactory {
+        fn name(&self) -> &str {
+            "invalid-config"
+        }
+
+        fn config_schema(&self) -> String {
+            "{}".into()
+        }
+
+        fn from_config(&self, _cfg: &str) -> Result<Box<dyn LLMProvider>, LLMError> {
+            Err(LLMError::InvalidRequest("bad provider config".into()))
+        }
+
+        fn list_models<'a>(
+            &'a self,
+            _cfg: &str,
+        ) -> querymt::plugin::Fut<'a, Result<Vec<String>, LLMError>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn build_provider_preserves_typed_factory_error() {
+        use crate::session::sqlite_storage::SqliteStorage;
+
+        let registry = Arc::new(PluginRegistry::empty());
+        registry.register_static(Arc::new(InvalidConfigFactory));
+        let storage = Arc::new(
+            SqliteStorage::connect(":memory:".into())
+                .await
+                .expect("connect test storage"),
+        );
+        let provider = SessionProvider::new(registry, storage, LLMParams::new());
+
+        let error = match provider
+            .build_provider(ProviderRequest::new("invalid-config", "test-model"))
+            .await
+        {
+            Ok(_) => panic!("factory construction should fail"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            SessionError::ProviderError(LLMError::InvalidRequest(message))
+                if message == "bad provider config"
+        ));
+    }
 
     // ── resolve_api_key_with_preference tests ─────────────────────────────────
 

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -67,8 +67,8 @@ export type AgentEventKind =
 	message_id?: string;
 }}
 	/**
-	 * Ephemeral signal emitted when mid-stream transport error is detected.
-	 * Accumulated text is discarded and a new stream is being created.
+	 * Ephemeral signal emitted when a retryable mid-stream error recreates the stream.
+	 * Accumulated server-side state is discarded before the fresh request.
 	 */
 	| { type: "stream_recovering", data: {
 	/** Human-readable error message that triggered the retry */
@@ -265,7 +265,10 @@ export type AgentEventKind =
 	| { type: "session_mode_changed", data: {
 	mode: string;
 }}
-	/** LLM request was rate limited, execution is paused and waiting */
+	/**
+	 * LLM request was rate limited, execution is paused and waiting.
+	 * Retained as a stable wire event for rate-limit-specific UI behavior.
+	 */
 	| { type: "rate_limited", data: {
 	/** Human-readable message from the provider */
 	message: string;
@@ -278,8 +281,26 @@ export type AgentEventKind =
 	/** Maximum retry attempts configured */
 	max_attempts: number;
 }}
-	/** Rate limit wait completed, resuming execution */
+	/** Rate limit wait completed, resuming execution. */
 	| { type: "rate_limit_resume", data: {
+	/** Which attempt is now being made */
+	attempt: number;
+}}
+	/** A non-rate-limit retryable LLM failure is waiting before the next attempt. */
+	| { type: "llm_retry_wait", data: {
+	/** Human-readable error that triggered the retry */
+	message: string;
+	/** Seconds until retry will be attempted */
+	wait_secs: number;
+	/** When the wait started (Unix timestamp in seconds) */
+	started_at: number;
+	/** Current retry attempt (1-indexed) */
+	attempt: number;
+	/** Maximum retry attempts configured */
+	max_attempts: number;
+}}
+	/** Non-rate-limit LLM retry wait completed, resuming execution. */
+	| { type: "llm_retry_resume", data: {
 	/** Which attempt is now being made */
 	attempt: number;
 }}

--- a/crates/agent/ui/src/hooks/useUiClient.ts
+++ b/crates/agent/ui/src/hooks/useUiClient.ts
@@ -534,6 +534,17 @@ export function useUiClient() {
         const eventKind = eventEnvelope?.kind?.type;
         const kindData = eventEnvelope?.kind?.data ?? {};
 
+        if (eventKind === 'llm_retry_wait' || eventKind === 'llm_retry_resume') {
+          // TODO(ui): replace this stub with the deferred generic retry countdown UI.
+          console.info('[useUiClient] LLM retry event (UI pending)', {
+            session_id: d.session_id,
+            agent_id: d.agent_id,
+            event_kind: eventKind,
+            ...kindData,
+          });
+          break;
+        }
+
         if (
           eventKind === 'llm_request_start' ||
           eventKind === 'llm_request_end' ||

--- a/crates/providers/alibaba/src/lib.rs
+++ b/crates/providers/alibaba/src/lib.rs
@@ -1,7 +1,7 @@
 use http::{Request, Response};
 use qmt_openai::api::{
-    OpenAIProviderConfig, openai_chat_request, openai_embed_request, openai_parse_chat,
-    openai_parse_embed, url_schema,
+    OpenAIProviderConfig, classify_openai_http_error, openai_chat_request, openai_embed_request,
+    openai_parse_chat, openai_parse_embed, url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -123,6 +123,10 @@ impl OpenAIProviderConfig for Alibaba {
 }
 
 impl HTTPChatProvider for Alibaba {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],

--- a/crates/providers/anthropic/src/lib.rs
+++ b/crates/providers/anthropic/src/lib.rs
@@ -25,8 +25,10 @@ use querymt::{
     },
     completion::{CompletionRequest, CompletionResponse, http::HTTPCompletionProvider},
     embedding::http::HTTPEmbeddingProvider,
-    error::LLMError,
-    handle_http_error,
+    error::{
+        LLMError, ProviderErrorKind, ProviderFailure, classify_status_only, parse_retry_after,
+        parse_retry_after_from_message,
+    },
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -489,6 +491,16 @@ struct AnthropicStreamResponse {
     usage: Option<Usage>,
     /// Nested message object (present on message_start events)
     message: Option<AnthropicStreamMessage>,
+    /// Nested error object (present on `type: "error"` SSE events)
+    error: Option<AnthropicApiErrorBody>,
+}
+
+/// Anthropic error envelope body (`{"type":"error","error":{...}}` or nested in SSE).
+#[derive(Deserialize, Debug)]
+struct AnthropicApiErrorBody {
+    #[serde(rename = "type")]
+    error_type: Option<String>,
+    message: Option<String>,
 }
 
 /// Nested message object within an Anthropic `message_start` SSE event.
@@ -1023,11 +1035,16 @@ impl HTTPChatProvider for Anthropic {
         cfg.chat_request(messages, tools)
     }
 
-    fn parse_chat(&self, resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-        handle_http_error!(resp);
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_anthropic_http_error(response)
+    }
 
+    fn parse_chat(&self, resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
         let mut json_resp: AnthropicCompleteResponse = serde_json::from_slice(resp.body())
-            .map_err(|e| LLMError::HttpError(format!("Failed to parse JSON: {}", e)))?;
+            .map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to parse Anthropic response JSON: {e}"),
+                raw_response: String::from_utf8_lossy(resp.body()).into_owned(),
+            })?;
 
         // Strip tool prefix from tool names in response (for OAuth)
         if self.is_oauth() {
@@ -1079,6 +1096,15 @@ impl ChatStreamParser for AnthropicStreamParser {
                     })?;
 
                 match stream_resp.response_type.as_str() {
+                    "error" => {
+                        return Err(map_anthropic_api_error(
+                            stream_resp.error.as_ref(),
+                            None,
+                            None,
+                            false,
+                        )
+                        .into());
+                    }
                     "message_start" => {
                         if let Some(usage) = stream_resp.message.and_then(|m| m.usage) {
                             chunks.push(querymt::chat::StreamChunk::Usage(usage));
@@ -1186,6 +1212,104 @@ impl ChatStreamParser for AnthropicStreamParser {
         }
         Ok(chunks)
     }
+}
+
+/// Normalize Anthropic `error.type` tokens for kind lookup.
+fn normalize_anthropic_error_token(token: &str) -> String {
+    token.trim().to_ascii_lowercase().replace(['-', ' '], "_")
+}
+
+/// Map Anthropic `error.type` to a unified kind.
+///
+/// Anthropic documents: `invalid_request_error`, `authentication_error`,
+/// `permission_error`, `not_found_error`, `request_too_large`, `rate_limit_error`,
+/// `api_error`, `overloaded_error`.
+fn anthropic_error_kind(error_type: &str) -> Option<ProviderErrorKind> {
+    match error_type {
+        "overloaded_error" | "overloaded" => Some(ProviderErrorKind::ServerOverloaded),
+        "rate_limit_error" | "rate_limit_exceeded" | "rate_limited" => {
+            Some(ProviderErrorKind::RateLimited)
+        }
+        "authentication_error" | "permission_error" => Some(ProviderErrorKind::Authentication),
+        "invalid_request_error" | "invalid_request" | "not_found_error" | "request_too_large" => {
+            Some(ProviderErrorKind::InvalidRequest)
+        }
+        "api_error" => Some(ProviderErrorKind::UnknownTransient),
+        _ => None,
+    }
+}
+
+fn map_anthropic_api_error(
+    error: Option<&AnthropicApiErrorBody>,
+    header_retry_after: Option<u64>,
+    request_id: Option<&str>,
+    unknown_transient: bool,
+) -> ProviderFailure {
+    let error_type = error.and_then(|e| e.error_type.clone());
+    let message = error
+        .and_then(|e| e.message.as_deref())
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| "anthropic request failed".to_owned());
+
+    let type_norm = error_type.as_deref().map(normalize_anthropic_error_token);
+    let kind = type_norm
+        .as_deref()
+        .and_then(anthropic_error_kind)
+        .unwrap_or(if unknown_transient {
+            ProviderErrorKind::UnknownTransient
+        } else {
+            ProviderErrorKind::UnknownPermanent
+        });
+
+    let retry_after_secs = if kind == ProviderErrorKind::RateLimited {
+        header_retry_after.or_else(|| parse_retry_after_from_message(&message))
+    } else {
+        header_retry_after
+    };
+
+    ProviderFailure::new(kind, message)
+        .with_error_type(error_type)
+        .with_request_id(request_id.map(str::to_owned))
+        .with_retry_after_secs(retry_after_secs)
+}
+
+/// Classify an Anthropic HTTP error body.
+fn classify_anthropic_http_error(response: &Response<Vec<u8>>) -> LLMError {
+    let status = response.status().as_u16();
+    let retry_after_secs = parse_retry_after(response.headers());
+    let request_id = response
+        .headers()
+        .get("request-id")
+        .or_else(|| response.headers().get("x-request-id"))
+        .and_then(|value| value.to_str().ok());
+    // Prefer structured `{"type":"error","error":{...}}` or top-level gateway errors.
+    if let Ok(envelope) = serde_json::from_slice::<Value>(response.body()) {
+        let error_value = envelope.get("error").cloned().or_else(|| {
+            (envelope.get("message").is_some() && envelope.get("type").is_some())
+                .then_some(envelope.clone())
+        });
+
+        if let Some(error_value) = error_value {
+            let parsed: Option<AnthropicApiErrorBody> = serde_json::from_value(error_value).ok();
+            if parsed
+                .as_ref()
+                .is_some_and(|e| e.error_type.is_some() || e.message.is_some())
+            {
+                let status_guess_transient = matches!(status, 429 | 500..=599);
+                return map_anthropic_api_error(
+                    parsed.as_ref(),
+                    retry_after_secs,
+                    request_id,
+                    status_guess_transient,
+                )
+                .into();
+            }
+        }
+    }
+
+    classify_status_only(status, response.headers(), response.body())
 }
 
 impl HTTPCompletionProvider for Anthropic {
@@ -1857,5 +1981,156 @@ mod tests {
             "expected a Text chunk"
         );
         // Parser state is per-stream and dropped with the parser instance.
+    }
+
+    #[test]
+    fn classify_http_top_level_gateway_error_is_classified() {
+        let response = Response::builder()
+            .status(503)
+            .body(br#"{"type":"api_error","message":"gateway busy"}"#.to_vec())
+            .unwrap();
+        let error = classify_anthropic_http_error(&response);
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.message() == "gateway busy"
+                    && failure.error_type() == Some("api_error")
+                    && failure.code().is_none()
+        ));
+    }
+
+    #[test]
+    fn classify_http_missing_message_uses_safe_fallback() {
+        let response = Response::builder()
+            .status(500)
+            .body(br#"{"type":"error","error":{"type":"api_error","private":"secret"}}"#.to_vec())
+            .unwrap();
+        let error = classify_anthropic_http_error(&response);
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.message() == "anthropic request failed"
+                    && !failure.message().contains("private")
+        ));
+    }
+
+    #[test]
+    fn classify_http_overloaded_is_retryable() {
+        let response = Response::builder()
+            .status(529)
+            .body(
+                br#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_anthropic_http_error(&response);
+        assert!(error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.error_type(), Some("overloaded_error"));
+                assert_eq!(failure.code(), None);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_invalid_request_is_permanent() {
+        let response = Response::builder()
+            .status(400)
+            .body(
+                br#"{"type":"error","error":{"type":"invalid_request_error","message":"messages: text content blocks must be non-empty"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_anthropic_http_error(&response);
+        assert!(!error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::InvalidRequest);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_rate_limit_is_retryable() {
+        let response = Response::builder()
+            .status(429)
+            .header(http::header::RETRY_AFTER, "12")
+            .header("request-id", "req-ant-http")
+            .body(
+                br#"{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_anthropic_http_error(&response);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after_secs(), Some(12));
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+                assert_eq!(failure.request_id(), Some("req-ant-http"));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn streaming_error_event_overloaded_is_retryable() {
+        let anthropic = test_anthropic("sk-ant-api03-test");
+        let mut parser = anthropic.chat_stream_parser().unwrap();
+        let line =
+            br#"data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+"#;
+        let err = parser
+            .parse_chunk(line)
+            .expect_err("error event must fail the stream");
+        assert!(err.is_retryable());
+        match err {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn streaming_api_error_is_transient() {
+        let anthropic = test_anthropic("sk-ant-api03-test");
+        let mut parser = anthropic.chat_stream_parser().unwrap();
+        let line = br#"data: {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
+"#;
+        let error = parser
+            .parse_chunk(line)
+            .expect_err("api error event must fail the stream");
+
+        assert!(error.is_retryable());
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn streaming_error_event_invalid_request_is_permanent() {
+        let anthropic = test_anthropic("sk-ant-api03-test");
+        let mut parser = anthropic.chat_stream_parser().unwrap();
+        let line = br#"data: {"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}
+"#;
+        let err = parser
+            .parse_chunk(line)
+            .expect_err("error event must fail the stream");
+        assert!(!err.is_retryable());
+        match err {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::InvalidRequest);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
     }
 }

--- a/crates/providers/codex/src/api.rs
+++ b/crates/providers/codex/src/api.rs
@@ -13,7 +13,10 @@ use querymt::{
         ChatMessage, ChatResponse, ChatRole, Content, FinishReason, ReasoningEffort, StreamChunk,
         Tool, ToolChoice,
     },
-    error::LLMError,
+    error::{
+        LLMError, ProviderErrorKind, ProviderFailure, extract_retry_after_from_json,
+        parse_retry_after, parse_retry_after_from_message,
+    },
     handle_http_error,
 };
 use schemars::{Schema, SchemaGenerator, json_schema};
@@ -95,13 +98,15 @@ pub trait CodexProviderConfig {
 
 #[derive(Debug, Clone, Default)]
 pub struct CodexToolUseState {
-    /// The Responses API item id (e.g. `fc_...`), used to correlate argument delta/done events.
+    /// The Responses API item id (e.g. `fc_...`), used to correlate streamed argument events.
     pub item_id: Option<String>,
     /// The tool call id (e.g. `call_...`), which we surface as `ToolCall.id`.
     pub id: Option<String>,
     pub name: Option<String>,
     pub arguments: String,
     pub started: bool,
+    /// Set only after the authoritative `response.output_item.done` event is parsed.
+    pub completed: bool,
     pub emitted_thinking: Vec<String>,
     pub emitted_thinking_text: String,
     pub streamed_thinking_seen: bool,
@@ -309,11 +314,13 @@ struct CodexSseEvent {
     #[serde(rename = "type")]
     kind: String,
     delta: Option<String>,
-    arguments: Option<String>,
     response: Option<Value>,
+    #[serde(alias = "requestId")]
+    request_id: Option<String>,
     item: Option<Value>,
     output_index: Option<usize>,
     item_id: Option<String>,
+    end_turn: Option<bool>,
 }
 
 fn joined_non_empty(pieces: Vec<String>) -> Option<String> {
@@ -750,7 +757,9 @@ pub fn codex_parse_chat_with_state(
     response: Response<Vec<u8>>,
     tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
 ) -> Result<Box<dyn ChatResponse>, LLMError> {
-    handle_http_error!(response);
+    if !response.status().is_success() {
+        return Err(classify_codex_http_error(&response));
+    }
 
     let body = response.body();
     let raw = String::from_utf8_lossy(body);
@@ -776,6 +785,36 @@ pub fn codex_parse_chat_with_state(
     }
 }
 
+pub fn classify_codex_http_error(response: &Response<Vec<u8>>) -> LLMError {
+    let status = response.status().as_u16();
+    let retry_after_secs = parse_retry_after(response.headers());
+    let request_id = response
+        .headers()
+        .get("x-request-id")
+        .or_else(|| response.headers().get("request-id"))
+        .and_then(|value| value.to_str().ok());
+    let envelope = serde_json::from_slice::<Value>(response.body()).ok();
+    if let Some(envelope) = envelope.as_ref() {
+        let response_value = envelope.get("response").unwrap_or(envelope);
+        if let Some(error) = response_value
+            .get("error")
+            .or_else(|| envelope.get("error"))
+        {
+            let mapped = map_codex_response_failed(
+                error,
+                response_value,
+                request_id,
+                matches!(status, 429 | 500..=599),
+            );
+            let retry_after_secs = retry_after_secs.or(mapped.retry_after_secs());
+            return mapped.with_retry_after_secs(retry_after_secs).into();
+        }
+    }
+
+    // No vendor envelope: classify from the status alone.
+    querymt::error::classify_status_only(status, response.headers(), response.body())
+}
+
 pub fn codex_parse_stream_chunk_with_state(
     chunk: &[u8],
     tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
@@ -798,20 +837,9 @@ pub fn codex_parse_stream_chunk_with_state(
             None => continue,
         };
 
+        // The Responses API is complete only after `response.completed`.
+        // `[DONE]` is transport framing and does not describe response semantics.
         if data == "[DONE]" {
-            let has_tool_calls = tool_state_buffer
-                .lock()
-                .unwrap()
-                .values()
-                .any(|s| s.started);
-            clear_thinking_state(tool_state_buffer);
-            results.push(StreamChunk::Done {
-                finish_reason: if has_tool_calls {
-                    FinishReason::ToolCalls
-                } else {
-                    FinishReason::Stop
-                },
-            });
             continue;
         }
 
@@ -857,27 +885,31 @@ pub fn codex_parse_stream_chunk_with_state(
                 }
             }
             "response.output_item.done" => {
-                if let Some(item) = event.item {
-                    if item.get("type").and_then(Value::as_str) == Some("reasoning") {
-                        if let Some(text) = extract_reasoning_text_from_value(&item)
-                            && let Some(text) =
-                                mark_final_thinking_emitted(tool_state_buffer, &text)
-                        {
-                            results.push(StreamChunk::Thinking(text));
-                        }
-                    } else {
-                        handle_output_item_event(
-                            &item,
-                            event.output_index,
-                            &mut results,
-                            tool_state_buffer,
-                        );
+                let Some(item) = event.item else {
+                    tool_state_buffer.lock().unwrap().clear();
+                    return Err(codex_stream_format_error(
+                        "response.output_item.done missing item payload",
+                        &Value::Null,
+                    ));
+                };
+                if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+                    if let Some(text) = extract_reasoning_text_from_value(&item)
+                        && let Some(text) = mark_final_thinking_emitted(tool_state_buffer, &text)
+                    {
+                        results.push(StreamChunk::Thinking(text));
                     }
+                } else {
+                    handle_output_item_done(
+                        &item,
+                        event.output_index,
+                        &mut results,
+                        tool_state_buffer,
+                    )?;
                 }
             }
             "response.output_item.added" => {
                 if let Some(item) = event.item {
-                    handle_output_item_event(
+                    handle_output_item_added(
                         &item,
                         event.output_index,
                         &mut results,
@@ -896,19 +928,19 @@ pub fn codex_parse_stream_chunk_with_state(
                     );
                 }
             }
-            "response.function_call_arguments.done" => {
-                handle_function_call_arguments_done(
-                    event.output_index,
-                    event.item_id.as_deref(),
-                    event.arguments.as_deref(),
-                    &mut results,
-                    tool_state_buffer,
-                );
-            }
+            // `response.output_item.done` contains the authoritative function call.
+            "response.function_call_arguments.done" => {}
             "response.completed" => {
                 debug!("codex stream: response.completed received");
+                if response_end_turn(&event) == Some(false) {
+                    tool_state_buffer.lock().unwrap().clear();
+                    return Err(codex_stream_format_error(
+                        "response.completed with end_turn=false is not supported",
+                        event.response.as_ref().unwrap_or(&Value::Null),
+                    ));
+                }
+                ensure_no_incomplete_tool_calls(tool_state_buffer)?;
                 if let Some(response) = event.response {
-                    emit_tool_calls_from_response(&response, &mut results, tool_state_buffer);
                     if let Some(text) = extract_reasoning_text_from_response(&response)
                         && let Some(text) = mark_final_thinking_emitted(tool_state_buffer, &text)
                     {
@@ -925,31 +957,138 @@ pub fn codex_parse_stream_chunk_with_state(
                     .lock()
                     .unwrap()
                     .values()
-                    .any(|s| s.started)
+                    .any(|state| state.completed)
                 {
                     FinishReason::ToolCalls
                 } else {
                     FinishReason::Stop
                 };
-                clear_thinking_state(tool_state_buffer);
+                clear_stream_state(tool_state_buffer);
                 results.push(StreamChunk::Done { finish_reason });
             }
-            "response.failed" => {
-                let message = event
-                    .response
-                    .as_ref()
-                    .and_then(|r| r.get("error"))
-                    .and_then(|e| e.get("message"))
+            "response.incomplete" => {
+                let response = event.response.unwrap_or(Value::Null);
+                let reason = response
+                    .get("incomplete_details")
+                    .and_then(|details| details.get("reason"))
                     .and_then(Value::as_str)
-                    .unwrap_or("Codex response failed");
-                clear_thinking_state(tool_state_buffer);
-                return Err(LLMError::ProviderError(message.to_string()));
+                    .unwrap_or("unknown");
+                tool_state_buffer.lock().unwrap().clear();
+                return Err(retryable_codex_stream_error(format!(
+                    "incomplete response returned, reason: {reason}"
+                )));
+            }
+            "response.failed" => {
+                let response = event.response.unwrap_or(Value::Null);
+                let error = response.get("error").unwrap_or(&Value::Null);
+                let provider_error =
+                    map_codex_response_failed(error, &response, event.request_id.as_deref(), true);
+                tool_state_buffer.lock().unwrap().clear();
+                return Err(provider_error.into());
             }
             _ => {}
         }
     }
 
     Ok(results)
+}
+
+/// Normalize a Codex/Responses API error `code`/`type` token for table lookup.
+fn normalize_error_token(token: &str) -> String {
+    token.trim().to_ascii_lowercase().replace(['-', ' '], "_")
+}
+
+/// Map a normalized Codex Responses API error `code`/`type` to a unified kind.
+///
+/// Mirrors Codex Responses API `response.failed` and HTTP bridge handlers.
+/// Kept provider-local in this stack; classifier deduplication is a separate refactor.
+fn codex_error_kind(code: &str) -> Option<ProviderErrorKind> {
+    match code {
+        // Upstream codex: is_server_overloaded_error
+        "server_is_overloaded" | "slow_down" => Some(ProviderErrorKind::ServerOverloaded),
+        // Upstream: rate_limit_exceeded (code). `rate_limit_error` is the common
+        // OpenAI `type` field — accepted on type-fallback only for HTTP bodies.
+        "rate_limit_exceeded" | "rate_limit_error" => Some(ProviderErrorKind::RateLimited),
+        // Upstream codex: context_length_exceeded → ContextWindowExceeded
+        "context_length_exceeded" => Some(ProviderErrorKind::ContextWindowExceeded),
+        // Upstream codex http 429 bridge: usage_limit_reached is a plan/account
+        // cap (UsageLimitReached), not a transient TPM rate limit — permanent.
+        // Also insufficient_quota / usage_not_included.
+        "usage_limit_reached" | "insufficient_quota" | "usage_not_included" => {
+            Some(ProviderErrorKind::QuotaExceeded)
+        }
+        // Upstream codex: cyber_policy / invalid_prompt / bio_policy → fatal request
+        "cyber_policy"
+        | "invalid_prompt"
+        | "bio_policy"
+        | "invalid_request"
+        | "invalid_request_error" => Some(ProviderErrorKind::InvalidRequest),
+        "authentication_error" | "invalid_api_key" | "unauthorized" => {
+            Some(ProviderErrorKind::Authentication)
+        }
+        _ => None,
+    }
+}
+
+/// Map Codex `response.failed` error objects into unified kinds.
+///
+/// Unknown structured codes stay retryable before semantic output
+/// (`unknown_transient: true` from the SSE path), matching upstream codex's
+/// catch-all `ApiError::Retryable` for unmapped response.failed codes.
+fn map_codex_response_failed(
+    error: &Value,
+    response: &Value,
+    explicit_request_id: Option<&str>,
+    unknown_transient: bool,
+) -> ProviderFailure {
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| "codex response failed".to_owned());
+    let code = error.get("code").and_then(Value::as_str).map(str::to_owned);
+    let error_type = error
+        .get("type")
+        .or_else(|| error.get("error_type"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let request_id = explicit_request_id.map(str::to_owned).or_else(|| {
+        error
+            .get("request_id")
+            .or_else(|| error.get("requestId"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    });
+    let retry_after_secs =
+        extract_retry_after_from_json(error).or_else(|| extract_retry_after_from_json(response));
+    let code_norm = code.as_deref().map(normalize_error_token);
+    let type_norm = error_type.as_deref().map(normalize_error_token);
+    let mapped = code_norm
+        .as_deref()
+        .and_then(codex_error_kind)
+        .or_else(|| type_norm.as_deref().and_then(codex_error_kind));
+
+    // Upstream: unmapped response.failed → Retryable. Known kinds own policy.
+    let kind = mapped.unwrap_or(if unknown_transient {
+        ProviderErrorKind::UnknownTransient
+    } else {
+        ProviderErrorKind::UnknownPermanent
+    });
+    // Structured payload hints are authoritative. Message parsing is only a fallback
+    // for rate_limit_exceeded envelopes without machine-readable delay metadata.
+    let retry_after_secs = if kind == ProviderErrorKind::RateLimited {
+        retry_after_secs.or_else(|| parse_retry_after_from_message(&message))
+    } else {
+        retry_after_secs
+    };
+
+    ProviderFailure::new(kind, message)
+        .with_code(code)
+        .with_error_type(error_type)
+        .with_request_id(request_id)
+        .with_retry_after_secs(retry_after_secs)
 }
 
 fn mark_streamed_thinking_emitted(
@@ -986,18 +1125,27 @@ fn mark_final_thinking_emitted(
     Some(text_to_emit)
 }
 
-fn clear_thinking_state(tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>) {
-    tool_state_buffer.lock().unwrap().remove(&usize::MAX);
+fn clear_stream_state(tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>) {
+    tool_state_buffer.lock().unwrap().clear();
 }
 
-fn handle_output_item_event(
+fn response_end_turn(event: &CodexSseEvent) -> Option<bool> {
+    event.end_turn.or_else(|| {
+        event
+            .response
+            .as_ref()
+            .and_then(|response| response.get("end_turn"))
+            .and_then(Value::as_bool)
+    })
+}
+
+fn handle_output_item_added(
     item: &Value,
     output_index: Option<usize>,
     results: &mut Vec<StreamChunk>,
     tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
 ) {
-    let item_type = item.get("type").and_then(Value::as_str).unwrap_or_default();
-    if item_type != "function_call" {
+    if item.get("type").and_then(Value::as_str) != Some("function_call") {
         return;
     }
 
@@ -1007,10 +1155,6 @@ fn handle_output_item_event(
         .and_then(Value::as_str)
         .map(str::to_string);
     let name = item.get("name").and_then(Value::as_str).map(str::to_string);
-    let arguments = item
-        .get("arguments")
-        .and_then(Value::as_str)
-        .map(str::to_string);
 
     let index = resolve_tool_index(output_index, tool_state_buffer);
     let mut buffer = tool_state_buffer.lock().unwrap();
@@ -1024,21 +1168,7 @@ fn handle_output_item_event(
     if let Some(name) = name {
         state.name = Some(name);
     }
-    if !state.started
-        && let (Some(id), Some(name)) = (state.id.clone(), state.name.clone())
-    {
-        state.started = true;
-        results.push(StreamChunk::ToolUseStart { index, id, name });
-    }
-
-    // `response.output_item.added` typically includes empty arguments; only complete when
-    // the backend provides non-empty JSON arguments (e.g. `response.output_item.done`).
-    if let Some(arguments) = arguments
-        && !arguments.trim().is_empty()
-    {
-        emit_arguments_delta(index, &arguments, state, results);
-        emit_tool_complete(index, state, results);
-    }
+    emit_tool_start(index, state, results);
 }
 
 fn handle_function_call_arguments_delta(
@@ -1051,12 +1181,10 @@ fn handle_function_call_arguments_delta(
     let index = resolve_tool_index_with_item(output_index, item_id, tool_state_buffer);
     let mut buffer = tool_state_buffer.lock().unwrap();
     let state = buffer.entry(index).or_default();
-    if !state.started
-        && let (Some(id), Some(name)) = (state.id.clone(), state.name.clone())
-    {
-        state.started = true;
-        results.push(StreamChunk::ToolUseStart { index, id, name });
+    if let Some(item_id) = item_id {
+        state.item_id = Some(item_id.to_string());
     }
+    emit_tool_start(index, state, results);
     state.arguments.push_str(delta);
     results.push(StreamChunk::ToolUseInputDelta {
         index,
@@ -1064,93 +1192,105 @@ fn handle_function_call_arguments_delta(
     });
 }
 
-fn handle_function_call_arguments_done(
+fn handle_output_item_done(
+    item: &Value,
     output_index: Option<usize>,
-    item_id: Option<&str>,
-    arguments: Option<&str>,
     results: &mut Vec<StreamChunk>,
     tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
-) {
-    let index = resolve_tool_index_with_item(output_index, item_id, tool_state_buffer);
-    let mut buffer = tool_state_buffer.lock().unwrap();
-    if let Some(state) = buffer.get_mut(&index) {
-        if !state.started
-            && let (Some(id), Some(name)) = (state.id.clone(), state.name.clone())
-        {
-            state.started = true;
-            results.push(StreamChunk::ToolUseStart { index, id, name });
-        }
-        if let Some(arguments) = arguments
-            && !arguments.trim().is_empty()
-        {
-            emit_arguments_delta(index, arguments, state, results);
-        }
-        emit_tool_complete(index, state, results);
+) -> Result<(), LLMError> {
+    if item.get("type").and_then(Value::as_str) != Some("function_call") {
+        return Ok(());
     }
-}
 
-fn emit_tool_calls_from_response(
-    response: &Value,
-    results: &mut Vec<StreamChunk>,
-    tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
-) {
-    let Some(items) = response.get("output").and_then(Value::as_array) else {
-        return;
+    let item_id = item.get("id").and_then(Value::as_str);
+    let index = resolve_tool_index_with_item(output_index, item_id, tool_state_buffer);
+    let call_id = item.get("call_id").and_then(Value::as_str);
+    let name = item.get("name").and_then(Value::as_str);
+    let arguments = item.get("arguments").and_then(Value::as_str);
+    let (Some(call_id), Some(name), Some(arguments)) = (call_id, name, arguments) else {
+        return Err(codex_stream_format_error(
+            "response.output_item.done contained an incomplete function call",
+            item,
+        ));
     };
 
-    for (idx, item) in items.iter().enumerate() {
-        let item_type = item.get("type").and_then(Value::as_str).unwrap_or_default();
-        if item_type != "function_call" {
-            continue;
-        }
+    let mut buffer = tool_state_buffer.lock().unwrap();
+    let state = buffer.entry(index).or_default();
+    if state.completed {
+        return Ok(());
+    }
+    if let Some(item_id) = item_id {
+        state.item_id = Some(item_id.to_string());
+    }
+    state.id = Some(call_id.to_string());
+    state.name = Some(name.to_string());
+    emit_tool_start(index, state, results);
+    emit_arguments_delta(index, arguments, state, results);
+    state.completed = true;
+    results.push(StreamChunk::ToolUseComplete {
+        index,
+        tool_call: ToolCall {
+            id: call_id.to_string(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: arguments.to_string(),
+            },
+        },
+    });
+    Ok(())
+}
 
-        let item_id = item.get("id").and_then(Value::as_str).map(str::to_string);
-        let id = item
-            .get("call_id")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let name = item.get("name").and_then(Value::as_str).map(str::to_string);
-        let arguments = item.get("arguments").and_then(Value::as_str).unwrap_or("");
-
-        let index = resolve_tool_index(Some(idx), tool_state_buffer);
-        let mut buffer = tool_state_buffer.lock().unwrap();
-        let state = buffer.entry(index).or_default();
-        if let Some(item_id) = item_id {
-            state.item_id = Some(item_id);
-        }
-        if let Some(id) = id {
-            state.id = Some(id);
-        }
-        if let Some(name) = name {
-            state.name = Some(name);
-        }
-        if !state.started
-            && let (Some(id), Some(name)) = (state.id.clone(), state.name.clone())
-        {
-            state.started = true;
-            results.push(StreamChunk::ToolUseStart { index, id, name });
-        }
-        if !arguments.is_empty() {
-            emit_arguments_delta(index, arguments, state, results);
-        }
-        emit_tool_complete(index, state, results);
+fn emit_tool_start(index: usize, state: &mut CodexToolUseState, results: &mut Vec<StreamChunk>) {
+    if !state.started
+        && let (Some(id), Some(name)) = (state.id.clone(), state.name.clone())
+    {
+        state.started = true;
+        results.push(StreamChunk::ToolUseStart { index, id, name });
     }
 }
 
-fn emit_tool_complete(index: usize, state: &CodexToolUseState, results: &mut Vec<StreamChunk>) {
-    if let (Some(id), Some(name)) = (state.id.clone(), state.name.clone()) {
-        results.push(StreamChunk::ToolUseComplete {
-            index,
-            tool_call: ToolCall {
-                id,
-                call_type: "function".to_string(),
-                function: FunctionCall {
-                    name,
-                    arguments: state.arguments.clone(),
-                },
-            },
-        });
+fn ensure_no_incomplete_tool_calls(
+    tool_state_buffer: &Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
+) -> Result<(), LLMError> {
+    let buffer = tool_state_buffer.lock().unwrap();
+    let incomplete = buffer
+        .iter()
+        .filter(|(index, state)| **index != usize::MAX && !state.completed)
+        .map(|(index, state)| {
+            state
+                .item_id
+                .as_deref()
+                .or(state.id.as_deref())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("index {index}"))
+        })
+        .collect::<Vec<_>>();
+    drop(buffer);
+    if incomplete.is_empty() {
+        Ok(())
+    } else {
+        tool_state_buffer.lock().unwrap().clear();
+        Err(retryable_codex_stream_error(format!(
+            "response.completed arrived before function call item(s) completed: {}",
+            incomplete.join(", ")
+        )))
     }
+}
+
+fn codex_stream_format_error(message: impl Into<String>, raw: &Value) -> LLMError {
+    LLMError::ResponseFormatError {
+        message: message.into(),
+        raw_response: raw.to_string(),
+    }
+}
+
+fn retryable_codex_stream_error(message: impl Into<String>) -> LLMError {
+    ProviderFailure::new(ProviderErrorKind::UnknownTransient, message).into()
+}
+
+pub fn codex_stream_closed_error() -> LLMError {
+    retryable_codex_stream_error("stream closed before response.completed")
 }
 
 fn emit_arguments_delta(
@@ -1338,12 +1478,16 @@ fn codex_effort_str(e: ReasoningEffort) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        CodexChatResponse, CodexToolUseState, chatgpt_account_id, codex_chat_body_json,
-        codex_chat_request, codex_parse_stream_chunk_with_state,
+        CodexChatResponse, CodexToolUseState, chatgpt_account_id, classify_codex_http_error,
+        codex_chat_body_json, codex_chat_request, codex_parse_chat_with_state,
+        codex_parse_stream_chunk_with_state,
     };
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-    use http::header::AUTHORIZATION;
-    use querymt::chat::{ChatMessage, ChatResponse, ChatRole, Content, FinishReason, StreamChunk};
+    use http::{Response, header::AUTHORIZATION};
+    use querymt::{
+        chat::{ChatMessage, ChatResponse, ChatRole, Content, FinishReason, StreamChunk},
+        error::{LLMError, ProviderErrorKind},
+    };
     use serde_json::Value;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -1754,6 +1898,305 @@ mod tests {
         assert_eq!(response.thinking().as_deref(), Some("why because details"));
     }
 
+    fn parse_failed_event(
+        payload: &str,
+    ) -> (LLMError, Arc<Mutex<HashMap<usize, CodexToolUseState>>>) {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::from([
+            (0, CodexToolUseState::default()),
+            (usize::MAX, CodexToolUseState::default()),
+        ])));
+        let chunk = format!("data: {payload}\n\n");
+        let error = codex_parse_stream_chunk_with_state(chunk.as_bytes(), &state)
+            .expect_err("response.failed should return an error");
+        (error, state)
+    }
+
+    #[test]
+    fn parse_chat_non_success_uses_live_classifier_guard() {
+        let state = Arc::new(Mutex::new(HashMap::new()));
+        let response = Response::builder()
+            .status(401)
+            .body(br#"{"error":{"message":"bad key","code":"invalid_api_key"}}"#.to_vec())
+            .unwrap();
+
+        let error = codex_parse_chat_with_state(response, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::Authentication
+                    && failure.message() == "bad key"
+        ));
+    }
+
+    #[test]
+    fn classify_http_error_maps_codex_envelope_and_headers() {
+        let response = Response::builder()
+            .status(503)
+            .header("retry-after", "3")
+            .header("x-request-id", "req-http")
+            .body(br#"{"error":{"message":"busy","code":"server_is_overloaded"}}"#.to_vec())
+            .unwrap();
+
+        let error = classify_codex_http_error(&response);
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.request_id(), Some("req-http"));
+                assert_eq!(failure.retry_after_secs(), Some(3));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_header_retry_hint_precedes_structured_body_hint() {
+        let response = Response::builder()
+            .status(429)
+            .header("retry-after", "30")
+            .body(
+                br#"{"error":{"message":"slow down","code":"rate_limit_exceeded","retry_after":"4s"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = classify_codex_http_error(&response);
+        assert_eq!(error.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn classify_http_unknown_error_uses_status_retryability() {
+        for (status, expected_retryable) in [(400, false), (429, true), (503, true)] {
+            let response = Response::builder()
+                .status(status)
+                .body(
+                    br#"{"error":{"message":"vendor failure","code":"vendor_specific"}}"#.to_vec(),
+                )
+                .unwrap();
+
+            let error = classify_codex_http_error(&response);
+            assert_eq!(error.is_retryable(), expected_retryable, "status={status}");
+        }
+    }
+
+    #[test]
+    fn classify_http_429_usage_limit_reached_is_permanent_quota() {
+        // Upstream api_bridge: 429 + error.type == usage_limit_reached →
+        // UsageLimitReached (not retryable). Must not look like RateLimited.
+        let response = Response::builder()
+            .status(429)
+            .header("retry-after", "60")
+            .body(
+                br#"{"error":{"message":"You have hit your usage limit.","type":"usage_limit_reached","resets_at":1710000000}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = classify_codex_http_error(&response);
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "You have hit your usage limit.");
+                assert_eq!(failure.kind(), ProviderErrorKind::QuotaExceeded);
+                assert_eq!(failure.error_type(), Some("usage_limit_reached"));
+                assert_eq!(failure.retry_after_secs(), Some(60));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+        assert!(!error.is_retryable());
+        assert!(!error.is_rate_limited());
+    }
+
+    #[test]
+    fn classify_http_429_rate_limit_exceeded_stays_retryable() {
+        let response = Response::builder()
+            .status(429)
+            .body(
+                br#"{"error":{"message":"Rate limit reached. Please try again in 5s.","code":"rate_limit_exceeded"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = classify_codex_http_error(&response);
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+                assert_eq!(failure.retry_after_secs(), Some(5));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+        assert!(error.is_retryable());
+        assert!(error.is_rate_limited());
+    }
+
+    #[test]
+    fn codex_response_failed_maps_server_is_overloaded_to_unified_kind() {
+        let (error, state) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"id":"resp_086d39fcd1bd4726016a6b3477038081919b8f301082107795","object":"response","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}"#,
+        );
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(
+                    failure.message(),
+                    "Our servers are currently overloaded. Please try again later."
+                );
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert!(error.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+        assert!(state.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn codex_response_failed_maps_slow_down_to_server_overloaded() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"code":"slow_down","message":"slow down"}}}"#,
+        );
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::ServerOverloaded
+        ));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn codex_response_failed_maps_invalid_request_codes() {
+        for code in [
+            "invalid_request",
+            "invalid_prompt",
+            "bio_policy",
+            "cyber_policy",
+        ] {
+            let payload = format!(
+                r#"{{"type":"response.failed","response":{{"error":{{"message":"bad","code":"{code}"}}}}}}"#
+            );
+            let (error, _) = parse_failed_event(&payload);
+            assert!(
+                matches!(error, LLMError::ProviderResponseError(ref failure)
+                    if failure.message() == "bad"
+                        && failure.kind() == ProviderErrorKind::InvalidRequest),
+                "code={code}, got {error}"
+            );
+            assert!(!error.is_retryable());
+        }
+    }
+
+    #[test]
+    fn codex_response_failed_maps_context_and_quota() {
+        let (ctx_err, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"message":"too long","code":"context_length_exceeded"}}}"#,
+        );
+        assert!(matches!(
+            ctx_err,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::ContextWindowExceeded
+        ));
+        assert!(!ctx_err.is_retryable());
+
+        let (quota_err, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"message":"no credits","code":"insufficient_quota"}}}"#,
+        );
+        assert!(matches!(
+            quota_err,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::QuotaExceeded
+        ));
+        assert!(!quota_err.is_retryable());
+    }
+
+    #[test]
+    fn codex_response_failed_maps_rate_limit_with_message_delay() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"message":"Rate limit reached for gpt-5.1. Please try again in 11.054s.","type":"rate_limit_error","code":"rate_limit_exceeded"}}}"#,
+        );
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert!(failure.message().contains("Rate limit reached"));
+                assert_eq!(failure.retry_after_secs(), Some(12));
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected rate limit, got {other}"),
+        }
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn codex_response_failed_preserves_event_request_id_on_overload() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","requestId":"req_event","response":{"id":"resp_not_request_id","error":{"message":"busy","code":"server_is_overloaded","retry_after":"2s"}}}"#,
+        );
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.request_id(), Some("req_event"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn codex_response_failed_falls_back_from_unknown_code_to_known_type() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"message":"slow down","code":"vendor_specific","type":"rate_limit_error"}}}"#,
+        );
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::RateLimited
+        ));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn codex_response_failed_maps_type_only_permanent_error() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"message":"bad key","type":"authentication_error"}}}"#,
+        );
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.message() == "bad key"
+                    && failure.kind() == ProviderErrorKind::Authentication
+        ));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn codex_response_failed_unknown_code_is_retryable_before_output() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"error":{"message":"Service unavailable; try again later","code":"unrecognized"}}}"#,
+        );
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.code(), Some("unrecognized"));
+                assert!(failure.is_retryable());
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn codex_response_failed_without_error_is_retryable_before_output() {
+        let (error, _) = parse_failed_event(
+            r#"{"type":"response.failed","response":{"id":"resp_not_request_id"}}"#,
+        );
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "codex response failed");
+                assert_eq!(failure.request_id(), None);
+                assert!(failure.is_retryable());
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+        assert!(error.is_retryable());
+    }
+
     #[test]
     fn codex_streaming_emits_thinking_deltas() {
         let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
@@ -2036,6 +2479,185 @@ data: {"type":"response.completed","response":{"output":[{"type":"reasoning","su
             StreamChunk::Done { finish_reason } => assert_eq!(*finish_reason, FinishReason::Stop),
             other => panic!("expected done chunk, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn codex_streaming_completes_tool_only_from_output_item_done() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let added = br#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":""}}
+
+"#;
+        let arguments_done = br#"data: {"type":"response.function_call_arguments.done","output_index":0,"item_id":"fc_1","arguments":"{\"command\":\"pwd\"}"}
+
+"#;
+        let item_done = br#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":"{\"command\":\"pwd\"}"}}
+
+"#;
+        let completed = br#"data: {"type":"response.completed","response":{"id":"resp_1"}}
+
+"#;
+
+        let added_events = codex_parse_stream_chunk_with_state(added, &state).unwrap();
+        assert_eq!(added_events.len(), 1);
+        assert!(matches!(
+            &added_events[0],
+            StreamChunk::ToolUseStart { index: 0, id, name }
+                if id == "call_1" && name == "shell"
+        ));
+        assert!(
+            codex_parse_stream_chunk_with_state(arguments_done, &state)
+                .unwrap()
+                .is_empty()
+        );
+
+        let item_events = codex_parse_stream_chunk_with_state(item_done, &state).unwrap();
+        assert_eq!(item_events.len(), 2);
+        assert!(matches!(
+            &item_events[0],
+            StreamChunk::ToolUseInputDelta { index: 0, partial_json }
+                if partial_json == r#"{"command":"pwd"}"#
+        ));
+        assert!(matches!(
+            &item_events[1],
+            StreamChunk::ToolUseComplete { index: 0, tool_call }
+                if tool_call.id == "call_1"
+                    && tool_call.function.name == "shell"
+                    && tool_call.function.arguments == r#"{"command":"pwd"}"#
+        ));
+
+        let completed_events = codex_parse_stream_chunk_with_state(completed, &state).unwrap();
+        assert!(matches!(
+            completed_events.as_slice(),
+            [StreamChunk::Done {
+                finish_reason: FinishReason::ToolCalls
+            }]
+        ));
+        assert!(state.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn codex_streaming_ignores_done_framing() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let added_and_done = br#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":""}}
+
+data: [DONE]
+
+"#;
+
+        let events = codex_parse_stream_chunk_with_state(added_and_done, &state).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], StreamChunk::ToolUseStart { .. }));
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, StreamChunk::Done { .. }))
+        );
+    }
+
+    #[test]
+    fn codex_streaming_rejects_completed_with_unfinished_tool() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let chunk = br#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":""}}
+
+data: {"type":"response.completed","response":{"id":"resp_1"}}
+
+"#;
+
+        let error = codex_parse_stream_chunk_with_state(chunk, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.message().contains("fc_1")
+        ));
+        assert!(state.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn codex_streaming_rejects_unresolved_argument_delta() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let chunk = br#"data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"command\":"}
+
+data: {"type":"response.completed","response":{"id":"resp_1"}}
+
+"#;
+
+        let error = codex_parse_stream_chunk_with_state(chunk, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.message().contains("fc_1")
+        ));
+        assert!(state.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn codex_streaming_rejects_output_item_done_without_item() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let chunk = br#"data: {"type":"response.output_item.done","output_index":0}
+
+"#;
+
+        let error = codex_parse_stream_chunk_with_state(chunk, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ResponseFormatError { ref message, .. }
+                if message.contains("missing item payload")
+        ));
+    }
+
+    #[test]
+    fn codex_streaming_rejects_incomplete_function_call_item() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let chunk = br#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell"}}
+
+"#;
+
+        let error = codex_parse_stream_chunk_with_state(chunk, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ResponseFormatError { ref message, ref raw_response }
+                if message.contains("incomplete function call")
+                    && raw_response.contains("call_1")
+        ));
+    }
+
+    #[test]
+    fn codex_streaming_rejects_unsupported_end_turn_false() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::new()));
+        let chunk =
+            br#"data: {"type":"response.completed","response":{"id":"resp_1","end_turn":false}}
+
+"#;
+
+        let error = codex_parse_stream_chunk_with_state(chunk, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ResponseFormatError { ref message, .. }
+                if message.contains("end_turn=false")
+        ));
+        assert!(state.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn codex_streaming_maps_response_incomplete_to_retryable_error() {
+        let state = Arc::new(Mutex::new(HashMap::<usize, CodexToolUseState>::from([
+            (0, CodexToolUseState::default()),
+            (usize::MAX, CodexToolUseState::default()),
+        ])));
+        let chunk = br#"data: {"type":"response.incomplete","response":{"id":"resp_1","incomplete_details":{"reason":"max_output_tokens"}}}
+
+"#;
+
+        let error = codex_parse_stream_chunk_with_state(chunk, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.message().contains("max_output_tokens")
+        ));
+        assert!(state.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/providers/codex/src/lib.rs
+++ b/crates/providers/codex/src/lib.rs
@@ -137,6 +137,10 @@ impl api::CodexProviderConfig for Codex {
 }
 
 impl HTTPChatProvider for Codex {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        api::classify_codex_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -170,11 +174,27 @@ impl HTTPChatProvider for Codex {
 #[derive(Default)]
 struct CodexStreamParser {
     tool_states: Arc<Mutex<HashMap<usize, api::CodexToolUseState>>>,
+    completed: bool,
 }
 
 impl ChatStreamParser for CodexStreamParser {
     fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, LLMError> {
-        api::codex_parse_stream_chunk_with_state(chunk, &self.tool_states)
+        let chunks = api::codex_parse_stream_chunk_with_state(chunk, &self.tool_states)?;
+        if chunks
+            .iter()
+            .any(|chunk| matches!(chunk, StreamChunk::Done { .. }))
+        {
+            self.completed = true;
+        }
+        Ok(chunks)
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamChunk>, LLMError> {
+        if self.completed {
+            Ok(Vec::new())
+        } else {
+            Err(api::codex_stream_closed_error())
+        }
     }
 }
 
@@ -288,5 +308,40 @@ mod extism_exports {
         config = Codex,
         factory = CodexFactory,
         name   = "codex",
+    }
+}
+
+#[cfg(test)]
+mod stream_parser_tests {
+    use super::{ChatStreamParser, CodexStreamParser, LLMError, StreamChunk};
+    use querymt::error::ProviderErrorKind;
+
+    #[test]
+    fn premature_eof_before_response_completed_is_retryable() {
+        let mut parser = CodexStreamParser::default();
+        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+        assert!(events.is_empty());
+
+        let error = parser.finish().unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.message() == "stream closed before response.completed"
+        ));
+    }
+
+    #[test]
+    fn eof_after_response_completed_is_clean() {
+        let mut parser = CodexStreamParser::default();
+        let events = parser
+            .parse_chunk(
+                br#"data: {"type":"response.completed","response":{"id":"resp_1"}}
+
+"#,
+            )
+            .unwrap();
+        assert!(matches!(events.as_slice(), [StreamChunk::Done { .. }]));
+        assert!(parser.finish().unwrap().is_empty());
     }
 }

--- a/crates/providers/deepseek/src/lib.rs
+++ b/crates/providers/deepseek/src/lib.rs
@@ -1,8 +1,8 @@
 use http::{Request, Response};
 use qmt_openai::api::{
-    OpenAIProviderConfig, OpenAIToolUseState, openai_chat_request, openai_embed_request,
-    openai_list_models_request, openai_parse_chat, openai_parse_embed, openai_parse_list_models,
-    parse_openai_sse_chunk, url_schema,
+    OpenAIProviderConfig, OpenAIToolUseState, classify_openai_http_error, openai_chat_request,
+    openai_embed_request, openai_list_models_request, openai_parse_chat, openai_parse_embed,
+    openai_parse_list_models, parse_openai_sse_chunk, url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -148,6 +148,10 @@ impl OpenAIProviderConfig for Deepseek {
 }
 
 impl HTTPChatProvider for Deepseek {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],

--- a/crates/providers/google/Cargo.toml
+++ b/crates/providers/google/Cargo.toml
@@ -25,4 +25,5 @@ schemars = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
 http = { workspace = true }
+log = { workspace = true }
 extism-pdk = { workspace = true, optional = true }

--- a/crates/providers/google/src/lib.rs
+++ b/crates/providers/google/src/lib.rs
@@ -41,18 +41,20 @@
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use http::{Method, Request, Response, header::CONTENT_TYPE};
+use log::trace;
 use querymt::{
     FunctionCall, HTTPLLMProvider, ToolCall, Usage,
     auth::ApiKeyResolver,
     chat::{
-        ChatMessage, ChatResponse, ChatRole, Content, FinishReason, ReasoningEffort, StreamChunk,
+        ChatMessage, ChatResponse, ChatRole, Content, FinishReason, ReasoningEffort,
         StructuredOutputFormat, Tool, ToolChoice,
         http::{ChatStreamParser, HTTPChatProvider},
     },
     completion::{CompletionRequest, CompletionResponse, http::HTTPCompletionProvider},
     embedding::http::HTTPEmbeddingProvider,
-    error::LLMError,
-    handle_http_error,
+    error::{
+        LLMError, ProviderErrorKind, ProviderFailure, classify_status_only, parse_retry_after,
+    },
     plugin::HTTPLLMProviderFactory,
 };
 use schemars::{JsonSchema, schema_for};
@@ -715,6 +717,10 @@ impl Google {
 }
 
 impl HTTPChatProvider for Google {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_google_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -913,7 +919,10 @@ impl HTTPChatProvider for Google {
     }
 
     fn parse_chat(&self, resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-        handle_http_error!(resp);
+        debug_assert!(
+            resp.status().is_success(),
+            "parse_chat is success-only; adapter must classify non-success first"
+        );
 
         let json_resp: Result<GoogleChatResponse, serde_json::Error> =
             serde_json::from_slice(resp.body());
@@ -1054,7 +1063,6 @@ impl ChatStreamParser for GoogleStreamParser {
 fn extract_complete_json_objects(
     buffer: &str,
 ) -> Result<(Vec<querymt::chat::StreamChunk>, usize), LLMError> {
-    let _result_chunks: Vec<querymt::chat::StreamChunk> = Vec::new();
     let mut bytes_consumed = 0;
 
     // Strip leading whitespace and array opening bracket
@@ -1091,23 +1099,34 @@ fn try_parse_json_objects(
     let mut result_chunks = Vec::new();
     let mut total_consumed = initial_offset;
 
-    // Try to parse JSON objects using StreamDeserializer
-    let mut deserializer = Deserializer::from_str(text).into_iter::<GoogleChatResponse>();
+    // Value first so mid-stream `{"error":{...}}` objects are classified, not
+    // left as incomplete GoogleChatResponse parse failures.
+    let mut deserializer = Deserializer::from_str(text).into_iter::<Value>();
 
     while let Some(result) = deserializer.next() {
         match result {
-            Ok(response) => {
-                // Track how many bytes we consumed
+            Ok(value) => {
                 let byte_offset = deserializer.byte_offset();
                 total_consumed = initial_offset + byte_offset;
 
-                // Extract StreamChunks from this response
-                let chunks = extract_google_stream_chunks(response);
-                result_chunks.extend(chunks);
+                if value.get("error").is_some() {
+                    return Err(map_google_error_value(&value, None, None, true).into());
+                }
+
+                match serde_json::from_value::<GoogleChatResponse>(value.clone()) {
+                    Ok(response) => {
+                        let chunks = extract_google_stream_chunks(response);
+                        result_chunks.extend(chunks);
+                    }
+                    Err(error) => {
+                        // Complete JSON that is neither a chat chunk nor an error —
+                        // skip it rather than stalling the stream.
+                        trace!("skipping unknown Google stream object: {error}; value={value}");
+                    }
+                }
             }
             Err(_e) => {
-                // Parse error - likely incomplete JSON
-                // Don't consume any more bytes - leave the rest in the buffer
+                // Incomplete JSON — leave the rest in the buffer.
                 break;
             }
         }
@@ -1126,6 +1145,145 @@ fn try_parse_json_objects(
     Ok((result_chunks, total_consumed))
 }
 
+/// Map Google Generative Language API error `status` strings to kinds.
+fn google_error_kind(status: &str) -> Option<ProviderErrorKind> {
+    match status {
+        "RESOURCE_EXHAUSTED" | "RESOURCE_EXHAUSTED_ERROR" => Some(ProviderErrorKind::RateLimited),
+        "UNAUTHENTICATED" | "PERMISSION_DENIED" => Some(ProviderErrorKind::Authentication),
+        "INVALID_ARGUMENT" | "FAILED_PRECONDITION" | "NOT_FOUND" | "OUT_OF_RANGE" => {
+            Some(ProviderErrorKind::InvalidRequest)
+        }
+        "UNAVAILABLE" => Some(ProviderErrorKind::ServerOverloaded),
+        "DEADLINE_EXCEEDED" | "INTERNAL" | "UNKNOWN" => Some(ProviderErrorKind::UnknownTransient),
+        _ => None,
+    }
+}
+
+fn parse_google_duration(value: &str) -> Option<std::time::Duration> {
+    let value = value.trim().strip_suffix('s')?;
+    let seconds = value.parse::<f64>().ok()?;
+    if !seconds.is_finite() || seconds < 0.0 {
+        return None;
+    }
+    Some(std::time::Duration::from_secs_f64(seconds))
+}
+
+fn google_retry_after_secs(error: Option<&Value>, header_retry_after: Option<u64>) -> Option<u64> {
+    header_retry_after.or_else(|| {
+        error?
+            .get("details")?
+            .as_array()?
+            .iter()
+            .find_map(|detail| {
+                let is_retry_info = detail
+                    .get("@type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|ty| {
+                        ty.ends_with("google.rpc.RetryInfo") || ty.ends_with("RetryInfo")
+                    });
+                is_retry_info
+                    .then(|| detail.get("retryDelay"))
+                    .flatten()
+                    .and_then(|delay| match delay {
+                        Value::String(value) => parse_google_duration(value),
+                        Value::Object(value) => {
+                            let seconds = value.get("seconds").and_then(|v| {
+                                v.as_u64()
+                                    .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
+                            })?;
+                            let nanos = value.get("nanos").and_then(Value::as_u64).unwrap_or(0);
+                            Some(std::time::Duration::new(
+                                seconds,
+                                nanos.min(999_999_999) as u32,
+                            ))
+                        }
+                        _ => None,
+                    })
+                    .map(|duration| duration.as_secs() + u64::from(duration.subsec_nanos() > 0))
+            })
+    })
+}
+
+fn map_google_error_value(
+    envelope: &Value,
+    header_retry_after: Option<u64>,
+    request_id: Option<&str>,
+    unknown_transient: bool,
+) -> ProviderFailure {
+    let error = envelope.get("error");
+    let retry_after_secs = google_retry_after_secs(error, header_retry_after);
+    let message = error
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            error
+                .and_then(|e| e.get("status"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "google request failed".to_owned());
+
+    let status_str = error
+        .and_then(|e| e.get("status"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let code = error.and_then(|e| e.get("code")).and_then(|c| {
+        c.as_i64()
+            .map(|n| n.to_string())
+            .or_else(|| c.as_str().map(str::to_owned))
+    });
+
+    let message_lower = message.to_ascii_lowercase();
+    let structured_kind = status_str.as_deref().and_then(google_error_kind);
+    let kind = if let Some(kind) = structured_kind {
+        kind
+    } else if message_lower.contains("token")
+        && (message_lower.contains("limit")
+            || message_lower.contains("context")
+            || message_lower.contains("too long")
+            || message_lower.contains("maximum"))
+    {
+        ProviderErrorKind::ContextWindowExceeded
+    } else if unknown_transient {
+        ProviderErrorKind::UnknownTransient
+    } else {
+        ProviderErrorKind::UnknownPermanent
+    };
+
+    ProviderFailure::new(kind, message)
+        .with_error_type(status_str)
+        .with_code(code)
+        .with_request_id(request_id.map(str::to_owned))
+        .with_retry_after_secs(retry_after_secs)
+}
+
+fn classify_google_http_error(response: &Response<Vec<u8>>) -> LLMError {
+    let status = response.status().as_u16();
+    let retry_after_secs = parse_retry_after(response.headers());
+    let request_id = response
+        .headers()
+        .get("x-request-id")
+        .or_else(|| response.headers().get("request-id"))
+        .and_then(|value| value.to_str().ok());
+    let status_guess_transient = matches!(status, 408 | 425 | 429 | 500..=599);
+
+    if let Ok(envelope) = serde_json::from_slice::<Value>(response.body())
+        && envelope.get("error").is_some()
+    {
+        return map_google_error_value(
+            &envelope,
+            retry_after_secs,
+            request_id,
+            status_guess_transient,
+        )
+        .into();
+    }
+
+    classify_status_only(status, response.headers(), response.body())
+}
+
 /// Extract StreamChunks from a GoogleChatResponse
 fn extract_google_stream_chunks(response: GoogleChatResponse) -> Vec<querymt::chat::StreamChunk> {
     let mut chunks = Vec::new();
@@ -1133,13 +1291,13 @@ fn extract_google_stream_chunks(response: GoogleChatResponse) -> Vec<querymt::ch
     if let Some(candidate) = response.candidates.first() {
         // Extract text from parts
         for (index, part) in candidate.content.parts.iter().enumerate() {
-            if let Some(text) = &part.text {
-                if !text.is_empty() {
-                    if part.thought {
-                        chunks.push(querymt::chat::StreamChunk::Thinking(text.clone()));
-                    } else {
-                        chunks.push(querymt::chat::StreamChunk::Text(text.clone()));
-                    }
+            if let Some(text) = &part.text
+                && !text.is_empty()
+            {
+                if part.thought {
+                    chunks.push(querymt::chat::StreamChunk::Thinking(text.clone()));
+                } else {
+                    chunks.push(querymt::chat::StreamChunk::Text(text.clone()));
                 }
             }
 
@@ -1334,5 +1492,254 @@ mod extism_exports {
         config = Google,
         factory = GoogleFactory,
         name   = "google",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use querymt::chat::http::HTTPChatProvider;
+
+    #[test]
+    fn classify_http_resource_exhausted_is_rate_limited() {
+        let google = test_google();
+        let response = Response::builder()
+            .status(429)
+            .header(http::header::RETRY_AFTER, "15")
+            .header("x-request-id", "req-google-http")
+            .body(
+                br#"{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = google.classify_chat_error(&response);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after_secs(), Some(15));
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+                assert_eq!(failure.error_type(), Some("RESOURCE_EXHAUSTED"));
+                assert_eq!(failure.code(), Some("429"));
+                assert_eq!(failure.request_id(), Some("req-google-http"));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    fn test_google() -> Google {
+        Google {
+            api_key: "test".into(),
+            model: "gemini-2.0-flash".into(),
+            max_tokens: None,
+            temperature: None,
+            system: None,
+            timeout_seconds: None,
+            stream: Some(true),
+            top_p: None,
+            top_k: None,
+            json_schema: None,
+            tools: None,
+            tool_choice: None,
+            reasoning_effort: None,
+            thinking_budget: None,
+            cached_content: None,
+            key_resolver: None,
+        }
+    }
+
+    #[test]
+    fn classify_http_google_retry_info_is_preserved() {
+        let response = Response::builder()
+            .status(429)
+            .body(
+                br#"{"error":{"code":429,"message":"Quota metric exhausted","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"1.5s"}]}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after_secs(), Some(2));
+    }
+
+    #[test]
+    fn classify_http_quota_metric_message_remains_rate_limited() {
+        let response = Response::builder()
+            .status(429)
+            .header(http::header::RETRY_AFTER, "9")
+            .body(
+                br#"{"error":{"code":429,"message":"Quota exceeded for quota metric 'GenerateContent requests per minute'","status":"RESOURCE_EXHAUSTED"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after_secs(), Some(9));
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_common_current_quota_message_is_rate_limited() {
+        let response = Response::builder()
+            .status(429)
+            .body(
+                br#"{"error":{"code":429,"message":"You exceeded your current quota","status":"RESOURCE_EXHAUSTED"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_structured_status_beats_quota_prose() {
+        let response = Response::builder()
+            .status(400)
+            .body(
+                br#"{"error":{"code":400,"message":"Quota wording from a gateway","status":"INVALID_ARGUMENT"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::InvalidRequest
+        ));
+    }
+
+    #[test]
+    fn generic_token_input_prose_is_not_context_window_overflow() {
+        let error = map_google_error_value(
+            &serde_json::json!({
+                "error": {
+                    "message": "Input token accounting service is unavailable",
+                    "status": "VENDOR_FAILURE"
+                }
+            }),
+            None,
+            None,
+            false,
+        );
+
+        assert_eq!(error.kind(), ProviderErrorKind::UnknownPermanent);
+    }
+
+    #[test]
+    fn classify_http_missing_message_uses_safe_fallback() {
+        let response = Response::builder()
+            .status(500)
+            .body(br#"{"error":{"details":[{"private":"secret"}]}}"#.to_vec())
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.message() == "google request failed"
+                    && !failure.message().contains("private")
+        ));
+    }
+
+    #[test]
+    fn classify_http_unauthenticated_is_permanent() {
+        let response = Response::builder()
+            .status(401)
+            .body(
+                br#"{"error":{"code":401,"message":"API key not valid","status":"UNAUTHENTICATED"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(!error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::Authentication);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_unavailable_is_overloaded() {
+        let response = Response::builder()
+            .status(503)
+            .body(
+                br#"{"error":{"code":503,"message":"The service is currently unavailable","status":"UNAVAILABLE"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_invalid_argument_is_permanent() {
+        let response = Response::builder()
+            .status(400)
+            .body(
+                br#"{"error":{"code":400,"message":"Invalid value at 'contents'","status":"INVALID_ARGUMENT"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_google_http_error(&response);
+        assert!(!error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::InvalidRequest);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn stream_parser_classifies_mid_stream_error_object() {
+        let google = test_google();
+        let mut parser = google.chat_stream_parser().unwrap();
+        let chunk = br#"{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}"#;
+        let err = parser
+            .parse_chunk(chunk)
+            .expect_err("mid-stream error object must classify");
+        assert!(err.is_retryable());
+        match &err {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn stream_parser_keeps_unknown_google_server_error_retryable() {
+        let google = test_google();
+        let mut parser = google.chat_stream_parser().unwrap();
+        let chunk =
+            br#"{"error":{"code":500,"message":"Internal server error","status":"INTERNAL"}}"#;
+        let error = parser
+            .parse_chunk(chunk)
+            .expect_err("mid-stream server error must classify");
+
+        assert!(error.is_retryable());
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
     }
 }

--- a/crates/providers/groq/src/lib.rs
+++ b/crates/providers/groq/src/lib.rs
@@ -3,9 +3,9 @@ use http::{
     header::{AUTHORIZATION, CONTENT_TYPE},
 };
 use qmt_openai::api::{
-    OpenAIProviderConfig, OpenAIToolUseState, openai_chat_request, openai_embed_request,
-    openai_list_models_request, openai_parse_chat, openai_parse_embed, openai_parse_list_models,
-    parse_openai_sse_chunk, url_schema,
+    OpenAIProviderConfig, OpenAIToolUseState, classify_openai_http_error, openai_chat_request,
+    openai_embed_request, openai_list_models_request, openai_parse_chat, openai_parse_embed,
+    openai_parse_list_models, parse_openai_sse_chunk, url_schema,
 };
 use querymt::{
     HTTPLLMProvider, ToolCall,
@@ -157,6 +157,10 @@ impl OpenAIProviderConfig for Groq {
 }
 
 impl HTTPChatProvider for Groq {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -247,7 +251,7 @@ impl HTTPCompletionProvider for Groq {
             Ok(completion_response) => Ok(CompletionResponse {
                 text: completion_response.choices[0].message.content.clone(), // FIXME
             }),
-            Err(e) => Err(LLMError::JsonError(e)),
+            Err(e) => Err(LLMError::from(e)),
         }
     }
 }

--- a/crates/providers/kimi-code/src/lib.rs
+++ b/crates/providers/kimi-code/src/lib.rs
@@ -4,8 +4,8 @@ use http::{
 };
 use kimi_auth::kimi_cli_oauth_config;
 use qmt_openai::api::{
-    OpenAIProviderConfig, OpenAIToolUseState, openai_chat_request, openai_parse_chat,
-    parse_openai_sse_chunk, url_schema,
+    OpenAIProviderConfig, OpenAIToolUseState, classify_openai_http_error, openai_chat_request,
+    openai_parse_chat, parse_openai_sse_chunk, url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -142,6 +142,10 @@ impl OpenAIProviderConfig for KimiCode {
 }
 
 impl HTTPChatProvider for KimiCode {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn supports_streaming(&self) -> bool {
         self.stream.unwrap_or(false)
     }

--- a/crates/providers/mistral/src/lib.rs
+++ b/crates/providers/mistral/src/lib.rs
@@ -3,8 +3,9 @@ use http::{
     header::{AUTHORIZATION, CONTENT_TYPE},
 };
 use qmt_openai::api::{
-    OpenAIProviderConfig, openai_chat_request, openai_embed_request, openai_list_models_request,
-    openai_parse_chat, openai_parse_embed, openai_parse_list_models, url_schema,
+    OpenAIProviderConfig, classify_openai_http_error, openai_chat_request, openai_embed_request,
+    openai_list_models_request, openai_parse_chat, openai_parse_embed, openai_parse_list_models,
+    url_schema,
 };
 use querymt::{
     HTTPLLMProvider, ToolCall,
@@ -148,6 +149,10 @@ impl OpenAIProviderConfig for Mistral {
 }
 
 impl HTTPChatProvider for Mistral {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -210,7 +215,7 @@ impl HTTPCompletionProvider for Mistral {
             Ok(completion_response) => Ok(CompletionResponse {
                 text: completion_response.choices[0].message.content.clone(), // FIXME
             }),
-            Err(e) => Err(LLMError::JsonError(e)),
+            Err(e) => Err(LLMError::from(e)),
         }
     }
 }

--- a/crates/providers/moonshot/src/lib.rs
+++ b/crates/providers/moonshot/src/lib.rs
@@ -1,7 +1,7 @@
 use http::{Request, Response};
 use qmt_openai::api::{
-    OpenAIProviderConfig, openai_chat_request, openai_list_models_request, openai_parse_chat,
-    openai_parse_list_models, url_schema,
+    OpenAIProviderConfig, classify_openai_http_error, openai_chat_request,
+    openai_list_models_request, openai_parse_chat, openai_parse_list_models, url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -128,6 +128,10 @@ impl OpenAIProviderConfig for MoonshotAI {
 }
 
 impl HTTPChatProvider for MoonshotAI {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],

--- a/crates/providers/mrs/src/factory.rs
+++ b/crates/providers/mrs/src/factory.rs
@@ -47,8 +47,7 @@ impl LLMProviderFactory for MistralRSFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn querymt::LLMProvider>, LLMError> {
-        let cfg: MistralRSConfig = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("mistral.rs config error: {}", e)))?;
+        let cfg: MistralRSConfig = serde_json::from_str(cfg)?;
 
         let provider = MistralRS::new_with_cache(cfg, &self.model_cache)?;
         Ok(Box::new(provider))

--- a/crates/providers/mrs/src/tests.rs
+++ b/crates/providers/mrs/src/tests.rs
@@ -2,13 +2,12 @@ use querymt::LLMProvider;
 use querymt::chat::{ChatMessageBuilder, ChatRole};
 use querymt::completion::CompletionRequest;
 use querymt::error::LLMError;
-use querymt::plugin::LLMProviderFactory;
 
 use crate::config::MistralRSConfig;
-use crate::factory::MistralRSFactory;
+use crate::factory::create_factory;
 
 fn get_provider() -> Box<dyn LLMProvider> {
-    let factory = MistralRSFactory {};
+    let factory = create_factory();
     let cfg = MistralRSConfig {
         model: "microsoft/Phi-3.5-mini-instruct".to_string(),
         model_kind: None,
@@ -46,6 +45,17 @@ fn get_provider() -> Box<dyn LLMProvider> {
 
     let json_cfg = serde_json::to_string(&cfg).unwrap();
     factory.from_config(&json_cfg).unwrap()
+}
+
+#[test]
+fn malformed_config_is_non_retryable_json_error() {
+    let error = create_factory()
+        .from_config("{")
+        .err()
+        .expect("config should be rejected");
+
+    assert!(!error.is_retryable());
+    assert!(matches!(error, LLMError::JsonError(_)));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/providers/ollama/src/lib.rs
+++ b/crates/providers/ollama/src/lib.rs
@@ -12,8 +12,10 @@ use querymt::{
     },
     completion::{CompletionRequest, CompletionResponse, http::HTTPCompletionProvider},
     embedding::http::HTTPEmbeddingProvider,
-    error::LLMError,
-    get_env_var, handle_http_error,
+    error::{
+        LLMError, ProviderErrorKind, ProviderFailure, classify_status_only, parse_retry_after,
+    },
+    get_env_var,
     plugin::HTTPLLMProviderFactory,
 };
 use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema, schema_for};
@@ -439,6 +441,10 @@ impl Ollama {
 }
 
 impl HTTPChatProvider for Ollama {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_ollama_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -573,7 +579,10 @@ impl HTTPChatProvider for Ollama {
     }
 
     fn parse_chat(&self, resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-        handle_http_error!(resp);
+        debug_assert!(
+            resp.status().is_success(),
+            "parse_chat is success-only; adapter must classify non-success first"
+        );
 
         let json_resp: OllamaResponse = serde_json::from_slice(resp.body())?;
         Ok(Box::new(json_resp))
@@ -881,4 +890,160 @@ mod tests {
             .expect("list_models_request should succeed");
         assert!(req.headers().get("authorization").is_none());
     }
+
+    #[test]
+    fn classify_http_invalid_api_key_is_authentication() {
+        let response = Response::builder()
+            .status(401)
+            .body(br#"{"error":"invalid api key"}"#.to_vec())
+            .unwrap();
+        let error = classify_ollama_http_error(&response);
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::Authentication
+        ));
+    }
+
+    #[test]
+    fn classify_http_try_again_text_does_not_override_request_status() {
+        let response = Response::builder()
+            .status(400)
+            .body(br#"{"error":"invalid request, please try again"}"#.to_vec())
+            .unwrap();
+        let error = classify_ollama_http_error(&response);
+        assert!(!error.is_retryable());
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::InvalidRequest
+        ));
+    }
+
+    #[test]
+    fn classify_http_model_not_found_is_permanent() {
+        let response = Response::builder()
+            .status(404)
+            .body(br#"{"error":"model 'nope' not found"}"#.to_vec())
+            .unwrap();
+        let error = classify_ollama_http_error(&response);
+        assert!(!error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert!(failure.message().contains("not found"));
+                assert_eq!(failure.kind(), ProviderErrorKind::InvalidRequest);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_context_length_is_permanent() {
+        let response = Response::builder()
+            .status(500)
+            .body(br#"{"error":"the input length exceeds the context length"}"#.to_vec())
+            .unwrap();
+        let error = classify_ollama_http_error(&response);
+        assert!(!error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ContextWindowExceeded);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_runner_busy_uses_transient_server_status() {
+        let response = Response::builder()
+            .status(500)
+            .body(br#"{"error":"server busy, try again"}"#.to_vec())
+            .unwrap();
+        let error = classify_ollama_http_error(&response);
+        assert!(error.is_retryable());
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_plain_text_falls_back_to_status() {
+        let response = Response::builder()
+            .status(429)
+            .header(http::header::RETRY_AFTER, "7")
+            .body(b"too many requests".to_vec())
+            .unwrap();
+        let error = classify_ollama_http_error(&response);
+        assert!(error.is_retryable());
+        assert_eq!(error.retry_after_secs(), Some(7));
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+}
+
+/// Classify an Ollama non-success chat response from its JSON (or plain) body.
+///
+/// Ollama typically returns `{"error":"..."}` (string) rather than a typed code table.
+/// Message heuristics map the common permanent/transient cases; otherwise status-only.
+fn classify_ollama_http_error(response: &Response<Vec<u8>>) -> LLMError {
+    let status = response.status().as_u16();
+    let retry_after_secs = parse_retry_after(response.headers());
+    let message = serde_json::from_slice::<Value>(response.body())
+        .ok()
+        .and_then(|value| {
+            value.get("error").and_then(|error| {
+                error.as_str().map(str::to_owned).or_else(|| {
+                    error
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                })
+            })
+        })
+        .filter(|message| !message.is_empty());
+
+    let status_error = classify_status_only(status, response.headers(), response.body());
+    let Some(message) = message else {
+        return status_error;
+    };
+    let LLMError::ProviderResponseError(status_failure) = status_error else {
+        return status_error;
+    };
+
+    let lower = message.to_ascii_lowercase();
+    let kind = if status == 401
+        || status == 403
+        || lower.contains("unauthorized")
+        || lower.contains("authentication")
+        || lower.contains("api key")
+        || lower.contains("access denied")
+    {
+        ProviderErrorKind::Authentication
+    } else if (lower.contains("context") && (lower.contains("length") || lower.contains("window")))
+        || lower.contains("exceeds the context")
+        || (lower.contains("token") && lower.contains("limit"))
+        || lower.contains("too many tokens")
+    {
+        ProviderErrorKind::ContextWindowExceeded
+    } else if !status_failure.is_retryable()
+        && (lower.contains("not found")
+            || lower.contains("does not support")
+            || lower.contains("unknown model")
+            || lower.contains("pull model"))
+    {
+        ProviderErrorKind::InvalidRequest
+    } else {
+        status_failure.kind()
+    };
+
+    ProviderFailure::new(kind, message)
+        .with_retry_after_secs(retry_after_secs.or(status_failure.retry_after_secs()))
+        .into()
 }

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -9,7 +9,10 @@ use querymt::{
         ChatMessage, ChatResponse, ChatRole, Content, FinishReason, ReasoningEffort, StreamChunk,
         StructuredOutputFormat, Tool, ToolChoice,
     },
-    error::LLMError,
+    error::{
+        LLMError, ProviderErrorKind, ProviderFailure, extract_retry_after_from_json,
+        parse_retry_after, parse_retry_after_from_message,
+    },
     handle_http_error,
     stt::{SttRequest, SttResponse},
     tts::{TtsRequest, TtsResponse},
@@ -885,10 +888,10 @@ pub fn openai_parse_chat<C: OpenAIProviderConfig>(
     _cfg: &C,
     response: Response<Vec<u8>>,
 ) -> Result<Box<dyn ChatResponse>, LLMError> {
-    // If we got a non-200 response, let's get the error details
-    handle_http_error!(response);
+    if !response.status().is_success() {
+        return Err(classify_openai_http_error(&response));
+    }
 
-    // Parse the successful response
     let json_resp: Result<OpenAIChatResponse, serde_json::Error> =
         serde_json::from_slice(response.body());
 
@@ -1197,7 +1200,151 @@ pub struct OpenAIToolUseState {
     pub started: bool,
 }
 
-/// Parse an OpenAI SSE chunk into StreamChunk events
+/// Normalize a vendor error `code`/`type` token for table lookup.
+fn normalize_error_token(token: &str) -> String {
+    token.trim().to_ascii_lowercase().replace(['-', ' '], "_")
+}
+
+/// Map a normalized OpenAI-compatible error `code`/`type` to a unified kind.
+///
+/// Dialect table for chat-completions / OpenAI-compatible providers. Kept in
+/// this crate on purpose — core must not know vendor code strings. Codex has
+/// its own responses-api table.
+fn openai_error_kind(code: &str) -> Option<ProviderErrorKind> {
+    match code {
+        // Chat Completions + common openai-compatible dialects.
+        "server_is_overloaded" | "slow_down" | "overloaded_error" | "overloaded" => {
+            Some(ProviderErrorKind::ServerOverloaded)
+        }
+        "rate_limit_exceeded"
+        | "rate_limit_error"
+        | "rate_limited"
+        | "rate_limit"
+        | "too_many_requests" => Some(ProviderErrorKind::RateLimited),
+        "context_length_exceeded" | "context_length_error" | "context_length" => {
+            Some(ProviderErrorKind::ContextWindowExceeded)
+        }
+        // usage_limit_reached: account/plan cap (chatgpt-style); same permanent
+        // bucket as insufficient_quota so openai-compatible paths (incl. xai chat)
+        // do not retry plan caps as TPM rate limits.
+        "insufficient_quota" | "usage_not_included" | "usage_limit_reached" => {
+            Some(ProviderErrorKind::QuotaExceeded)
+        }
+        "invalid_request"
+        | "invalid_request_error"
+        | "invalid_prompt"
+        | "bio_policy"
+        | "cyber_policy" => Some(ProviderErrorKind::InvalidRequest),
+        "authentication_error" | "invalid_api_key" | "unauthorized" => {
+            Some(ProviderErrorKind::Authentication)
+        }
+        _ => None,
+    }
+}
+
+/// Map an OpenAI-compatible SSE/HTTP `{ "error": ... }` envelope into unified
+/// [`ProviderFailure`] kinds. Vendor `code`/`type` dialect stays here.
+fn map_openai_error_envelope(
+    error: &Value,
+    envelope: &Value,
+    explicit_request_id: Option<&str>,
+    unknown_transient: bool,
+) -> ProviderFailure {
+    let message = error
+        .as_str()
+        .map(str::to_owned)
+        .or_else(|| {
+            error
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .map(|message| message.trim().to_owned())
+        .filter(|message| !message.is_empty())
+        .unwrap_or_else(|| "openai response failed".to_owned());
+    let code = error.get("code").and_then(|value| {
+        value
+            .as_str()
+            .map(str::to_owned)
+            .or_else(|| value.as_i64().map(|number| number.to_string()))
+    });
+    let error_type = error
+        .get("type")
+        .or_else(|| error.get("error_type"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let request_id = explicit_request_id.map(str::to_owned).or_else(|| {
+        error
+            .get("request_id")
+            .or_else(|| error.get("requestId"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    });
+    let retry_after_secs =
+        extract_retry_after_from_json(error).or_else(|| extract_retry_after_from_json(envelope));
+    let code_norm = code.as_deref().map(normalize_error_token);
+    let type_norm = error_type.as_deref().map(normalize_error_token);
+    let mapped = code_norm
+        .as_deref()
+        .and_then(openai_error_kind)
+        .or_else(|| type_norm.as_deref().and_then(openai_error_kind));
+
+    // Unclassified server-side codes are transient; anything else unknown
+    // defers to the caller's status-based guess.
+    let server_side = matches!(
+        code_norm.as_deref(),
+        Some("server_error" | "internal_server_error")
+    ) || matches!(
+        type_norm.as_deref(),
+        Some("server_error" | "internal_server_error")
+    );
+    let kind = mapped.unwrap_or(if unknown_transient || server_side {
+        ProviderErrorKind::UnknownTransient
+    } else {
+        ProviderErrorKind::UnknownPermanent
+    });
+    // Structured payload hints are authoritative. Message parsing is only a fallback
+    // for rate-limit envelopes that omit machine-readable delay metadata.
+    let retry_after_secs = if kind == ProviderErrorKind::RateLimited {
+        retry_after_secs.or_else(|| parse_retry_after_from_message(&message))
+    } else {
+        retry_after_secs
+    };
+
+    ProviderFailure::new(kind, message)
+        .with_code(code)
+        .with_error_type(error_type)
+        .with_request_id(request_id)
+        .with_retry_after_secs(retry_after_secs)
+}
+
+/// Classify an OpenAI-compatible HTTP error body.
+pub fn classify_openai_http_error(response: &Response<Vec<u8>>) -> LLMError {
+    let status = response.status().as_u16();
+    let retry_after_secs = parse_retry_after(response.headers());
+    let request_id = response
+        .headers()
+        .get("x-request-id")
+        .or_else(|| response.headers().get("request-id"))
+        .and_then(|value| value.to_str().ok());
+    let envelope = serde_json::from_slice::<Value>(response.body()).ok();
+    if let Some(envelope) = envelope.as_ref()
+        && let Some(error) = envelope.get("error")
+    {
+        let mapped = map_openai_error_envelope(
+            error,
+            envelope,
+            request_id,
+            matches!(status, 429 | 500..=599),
+        );
+        let retry_after_secs = retry_after_secs.or(mapped.retry_after_secs());
+        return mapped.with_retry_after_secs(retry_after_secs).into();
+    }
+
+    // No vendor envelope: classify from the status alone.
+    querymt::error::classify_status_only(status, response.headers(), response.body())
+}
+
 pub fn parse_openai_sse_chunk(
     chunk: &[u8],
     tool_states: &mut HashMap<usize, OpenAIToolUseState>,
@@ -1255,9 +1402,23 @@ pub fn parse_openai_sse_chunk(
             continue;
         }
 
-        // Parse JSON chunk
-        let mut stream_chunk: OpenAIStreamChunk =
+        // Parse once so provider error envelopes and normal stream chunks share the same payload.
+        let envelope: Value =
             serde_json::from_str(data).map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to parse OpenAI stream chunk: {}", e),
+                raw_response: data.to_string(),
+            })?;
+        if let Some(error) = envelope.get("error") {
+            let explicit_request_id = envelope
+                .get("request_id")
+                .or_else(|| envelope.get("requestId"))
+                .and_then(Value::as_str);
+            return Err(
+                map_openai_error_envelope(error, &envelope, explicit_request_id, false).into(),
+            );
+        }
+        let mut stream_chunk: OpenAIStreamChunk =
+            serde_json::from_value(envelope).map_err(|e| LLMError::ResponseFormatError {
                 message: format!("Failed to parse OpenAI stream chunk: {}", e),
                 raw_response: data.to_string(),
             })?;
@@ -1375,14 +1536,15 @@ mod tests {
     use http::Response;
     use querymt::{
         chat::{ChatResponse, StreamChunk},
-        error::LLMError,
+        error::{LLMError, ProviderErrorKind},
     };
     use std::collections::HashMap;
 
     use super::{
-        MultipartForm, OpenAIChatResponse, OpenAIToolUseState, openai_parse_list_models,
-        parse_openai_sse_chunk,
+        MultipartForm, OpenAIChatResponse, OpenAIToolUseState, classify_openai_http_error,
+        openai_parse_chat, openai_parse_list_models, parse_openai_sse_chunk,
     };
+    use crate::OpenAI;
 
     #[test]
     fn multipart_form_encodes_text_and_file_parts() {
@@ -1672,6 +1834,282 @@ data: {"choices":[{"index":0,"delta":{"reasoning_content":"continued"}}]}
             StreamChunk::Thinking(text) => assert_eq!(text, "continued"),
             other => panic!("expected thinking chunk, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_chat_non_success_uses_live_classifier_guard() {
+        let response = Response::builder()
+            .status(401)
+            .body(br#"{"error":{"message":"bad key","code":"invalid_api_key"}}"#.to_vec())
+            .unwrap();
+
+        let config: OpenAI = serde_json::from_value(serde_json::json!({
+            "model": "gpt-test"
+        }))
+        .unwrap();
+        let error = openai_parse_chat(&config, response).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::Authentication
+                    && failure.message() == "bad key"
+        ));
+    }
+
+    #[test]
+    fn classify_http_499_uses_central_cancellation_mapping() {
+        let response = Response::builder().status(499).body(Vec::new()).unwrap();
+        assert!(matches!(
+            classify_openai_http_error(&response),
+            LLMError::Cancelled
+        ));
+    }
+
+    #[test]
+    fn classify_http_error_uses_provider_mapping_and_headers() {
+        let response = Response::builder()
+            .status(429)
+            .header("retry-after", "4")
+            .header("x-request-id", "req-http")
+            .body(
+                br#"{"error":{"message":"slow down","type":"rate_limit_error","code":"rate_limit_exceeded"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = classify_openai_http_error(&response);
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "slow down");
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+                assert_eq!(failure.request_id(), Some("req-http"));
+                assert_eq!(failure.retry_after_secs(), Some(4));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_header_retry_hint_precedes_structured_body_hint() {
+        let response = Response::builder()
+            .status(429)
+            .header("retry-after", "30")
+            .body(
+                br#"{"error":{"message":"slow down","code":"rate_limit_exceeded","retry_after":"4s"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = classify_openai_http_error(&response);
+        assert_eq!(error.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn classify_http_unknown_error_uses_status_retryability() {
+        for (status, expected_retryable) in [(400, false), (429, true), (503, true)] {
+            let response = Response::builder()
+                .status(status)
+                .body(
+                    br#"{"error":{"message":"vendor failure","code":"vendor_specific"}}"#.to_vec(),
+                )
+                .unwrap();
+
+            let error = classify_openai_http_error(&response);
+            assert_eq!(error.is_retryable(), expected_retryable, "status={status}");
+        }
+    }
+
+    #[test]
+    fn parse_sse_unknown_error_without_server_evidence_is_permanent() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"vendor failure","code":"vendor_specific"}}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownPermanent
+        ));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_returns_classified_error() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"busy","code":"server_error"}}
+
+"#;
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+        ));
+    }
+
+    #[test]
+    fn parse_sse_chunk_maps_server_error_as_retryable_catch_all() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"request_id":"req_123","retry_after":"3s","error":{"message":"backend unavailable","code":"server_error","type":"server_error"}}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states)
+            .expect_err("error envelope should return an error");
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "backend unavailable");
+                assert_eq!(failure.code(), Some("server_error"));
+                assert_eq!(failure.error_type(), Some("server_error"));
+                assert_eq!(failure.request_id(), Some("req_123"));
+                assert_eq!(failure.retry_after_secs(), Some(3));
+                assert!(failure.is_retryable());
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_maps_invalid_request_as_permanent() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"unsupported field","code":"invalid_request","type":"invalid_request_error"}}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states)
+            .expect_err("error envelope should return an error");
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.message() == "unsupported field"
+                    && failure.kind() == ProviderErrorKind::InvalidRequest
+        ));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_maps_rate_limit_error() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"Rate limit reached for requests. Please try again in 2s.","type":"rate_limit_error","code":"rate_limit_exceeded"}}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states)
+            .expect_err("rate limit envelope should return an error");
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert!(failure.message().contains("Rate limit"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected rate limit, got {other}"),
+        }
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_maps_insufficient_quota() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"You exceeded your current quota","type":"insufficient_quota","code":"insufficient_quota"}}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states)
+            .expect_err("quota envelope should return an error");
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert!(failure.message().contains("quota"));
+                assert_eq!(failure.kind(), ProviderErrorKind::QuotaExceeded);
+                assert_eq!(failure.code(), Some("insufficient_quota"));
+            }
+            other => panic!("expected QuotaExceeded, got {other}"),
+        }
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn classify_http_429_usage_limit_reached_is_permanent_quota() {
+        // Same permanent bucket as codex: plan/account caps must not retry.
+        let response = Response::builder()
+            .status(429)
+            .header(http::header::RETRY_AFTER, "60")
+            .body(
+                br#"{"error":{"message":"You have hit your usage limit.","type":"usage_limit_reached"}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+        let error = classify_openai_http_error(&response);
+        assert!(!error.is_retryable());
+        assert!(!error.is_rate_limited());
+        assert_eq!(error.retry_after_secs(), Some(60));
+        match &error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::QuotaExceeded);
+                assert_eq!(failure.error_type(), Some("usage_limit_reached"));
+            }
+            other => panic!("expected QuotaExceeded, got {other}"),
+        }
+    }
+
+    #[test]
+    fn parse_sse_chunk_maps_overloaded_type_to_server_overloaded() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"busy","type":"overloaded_error"}}
+
+"#;
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::ServerOverloaded
+        ));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_falls_back_from_unknown_code_to_known_type() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"slow down","code":"vendor_specific","type":"rate_limit_error"}}
+
+"#;
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::RateLimited
+        ));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_maps_type_only_permanent_error() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"too long","type":"context_length_error"}}
+
+"#;
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::ContextWindowExceeded
+        ));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_chunk_preserves_response_format_error_for_invalid_normal_shape() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"choices":"not-an-array"}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states)
+            .expect_err("invalid normal chunk should return an error");
+        assert!(matches!(error, LLMError::ResponseFormatError { .. }));
     }
 
     #[test]

--- a/crates/providers/openai/src/lib.rs
+++ b/crates/providers/openai/src/lib.rs
@@ -179,6 +179,10 @@ impl api::OpenAIProviderConfig for OpenAI {
 }
 
 impl HTTPChatProvider for OpenAI {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        api::classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -302,7 +306,10 @@ impl HTTPLLMProviderFactory for OpenAIFactory {
 #[cfg(test)]
 mod tests {
     use super::OpenAI;
-    use querymt::chat::{StreamChunk, http::HTTPChatProvider};
+    use querymt::{
+        chat::{StreamChunk, http::HTTPChatProvider},
+        error::LLMError,
+    };
     use serde_json::Value;
 
     #[test]
@@ -335,6 +342,22 @@ mod tests {
             .expect("stream request should build");
         let body: Value = serde_json::from_slice(req.body()).expect("body should be valid json");
         assert_eq!(body.get("stream"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn stream_parser_returns_classified_error() {
+        let cfg = serde_json::json!({
+            "api_key": "test-key",
+            "model": "gpt-4o-mini"
+        });
+        let provider: OpenAI = serde_json::from_value(cfg).unwrap();
+        let mut parser = provider.chat_stream_parser().unwrap();
+        let chunk = br#"data: {"error":{"message":"busy","code":"server_error"}}
+
+"#;
+
+        let error = parser.parse_chunk(chunk).unwrap_err();
+        assert!(matches!(error, LLMError::ProviderResponseError(_)));
     }
 
     #[test]

--- a/crates/providers/openrouter/src/lib.rs
+++ b/crates/providers/openrouter/src/lib.rs
@@ -1,7 +1,8 @@
 use http::{Method, Request, Response, header::CONTENT_TYPE};
 use qmt_openai::api::{
-    OpenAIProviderConfig, OpenAIToolUseState, openai_chat_request, openai_embed_request,
-    openai_parse_chat, openai_parse_embed, parse_openai_sse_chunk, url_schema,
+    OpenAIProviderConfig, OpenAIToolUseState, classify_openai_http_error, openai_chat_request,
+    openai_embed_request, openai_parse_chat, openai_parse_embed, parse_openai_sse_chunk,
+    url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -114,6 +115,10 @@ impl OpenAIProviderConfig for OpenRouter {
 }
 
 impl HTTPChatProvider for OpenRouter {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -237,8 +242,7 @@ impl HTTPLLMProviderFactory for OpenRouterFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn HTTPLLMProvider>, LLMError> {
-        let provider: OpenRouter = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("OpenRouter config error: {}", e)))?;
+        let provider: OpenRouter = serde_json::from_str(cfg)?;
 
         // 2) Done—our OpenAI::send/chat/etc methods will lazily build the Client
         Ok(Box::new(provider))
@@ -270,8 +274,9 @@ mod extism_exports {
 
 #[cfg(test)]
 mod tests {
-    use super::OpenRouter;
+    use super::{OpenRouter, OpenRouterFactory};
     use querymt::chat::{StreamChunk, http::HTTPChatProvider};
+    use querymt::{error::LLMError, plugin::HTTPLLMProviderFactory};
     use serde_json::Value;
 
     fn test_provider() -> OpenRouter {
@@ -280,6 +285,17 @@ mod tests {
             "model": "openai/gpt-4o-mini"
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn malformed_config_is_non_retryable_json_error() {
+        let error = OpenRouterFactory
+            .from_config("{")
+            .err()
+            .expect("config should be rejected");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(error, LLMError::JsonError(_)));
     }
 
     #[test]

--- a/crates/providers/xai/src/lib.rs
+++ b/crates/providers/xai/src/lib.rs
@@ -4,13 +4,14 @@ use http::{
     header::{AUTHORIZATION, CONTENT_TYPE},
 };
 use qmt_codex::api::{
-    CodexToolUseState, codex_parse_chat_with_state, codex_parse_stream_chunk_with_state,
+    CodexToolUseState, classify_codex_http_error, codex_parse_chat_with_state,
+    codex_parse_stream_chunk_with_state,
 };
 use qmt_openai::{
     AuthType,
     api::{
-        OpenAIProviderConfig, openai_chat_request, openai_embed_request,
-        openai_list_models_request, openai_parse_chat, openai_parse_embed,
+        OpenAIProviderConfig, classify_openai_http_error, openai_chat_request,
+        openai_embed_request, openai_list_models_request, openai_parse_chat, openai_parse_embed,
         openai_parse_list_models, parse_openai_sse_chunk, url_schema,
     },
 };
@@ -35,7 +36,6 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use url::Url;
-
 const XAI_ADDITIONAL_LIST_MODELS: &[&str] = &["grok-composer-2.5-fast", "grok-4.5"];
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Serialize)]
@@ -176,6 +176,14 @@ impl OpenAIProviderConfig for Xai {
 }
 
 impl HTTPChatProvider for Xai {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        if self.should_use_responses_api() {
+            classify_codex_http_error(response)
+        } else {
+            classify_openai_http_error(response)
+        }
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -332,13 +340,14 @@ impl HTTPCompletionProvider for Xai {
             Ok(completion_response) => Ok(CompletionResponse {
                 text: completion_response.choices[0].message.content.clone(), // FIXME
             }),
-            Err(e) => Err(LLMError::JsonError(e)),
+            Err(e) => Err(LLMError::from(e)),
         }
     }
 }
 
 struct XaiStreamParser {
     use_responses_api: bool,
+    responses_completed: bool,
     codex_tool_state: Arc<Mutex<HashMap<usize, CodexToolUseState>>>,
     openai_tool_state: HashMap<usize, qmt_openai::api::OpenAIToolUseState>,
 }
@@ -347,6 +356,7 @@ impl XaiStreamParser {
     fn new(use_responses_api: bool) -> Self {
         Self {
             use_responses_api,
+            responses_completed: false,
             codex_tool_state: Arc::new(Mutex::new(HashMap::new())),
             openai_tool_state: HashMap::new(),
         }
@@ -356,9 +366,24 @@ impl XaiStreamParser {
 impl ChatStreamParser for XaiStreamParser {
     fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, LLMError> {
         if self.use_responses_api {
-            codex_parse_stream_chunk_with_state(chunk, &self.codex_tool_state)
+            let chunks = codex_parse_stream_chunk_with_state(chunk, &self.codex_tool_state)?;
+            if chunks
+                .iter()
+                .any(|chunk| matches!(chunk, StreamChunk::Done { .. }))
+            {
+                self.responses_completed = true;
+            }
+            Ok(chunks)
         } else {
             parse_openai_sse_chunk(chunk, &mut self.openai_tool_state)
+        }
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamChunk>, LLMError> {
+        if !self.use_responses_api || self.responses_completed {
+            Ok(Vec::new())
+        } else {
+            Err(qmt_codex::api::codex_stream_closed_error())
         }
     }
 }
@@ -1001,6 +1026,63 @@ mod tests {
         let body: Value = serde_json::from_slice(req.body()).expect("body should be JSON");
 
         assert_eq!(body["stream"], Value::Bool(true));
+    }
+
+    #[test]
+    fn responses_stream_eof_before_response_completed_is_retryable() {
+        let mut parser = XaiStreamParser::new(true);
+        assert!(parser.parse_chunk(b"data: [DONE]\n\n").unwrap().is_empty());
+
+        let error = parser
+            .finish()
+            .expect_err("responses EOF before response.completed must fail");
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == querymt::error::ProviderErrorKind::UnknownTransient
+                    && failure.message() == "stream closed before response.completed"
+        ));
+    }
+
+    #[test]
+    fn responses_stream_response_completed_finishes_cleanly() {
+        let mut parser = XaiStreamParser::new(true);
+        let chunks = parser
+            .parse_chunk(
+                br#"data: {"type":"response.completed","response":{"id":"resp_1"}}
+
+"#,
+            )
+            .unwrap();
+        assert!(matches!(chunks.as_slice(), [StreamChunk::Done { .. }]));
+        assert!(parser.finish().unwrap().is_empty());
+    }
+
+    #[test]
+    fn openai_stream_finish_behavior_is_unchanged() {
+        let mut parser = XaiStreamParser::new(false);
+        assert!(parser.finish().unwrap().is_empty());
+    }
+
+    #[test]
+    fn stream_parser_returns_classified_codex_error() {
+        let mut xai = test_xai("xai-key");
+        xai.conversation_id = Some("conversation-id".to_string());
+        let mut parser = xai.chat_stream_parser().unwrap();
+        let chunk = br#"data: {"type":"response.failed","response":{"error":{"message":"busy","code":"server_is_overloaded"}}}
+
+"#;
+
+        let error = parser.parse_chunk(chunk).unwrap_err();
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(
+                    failure.kind(),
+                    querymt::error::ProviderErrorKind::ServerOverloaded
+                );
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
     }
 
     #[test]

--- a/crates/providers/zai/src/lib.rs
+++ b/crates/providers/zai/src/lib.rs
@@ -1,8 +1,8 @@
 use http::{Request, Response};
 use qmt_openai::api::{
-    OpenAIProviderConfig, OpenAIToolUseState, openai_chat_request, openai_embed_request,
-    openai_list_models_request, openai_parse_chat, openai_parse_embed, openai_parse_list_models,
-    parse_openai_sse_chunk, url_schema,
+    OpenAIProviderConfig, OpenAIToolUseState, classify_openai_http_error, openai_chat_request,
+    openai_embed_request, openai_list_models_request, openai_parse_chat, openai_parse_embed,
+    openai_parse_list_models, parse_openai_sse_chunk, url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -135,6 +135,10 @@ impl OpenAIProviderConfig for Zai {
 }
 
 impl HTTPChatProvider for Zai {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_openai_http_error(response)
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],

--- a/crates/querymt-extism-macros/src/lib.rs
+++ b/crates/querymt-extism-macros/src/lib.rs
@@ -207,13 +207,13 @@ macro_rules! impl_extism_http_plugin {
             Ok(s)
         }
 
-        // Validate the config inside WASM
+        // Validate the config inside WASM while preserving typed errors for the host.
         #[plugin_fn]
-        pub fn from_config(cfg: Json<$Config>) -> FnResult<Json<$Config>> {
-            // Try to deserialize into the config type
-            let native_cfg: $Config = cfg.0;
-
-            Ok(Json(native_cfg))
+        pub fn from_config(Json(cfg): Json<Value>) -> FnResult<Json<Value>> {
+            serde_json::from_value::<$Config>(cfg.clone())
+                .map_err(querymt::error::LLMError::from)
+                .map_err(llm_err_to_pdk)?;
+            Ok(Json(cfg))
         }
 
         // list models (new request/parse split)
@@ -268,6 +268,15 @@ macro_rules! impl_extism_http_plugin {
                 .chat_stream_request(&input.messages, input.tools.as_deref())
                 .map_err(llm_err_to_pdk)?;
             Ok(Json(querymt::plugin::extism_impl::SerializableHttpRequest { req }))
+        }
+
+        #[plugin_fn]
+        pub fn classify_chat_error(
+            Json(input): Json<querymt::plugin::extism_impl::ExtismChatParseRequest<$Config>>,
+        ) -> FnResult<Json<querymt::plugin::extism_impl::PluginError>> {
+            // Returning the payload keeps this optional export compatible with older hosts.
+            let error = input.cfg.classify_chat_error(&input.resp.resp);
+            Ok(Json(PluginError::from_llm_error(&error)))
         }
 
         #[plugin_fn]

--- a/crates/querymt/examples/google_embedding_example.rs
+++ b/crates/querymt/examples/google_embedding_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector = llm.embed(vec!["Hello world!".to_string()]).await?;
 
     // Print embedding statistics and data
-    println!("Data: {:?}", &vector);
+    println!("Data: {:?}", vector);
 
     Ok(())
 }

--- a/crates/querymt/examples/openai_embedding_example.rs
+++ b/crates/querymt/examples/openai_embedding_example.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector = llm.embed(vec!["Hello world!".to_string()]).await?;
 
     // Print embedding statistics and data
-    println!("Data: {:?}", &vector);
+    println!("Data: {:?}", vector);
 
     Ok(())
 }

--- a/crates/querymt/src/adapters.rs
+++ b/crates/querymt/src/adapters.rs
@@ -4,7 +4,7 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
-    outbound::{call_outbound, call_outbound_stream},
+    outbound::{OutboundStreamResult, call_outbound, call_outbound_raw, call_outbound_stream_raw},
     stt, tts,
 };
 use async_trait::async_trait;
@@ -42,12 +42,12 @@ impl LLMProviderFromHTTP {
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         self.ensure_credential_fresh().await?;
 
-        let req = self
-            .inner
-            .chat_request(messages, tools)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let req = self.inner.chat_request(messages, tools)?;
 
-        let resp = call_outbound(req).await?;
+        let resp = call_outbound_raw(req).await?;
+        if !resp.status().is_success() {
+            return Err(self.inner.classify_chat_error_async(&resp).await);
+        }
 
         self.inner.parse_chat(resp)
     }
@@ -89,17 +89,16 @@ impl ChatProvider for LLMProviderFromHTTP {
 
         self.ensure_credential_fresh().await?;
 
-        let req = self
-            .inner
-            .chat_stream_request(messages, tools)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let req = self.inner.chat_stream_request(messages, tools)?;
 
-        let stream = call_outbound_stream(req).await?;
-        let mut parser = self
-            .inner
-            .chat_stream_parser()
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))?;
+        let stream = match call_outbound_stream_raw(req).await? {
+            OutboundStreamResult::Failure { response } => {
+                return Err(self.inner.classify_chat_error_async(&response).await);
+            }
+            OutboundStreamResult::Success { stream } => stream,
+        };
 
+        let mut parser = self.inner.chat_stream_parser()?;
         let s = stream
             .map(move |res: reqwest::Result<bytes::Bytes>| res.map_err(LLMError::from))
             .chain(futures::stream::iter([
@@ -145,7 +144,9 @@ impl ChatProvider for LLMProviderFromHTTP {
                             *done = true;
                             match parser.finish() {
                                 Ok(mut tail) => chunks.append(&mut tail),
-                                Err(e) => return futures::future::ready(Some(Err(e))),
+                                Err(e) => {
+                                    return futures::future::ready(Some(Err(e)));
+                                }
                             }
                         }
 
@@ -176,12 +177,9 @@ impl EmbeddingProvider for LLMProviderFromHTTP {
     async fn embed(&self, inputs: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.embed_request(&inputs)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_embed(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        // call_outbound already classifies non-success statuses.
+        let resp = call_outbound(req).await?;
+        self.inner.parse_embed(resp)
     }
 }
 
@@ -194,12 +192,8 @@ impl CompletionProvider for LLMProviderFromHTTP {
     async fn complete(&self, req_obj: &CompletionRequest) -> Result<CompletionResponse, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.complete_request(req_obj)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_complete(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        let resp = call_outbound(req).await?;
+        self.inner.parse_complete(resp)
     }
 }
 
@@ -224,12 +218,8 @@ impl LLMProvider for LLMProviderFromHTTP {
     async fn transcribe(&self, req_obj: &stt::SttRequest) -> Result<stt::SttResponse, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.stt_request(req_obj)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_stt(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        let resp = call_outbound(req).await?;
+        self.inner.parse_stt(resp)
     }
 
     #[cfg_attr(
@@ -239,223 +229,11 @@ impl LLMProvider for LLMProviderFromHTTP {
     async fn speech(&self, req_obj: &tts::TtsRequest) -> Result<tts::TtsResponse, LLMError> {
         self.ensure_credential_fresh().await?;
         let req = self.inner.tts_request(req_obj)?;
-        let resp = call_outbound(req)
-            .await
-            .map_err(|e| LLMError::HttpError(format!("{:#}", e)))?;
-        self.inner
-            .parse_tts(resp)
-            .map_err(|e| LLMError::ProviderError(format!("{:#}", e)))
+        let resp = call_outbound(req).await?;
+        self.inner.parse_tts(resp)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::auth::{ApiKeyResolver, static_key};
-    use crate::chat::http::{ChatStreamParser, HTTPChatProvider};
-    use crate::completion::http::HTTPCompletionProvider;
-    use crate::embedding::http::HTTPEmbeddingProvider;
-    use http::{Request, Response};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct DummyHttpProvider {
-        resolver: Option<Arc<dyn ApiKeyResolver>>,
-    }
-
-    #[derive(Debug)]
-    struct CountingResolver {
-        resolves: AtomicUsize,
-    }
-
-    impl CountingResolver {
-        fn new() -> Self {
-            Self {
-                resolves: AtomicUsize::new(0),
-            }
-        }
-
-        fn resolve_count(&self) -> usize {
-            self.resolves.load(Ordering::SeqCst)
-        }
-    }
-
-    impl ApiKeyResolver for CountingResolver {
-        fn resolve(&self) -> Pin<Box<dyn Future<Output = Result<(), LLMError>> + Send + '_>> {
-            self.resolves.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(()) })
-        }
-
-        fn current(&self) -> String {
-            if self.resolve_count() > 0 {
-                "resolved-token".to_string()
-            } else {
-                "stale-token".to_string()
-            }
-        }
-    }
-
-    struct ResolveAwareHttpProvider {
-        resolver: Arc<dyn ApiKeyResolver>,
-    }
-
-    impl HTTPChatProvider for DummyHttpProvider {
-        fn chat_request(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: Option<&[Tool]>,
-        ) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn supports_streaming(&self) -> bool {
-            false
-        }
-
-        fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPCompletionProvider for DummyHttpProvider {
-        fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPEmbeddingProvider for DummyHttpProvider {
-        fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPLLMProvider for DummyHttpProvider {
-        fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
-            self.resolver.as_ref()
-        }
-
-        fn set_key_resolver(&mut self, resolver: Arc<dyn ApiKeyResolver>) {
-            self.resolver = Some(resolver);
-        }
-    }
-
-    impl HTTPChatProvider for ResolveAwareHttpProvider {
-        fn chat_request(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: Option<&[Tool]>,
-        ) -> Result<Request<Vec<u8>>, LLMError> {
-            let token = self.resolver.current();
-            let req = Request::builder()
-                .method("POST")
-                .uri("https://example.invalid/chat")
-                .header("authorization", format!("Bearer {token}"))
-                .body(Vec::new())
-                .map_err(|e| LLMError::InvalidRequest(format!("failed building request: {e}")))?;
-            Ok(req)
-        }
-
-        fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn supports_streaming(&self) -> bool {
-            false
-        }
-
-        fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPCompletionProvider for ResolveAwareHttpProvider {
-        fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPEmbeddingProvider for ResolveAwareHttpProvider {
-        fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-
-        fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
-            Err(LLMError::NotImplemented("unused in test".into()))
-        }
-    }
-
-    impl HTTPLLMProvider for ResolveAwareHttpProvider {
-        fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
-            Some(&self.resolver)
-        }
-    }
-
-    #[test]
-    fn set_key_resolver_forwards_to_inner_provider() {
-        let inner: Box<dyn HTTPLLMProvider> = Box::new(DummyHttpProvider { resolver: None });
-        let mut adapter = LLMProviderFromHTTP::new(inner);
-        let resolver = static_key("resolver-token");
-
-        adapter.set_key_resolver(resolver.clone());
-
-        let forwarded = adapter
-            .key_resolver()
-            .expect("resolver should be set on wrapped provider");
-        assert_eq!(forwarded.current(), "resolver-token");
-    }
-
-    #[tokio::test]
-    async fn ensure_credential_fresh_resolves_before_request_building() {
-        let resolver = Arc::new(CountingResolver::new());
-        let inner: Box<dyn HTTPLLMProvider> = Box::new(ResolveAwareHttpProvider {
-            resolver: resolver.clone(),
-        });
-        let adapter = LLMProviderFromHTTP::new(inner);
-
-        assert_eq!(resolver.resolve_count(), 0);
-        assert_eq!(
-            adapter
-                .inner
-                .chat_request(&[], None)
-                .expect("request should build")
-                .headers()
-                .get("authorization")
-                .expect("auth header should exist"),
-            "Bearer stale-token"
-        );
-
-        adapter
-            .ensure_credential_fresh()
-            .await
-            .expect("resolver should succeed");
-
-        assert_eq!(resolver.resolve_count(), 1);
-        assert_eq!(
-            adapter
-                .inner
-                .chat_request(&[], None)
-                .expect("request should build")
-                .headers()
-                .get("authorization")
-                .expect("auth header should exist"),
-            "Bearer resolved-token"
-        );
-    }
-}
+#[path = "adapters/tests.rs"]
+mod tests;

--- a/crates/querymt/src/adapters/tests.rs
+++ b/crates/querymt/src/adapters/tests.rs
@@ -1,0 +1,481 @@
+use super::*;
+use crate::auth::{ApiKeyResolver, static_key};
+use crate::chat::ChatProvider;
+use crate::chat::http::{ChatStreamParser, HTTPChatProvider};
+use crate::completion::http::HTTPCompletionProvider;
+use crate::embedding::http::HTTPEmbeddingProvider;
+use crate::error::LLMError;
+use futures::StreamExt;
+use http::{Request, Response};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct DummyHttpProvider {
+    resolver: Option<Arc<dyn ApiKeyResolver>>,
+}
+
+#[derive(Debug)]
+struct CountingResolver {
+    resolves: AtomicUsize,
+}
+
+impl CountingResolver {
+    fn new() -> Self {
+        Self {
+            resolves: AtomicUsize::new(0),
+        }
+    }
+
+    fn resolve_count(&self) -> usize {
+        self.resolves.load(Ordering::SeqCst)
+    }
+}
+
+impl ApiKeyResolver for CountingResolver {
+    fn resolve(&self) -> Pin<Box<dyn Future<Output = Result<(), LLMError>> + Send + '_>> {
+        self.resolves.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn current(&self) -> String {
+        if self.resolve_count() > 0 {
+            "resolved-token".to_string()
+        } else {
+            "stale-token".to_string()
+        }
+    }
+}
+
+struct ResolveAwareHttpProvider {
+    resolver: Arc<dyn ApiKeyResolver>,
+}
+
+impl HTTPChatProvider for DummyHttpProvider {
+    fn chat_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPCompletionProvider for DummyHttpProvider {
+    fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPEmbeddingProvider for DummyHttpProvider {
+    fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPLLMProvider for DummyHttpProvider {
+    fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
+        self.resolver.as_ref()
+    }
+
+    fn set_key_resolver(&mut self, resolver: Arc<dyn ApiKeyResolver>) {
+        self.resolver = Some(resolver);
+    }
+}
+
+impl HTTPChatProvider for ResolveAwareHttpProvider {
+    fn chat_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        let token = self.resolver.current();
+        let req = Request::builder()
+            .method("POST")
+            .uri("https://example.invalid/chat")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Vec::new())
+            .map_err(|e| LLMError::InvalidRequest(format!("failed building request: {e}")))?;
+        Ok(req)
+    }
+
+    fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPCompletionProvider for ResolveAwareHttpProvider {
+    fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPEmbeddingProvider for ResolveAwareHttpProvider {
+    fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+
+    fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::NotImplemented("unused in test".into()))
+    }
+}
+
+impl HTTPLLMProvider for ResolveAwareHttpProvider {
+    fn key_resolver(&self) -> Option<&Arc<dyn ApiKeyResolver>> {
+        Some(&self.resolver)
+    }
+}
+
+#[test]
+fn set_key_resolver_forwards_to_inner_provider() {
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(DummyHttpProvider { resolver: None });
+    let mut adapter = LLMProviderFromHTTP::new(inner);
+    let resolver = static_key("resolver-token");
+
+    adapter.set_key_resolver(resolver.clone());
+
+    let forwarded = adapter
+        .key_resolver()
+        .expect("resolver should be set on wrapped provider");
+    assert_eq!(forwarded.current(), "resolver-token");
+}
+
+#[tokio::test]
+async fn ensure_credential_fresh_resolves_before_request_building() {
+    let resolver = Arc::new(CountingResolver::new());
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(ResolveAwareHttpProvider {
+        resolver: resolver.clone(),
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    assert_eq!(resolver.resolve_count(), 0);
+    assert_eq!(
+        adapter
+            .inner
+            .chat_request(&[], None)
+            .expect("request should build")
+            .headers()
+            .get("authorization")
+            .expect("auth header should exist"),
+        "Bearer stale-token"
+    );
+
+    adapter
+        .ensure_credential_fresh()
+        .await
+        .expect("resolver should succeed");
+
+    assert_eq!(resolver.resolve_count(), 1);
+    assert_eq!(
+        adapter
+            .inner
+            .chat_request(&[], None)
+            .expect("request should build")
+            .headers()
+            .get("authorization")
+            .expect("auth header should exist"),
+        "Bearer resolved-token"
+    );
+}
+
+/// One-shot HTTP/1.1 responder for adapter integration tests.
+async fn serve_once(status_line: &str, headers: &[(&str, &str)], body: &[u8]) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let body = body.to_vec();
+    let headers: Vec<(String, String)> = headers
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+        .collect();
+    let status_line = status_line.to_owned();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+        let mut buf = vec![0u8; 8192];
+        let _ = socket.read(&mut buf).await;
+        let mut response = format!("{status_line}\r\nContent-Length: {}\r\n", body.len());
+        for (k, v) in &headers {
+            response.push_str(&format!("{k}: {v}\r\n"));
+        }
+        response.push_str("Connection: close\r\n\r\n");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write hdr");
+        socket.write_all(&body).await.expect("write body");
+    });
+
+    format!("http://{addr}/chat")
+}
+
+/// Streaming HTTP provider that hits a fixed URI and classifies with a
+/// vendor-shaped kind so tests can prove the adapter path (not status-only).
+struct StreamTestProvider {
+    uri: String,
+    parser: StreamTestParserMode,
+}
+
+#[derive(Clone, Copy)]
+enum StreamTestParserMode {
+    /// Never reached on open-failure tests.
+    Unused,
+    /// `finish()` returns a classified permanent failure.
+    FinishClassified,
+    /// Non-empty lines classify as rate-limited.
+    ChunkClassified,
+}
+
+struct StreamTestParser {
+    mode: StreamTestParserMode,
+}
+
+impl ChatStreamParser for StreamTestParser {
+    fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, crate::error::LLMError> {
+        match self.mode {
+            StreamTestParserMode::ChunkClassified
+                if !chunk.iter().all(|b| b.is_ascii_whitespace()) =>
+            {
+                Err(crate::error::ProviderFailure::new(
+                    crate::error::ProviderErrorKind::RateLimited,
+                    "mid-stream boom",
+                )
+                .with_retry_after_secs(Some(3))
+                .into())
+            }
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamChunk>, crate::error::LLMError> {
+        match self.mode {
+            StreamTestParserMode::FinishClassified => Err(crate::error::ProviderFailure::new(
+                crate::error::ProviderErrorKind::QuotaExceeded,
+                "finish boom",
+            )
+            .into()),
+            _ => Ok(Vec::new()),
+        }
+    }
+}
+
+impl HTTPChatProvider for StreamTestProvider {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> crate::error::LLMError {
+        // Prove the adapter calls the provider classifier (not only status-only).
+        let body = String::from_utf8_lossy(response.body());
+        crate::error::ProviderFailure::new(
+            crate::error::ProviderErrorKind::RateLimited,
+            format!("classified:{body}"),
+        )
+        .with_retry_after_secs(Some(9))
+        .with_code(Some("vendor_rate".into()))
+        .into()
+    }
+
+    fn chat_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn chat_stream_request(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+    ) -> Result<Request<Vec<u8>>, LLMError> {
+        Request::builder()
+            .method("POST")
+            .uri(&self.uri)
+            .body(Vec::new())
+            .map_err(|e| LLMError::InvalidRequest(e.to_string()))
+    }
+
+    fn parse_chat(&self, _resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn chat_stream_parser(&self) -> Result<Box<dyn ChatStreamParser>, LLMError> {
+        Ok(Box::new(StreamTestParser { mode: self.parser }))
+    }
+}
+
+impl HTTPCompletionProvider for StreamTestProvider {
+    fn complete_request(&self, _req: &CompletionRequest) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn parse_complete(&self, _resp: Response<Vec<u8>>) -> Result<CompletionResponse, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+}
+
+impl HTTPEmbeddingProvider for StreamTestProvider {
+    fn embed_request(&self, _inputs: &[String]) -> Result<Request<Vec<u8>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+
+    fn parse_embed(&self, _resp: Response<Vec<u8>>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(LLMError::NotImplemented("unused".into()))
+    }
+}
+
+impl HTTPLLMProvider for StreamTestProvider {}
+
+#[tokio::test]
+async fn stream_open_non_success_preserves_classification() {
+    let uri = serve_once(
+        "HTTP/1.1 429 Too Many Requests",
+        &[("Retry-After", "5"), ("Content-Type", "application/json")],
+        br#"{"error":"vendor body"}"#,
+    )
+    .await;
+
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(StreamTestProvider {
+        uri,
+        parser: StreamTestParserMode::Unused,
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    let err = match adapter.chat_stream_with_tools(&[], None).await {
+        Ok(_) => panic!("non-success stream open must fail before yielding a stream"),
+        Err(e) => e,
+    };
+
+    match &err {
+        LLMError::ProviderResponseError(failure) => {
+            assert!(
+                failure.message().contains("classified:")
+                    && failure.message().contains("vendor body"),
+                "adapter must use provider classify_chat_error, got message={}",
+                failure.message()
+            );
+            assert_eq!(failure.kind(), crate::error::ProviderErrorKind::RateLimited);
+            assert_eq!(failure.code(), Some("vendor_rate"));
+            assert_eq!(failure.retry_after_secs(), Some(9));
+        }
+        other => panic!("expected ProviderResponseError, got {other}"),
+    }
+    assert!(err.is_retryable());
+    assert!(err.is_rate_limited());
+}
+
+#[tokio::test]
+async fn stream_parser_finish_failure_preserves_classification() {
+    let uri = serve_once(
+        "HTTP/1.1 200 OK",
+        &[("Content-Type", "text/event-stream")],
+        b"", // empty body; adapter still calls finish() on stream end
+    )
+    .await;
+
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(StreamTestProvider {
+        uri,
+        parser: StreamTestParserMode::FinishClassified,
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    let mut stream = adapter
+        .chat_stream_with_tools(&[], None)
+        .await
+        .expect("200 open should succeed");
+
+    let err = loop {
+        match stream.next().await {
+            Some(Err(e)) => break e,
+            Some(Ok(_)) => continue,
+            None => panic!("expected classified finish error before stream end"),
+        }
+    };
+
+    match &err {
+        LLMError::ProviderResponseError(failure) => {
+            assert_eq!(failure.message(), "finish boom");
+            assert_eq!(
+                failure.kind(),
+                crate::error::ProviderErrorKind::QuotaExceeded
+            );
+        }
+        other => panic!("expected ProviderResponseError, got {other}"),
+    }
+    assert!(!err.is_retryable());
+}
+
+#[tokio::test]
+async fn stream_parser_chunk_failure_preserves_classification() {
+    let uri = serve_once(
+        "HTTP/1.1 200 OK",
+        &[("Content-Type", "text/event-stream")],
+        b"data: nope\n",
+    )
+    .await;
+
+    let inner: Box<dyn HTTPLLMProvider> = Box::new(StreamTestProvider {
+        uri,
+        parser: StreamTestParserMode::ChunkClassified,
+    });
+    let adapter = LLMProviderFromHTTP::new(inner);
+
+    let mut stream = adapter
+        .chat_stream_with_tools(&[], None)
+        .await
+        .expect("200 open should succeed");
+
+    let err = loop {
+        match stream.next().await {
+            Some(Err(e)) => break e,
+            Some(Ok(_)) => continue,
+            None => panic!("expected classified chunk error before stream end"),
+        }
+    };
+
+    match &err {
+        LLMError::ProviderResponseError(failure) => {
+            assert_eq!(failure.message(), "mid-stream boom");
+            assert_eq!(failure.kind(), crate::error::ProviderErrorKind::RateLimited);
+            assert_eq!(failure.retry_after_secs(), Some(3));
+        }
+        other => panic!("expected ProviderResponseError, got {other}"),
+    }
+    assert!(err.is_retryable());
+}

--- a/crates/querymt/src/chat/http.rs
+++ b/crates/querymt/src/chat/http.rs
@@ -1,9 +1,10 @@
 use crate::{
     Tool,
     chat::{ChatMessage, ChatResponse, StreamChunk},
-    error::LLMError,
+    error::{LLMError, classify_status_only},
 };
 use http::{Request, Response};
+use std::{future::Future, pin::Pin};
 
 pub trait ChatStreamParser: Send {
     fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, LLMError>;
@@ -14,6 +15,21 @@ pub trait ChatStreamParser: Send {
 }
 
 pub trait HTTPChatProvider: Send + Sync {
+    fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
+        classify_status_only(
+            response.status().as_u16(),
+            response.headers(),
+            response.body(),
+        )
+    }
+
+    fn classify_chat_error_async<'a>(
+        &'a self,
+        response: &'a Response<Vec<u8>>,
+    ) -> Pin<Box<dyn Future<Output = LLMError> + Send + 'a>> {
+        Box::pin(async move { self.classify_chat_error(response) })
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -30,6 +46,11 @@ pub trait HTTPChatProvider: Send + Sync {
         ))
     }
 
+    /// Parse a **successful** chat HTTP body.
+    ///
+    /// The HTTP adapter only calls this after a success status. Non-success
+    /// responses go through [`Self::classify_chat_error`] instead — do not
+    /// re-check status here.
     fn parse_chat(&self, resp: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError>;
 
     fn supports_streaming(&self) -> bool {

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -15,6 +15,136 @@ pub enum TransportErrorKind {
     Other,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderErrorKind {
+    ServerOverloaded,
+    RateLimited,
+    QuotaExceeded,
+    ContextWindowExceeded,
+    Authentication,
+    InvalidRequest,
+    /// Unclassified vendor failure treated as transient (e.g. bare 5xx).
+    /// Retryability lives **only** on the kind — there is no parallel
+    /// `transient` flag that can disagree.
+    UnknownTransient,
+    /// Unclassified vendor failure treated as permanent.
+    #[serde(other)]
+    UnknownPermanent,
+}
+
+impl ProviderErrorKind {
+    /// Unified retry policy for provider failures.
+    ///
+    /// QueryMT product choice: overload is retried (upstream Codex marks it
+    /// non-retryable). Quota/context/auth/request failures never are.
+    /// [`Self::UnknownTransient`] / [`Self::UnknownPermanent`] cover unmapped
+    /// vendor envelopes without a second field.
+    pub fn is_retryable(self) -> bool {
+        matches!(
+            self,
+            Self::ServerOverloaded | Self::RateLimited | Self::UnknownTransient
+        )
+    }
+}
+
+/// Structured provider failure with retry semantics and vendor diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFailure {
+    message: String,
+    kind: ProviderErrorKind,
+    code: Option<String>,
+    error_type: Option<String>,
+    request_id: Option<String>,
+    retry_after_secs: Option<u64>,
+}
+
+impl ProviderFailure {
+    pub fn new(kind: ProviderErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            kind,
+            code: None,
+            error_type: None,
+            request_id: None,
+            retry_after_secs: None,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn kind(&self) -> ProviderErrorKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+
+    pub fn error_type(&self) -> Option<&str> {
+        self.error_type.as_deref()
+    }
+
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        self.retry_after_secs
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
+    }
+
+    pub fn with_code(mut self, code: Option<String>) -> Self {
+        self.code = code;
+        self
+    }
+
+    pub fn with_error_type(mut self, error_type: Option<String>) -> Self {
+        self.error_type = error_type;
+        self
+    }
+
+    pub fn with_request_id(mut self, request_id: Option<String>) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn with_retry_after_secs(mut self, retry_after_secs: Option<u64>) -> Self {
+        self.retry_after_secs = retry_after_secs;
+        self
+    }
+}
+
+impl std::fmt::Display for ProviderFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (kind={:?}", self.message, self.kind)?;
+        if let Some(code) = &self.code {
+            write!(f, ", code={code}")?;
+        }
+        if let Some(error_type) = &self.error_type {
+            write!(f, ", type={error_type}")?;
+        }
+        if let Some(request_id) = &self.request_id {
+            write!(f, ", request_id={request_id}")?;
+        }
+        if let Some(retry_after_secs) = self.retry_after_secs {
+            write!(f, ", retry_after_secs={retry_after_secs}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl From<ProviderFailure> for LLMError {
+    fn from(failure: ProviderFailure) -> Self {
+        Self::ProviderResponseError(Box::new(failure))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LLMErrorPayload {
@@ -23,6 +153,16 @@ pub enum LLMErrorPayload {
     },
     ProviderError {
         message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kind: Option<ProviderErrorKind>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_type: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_after_secs: Option<u64>,
     },
     AuthError {
         message: String,
@@ -88,6 +228,10 @@ pub enum LLMError {
     #[error("LLM Provider Error: {0}")]
     ProviderError(String),
 
+    /// A provider failure with structured classification metadata.
+    #[error("LLM Provider Error: {0}")]
+    ProviderResponseError(Box<ProviderFailure>),
+
     /// A wrapper for authentication/authorization errors.
     #[error("Auth Error: {0}")]
     AuthError(String),
@@ -152,12 +296,16 @@ pub enum LLMError {
     NotImplemented(String),
 
     /// Handles JSON serialization and deserialization errors.
+    ///
+    /// Stored as a string so wire payloads round-trip without changing retryability.
     #[error("JSON Error: {0}")]
-    JsonError(#[from] serde_json::Error),
+    JsonError(String),
 
     /// Handles errors from parsing URLs.
-    #[error("Invalid URL")]
-    InvalidUrl(#[from] url::ParseError),
+    ///
+    /// Stored as a string so wire payloads round-trip without changing retryability.
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
 
     /// Handles standard I/O errors.
     #[error("I/O Error")]
@@ -172,6 +320,19 @@ impl LLMError {
             },
             Self::ProviderError(message) => LLMErrorPayload::ProviderError {
                 message: message.clone(),
+                kind: None,
+                code: None,
+                error_type: None,
+                request_id: None,
+                retry_after_secs: None,
+            },
+            Self::ProviderResponseError(failure) => LLMErrorPayload::ProviderError {
+                message: failure.message.clone(),
+                kind: Some(failure.kind),
+                code: failure.code.clone(),
+                error_type: failure.error_type.clone(),
+                request_id: failure.request_id.clone(),
+                retry_after_secs: failure.retry_after_secs,
             },
             Self::AuthError(message) => LLMErrorPayload::AuthError {
                 message: message.clone(),
@@ -227,11 +388,11 @@ impl LLMError {
             Self::NotImplemented(message) => LLMErrorPayload::NotImplemented {
                 message: message.clone(),
             },
-            Self::JsonError(err) => LLMErrorPayload::JsonError {
-                message: err.to_string(),
+            Self::JsonError(message) => LLMErrorPayload::JsonError {
+                message: message.clone(),
             },
-            Self::InvalidUrl(err) => LLMErrorPayload::InvalidUrl {
-                message: err.to_string(),
+            Self::InvalidUrl(message) => LLMErrorPayload::InvalidUrl {
+                message: message.clone(),
             },
             Self::IoError(err) => LLMErrorPayload::IoError {
                 message: err.to_string(),
@@ -242,7 +403,23 @@ impl LLMError {
     pub fn from_payload(payload: LLMErrorPayload) -> Self {
         match payload {
             LLMErrorPayload::GenericError { message } => Self::GenericError(message),
-            LLMErrorPayload::ProviderError { message } => Self::ProviderError(message),
+            LLMErrorPayload::ProviderError {
+                message,
+                kind,
+                code,
+                error_type,
+                request_id,
+                retry_after_secs,
+            } => match kind {
+                Some(kind) => Self::ProviderResponseError(Box::new(
+                    ProviderFailure::new(kind, message)
+                        .with_code(code)
+                        .with_error_type(error_type)
+                        .with_request_id(request_id)
+                        .with_retry_after_secs(retry_after_secs),
+                )),
+                None => Self::ProviderError(message),
+            },
             LLMErrorPayload::AuthError { message } => Self::AuthError(message),
             LLMErrorPayload::ToolConfigError { message } => Self::ToolConfigError(message),
             LLMErrorPayload::PluginError { message } => Self::PluginError(message),
@@ -280,8 +457,12 @@ impl LLMError {
                 Self::RemoteStreamReconnected { message }
             }
             LLMErrorPayload::NotImplemented { message } => Self::NotImplemented(message),
-            LLMErrorPayload::JsonError { message } => Self::PluginError(message),
-            LLMErrorPayload::InvalidUrl { message } => Self::HttpError(message),
+            // Lossless: keep payload tags as distinct runtime variants so
+            // payload.is_retryable() == from_payload(p).is_retryable().
+            LLMErrorPayload::JsonError { message } => Self::JsonError(message),
+            LLMErrorPayload::InvalidUrl { message } => Self::InvalidUrl(message),
+            // Io has no dedicated runtime variant; Transport is the stable
+            // retryable home and matches payload IoError retryability.
             LLMErrorPayload::IoError { message } => Self::Transport {
                 kind: TransportErrorKind::Other,
                 message,
@@ -297,12 +478,51 @@ impl LLMError {
             | Self::HttpStatus {
                 retry_after_secs, ..
             } => *retry_after_secs,
+            Self::ProviderResponseError(failure) => failure.retry_after_secs(),
             _ => None,
         }
     }
 
-    pub fn is_retryable_setup_failure(&self) -> bool {
-        self.is_retryable()
+    /// Whether this error is a rate-limit failure (for UI events / wait messaging).
+    ///
+    /// Two representations exist on purpose:
+    /// - [`Self::RateLimited`] / bare HTTP 429: generic HTTP path
+    /// - [`Self::ProviderResponseError`] with [`ProviderErrorKind::RateLimited`]:
+    ///   classified chat path
+    ///
+    /// Callers must use this helper instead of matching one form only.
+    pub fn is_rate_limited(&self) -> bool {
+        match self {
+            Self::RateLimited { .. } => true,
+            Self::HttpStatus {
+                status_code: 429, ..
+            } => true,
+            Self::ProviderResponseError(failure) => {
+                failure.kind() == ProviderErrorKind::RateLimited
+            }
+            _ => false,
+        }
+    }
+
+    /// Message + retry-after when [`Self::is_rate_limited`] is true.
+    pub fn rate_limit_info(&self) -> Option<(String, Option<u64>)> {
+        match self {
+            Self::RateLimited {
+                message,
+                retry_after_secs,
+            } => Some((message.clone(), *retry_after_secs)),
+            Self::HttpStatus {
+                status_code: 429,
+                message,
+                retry_after_secs,
+            } => Some((message.clone(), *retry_after_secs)),
+            Self::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::RateLimited =>
+            {
+                Some((failure.message.clone(), failure.retry_after_secs()))
+            }
+            _ => None,
+        }
     }
 
     /// Whether this error is worth retrying (transient infrastructure error).
@@ -311,6 +531,9 @@ impl LLMError {
     /// on a second attempt. Only semantic/auth/validation errors are not retryable.
     /// The mesh-specific `RemoteStreamDisconnected`/`RemoteStreamReconnected` events
     /// are excluded — they have their own handling in the streaming loop.
+    ///
+    /// Retry policy is keyed off **unified** error kinds. Vendor code tables live
+    /// in providers; they map wire errors into these variants before core sees them.
     pub fn is_retryable(&self) -> bool {
         match self {
             // Always retry: transient infrastructure
@@ -323,6 +546,10 @@ impl LLMError {
             Self::PluginError(_) => true, // may be a transient WASM/HTTP issue
             Self::IoError { .. } => true,
 
+            // Structured provider failure: unified kind policy, including
+            // explicit UnknownTransient / UnknownPermanent fallback kinds.
+            Self::ProviderResponseError(failure) => failure.is_retryable(),
+
             // Never retry: semantic errors
             Self::AuthError(_) => false,
             Self::InvalidRequest(_) => false,
@@ -331,8 +558,8 @@ impl LLMError {
             Self::ResponseFormatError { .. } => false,
             Self::GenericError(_) => false,
             Self::Cancelled => false,
-            Self::JsonError { .. } => false,
-            Self::InvalidUrl { .. } => false,
+            Self::JsonError(_) => false,
+            Self::InvalidUrl(_) => false,
             Self::NotImplemented(_) => false,
 
             // Mesh transport events — handled by the existing continue logic
@@ -442,7 +669,9 @@ fn json_retry_after_value(v: &serde_json::Value) -> Option<u64> {
 /// Checks common locations where providers embed retry hints:
 /// - `error.retry_after` / `error.retry_after_secs`
 /// - top-level `retry_after` / `retry_after_secs`
-fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
+///
+/// Vendor-agnostic field lookup only — no error-code classification.
+pub fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
     [
         json.pointer("/error/retry_after"),
         json.pointer("/error/retry_after_secs"),
@@ -454,11 +683,63 @@ fn extract_retry_after_from_json(json: &serde_json::Value) -> Option<u64> {
     .find_map(json_retry_after_value)
 }
 
-pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
-    if status_code == 499 {
-        return LLMError::Cancelled;
+/// Parse `"try again in 11.054s"` style delays from a provider message.
+///
+/// Used by providers (e.g. OpenAI/Codex rate-limit messages) after they have
+/// already decided the failure is a rate limit from structured `code`/`type`.
+pub fn parse_retry_after_from_message(message: &str) -> Option<u64> {
+    // Mirror openai/codex: `(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)`
+    let lower = message.to_ascii_lowercase();
+    let marker = "try again in";
+    let rest = lower.split_once(marker)?.1.trim_start();
+    let mut num = String::new();
+    let mut chars = rest.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() || c == '.' {
+            num.push(c);
+            chars.next();
+        } else {
+            break;
+        }
     }
+    if num.is_empty() {
+        return None;
+    }
+    let value: f64 = num.parse().ok()?;
+    // skip whitespace
+    while matches!(chars.peek(), Some(c) if c.is_whitespace()) {
+        chars.next();
+    }
+    let unit: String = chars
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if unit == "ms" {
+        let millis = value as u64;
+        return Some(if millis == 0 && value > 0.0 {
+            1
+        } else {
+            duration_to_secs(Duration::from_millis(millis.max(1)))
+        });
+    }
+    if unit == "s" || unit.starts_with("second") {
+        return Some(if value <= 0.0 {
+            0
+        } else if value < 1.0 {
+            1
+        } else {
+            value.ceil() as u64
+        });
+    }
+    None
+}
 
+/// Extract the human-readable message and retry hint from an error response.
+fn status_message_and_retry(
+    status_code: u16,
+    headers: &http::HeaderMap,
+    body: &[u8],
+) -> (String, Option<u64>) {
     // Parse body JSON once; reuse for both retry-after and message extraction.
     let body_json = serde_json::from_slice::<serde_json::Value>(body).ok();
 
@@ -478,6 +759,40 @@ pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &
     } else {
         clean_message
     };
+    (message, retry_after_secs)
+}
+
+/// Classify a non-success HTTP status when the body carries no recognizable
+/// vendor error envelope.
+pub fn classify_status_only(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let (message, retry_after_secs) = status_message_and_retry(status_code, headers, body);
+    let kind = match status_code {
+        429 => ProviderErrorKind::RateLimited,
+        401 | 403 => ProviderErrorKind::Authentication,
+        400 | 422 => ProviderErrorKind::InvalidRequest,
+        408 | 425 | 500..=599 => ProviderErrorKind::UnknownTransient,
+        _ => ProviderErrorKind::UnknownPermanent,
+    };
+    ProviderFailure::new(kind, message)
+        .with_retry_after_secs(retry_after_secs)
+        .into()
+}
+
+/// Generic HTTP status classifier.
+///
+/// Rate limits stay on the legacy [`LLMError::RateLimited`] variant here so
+/// generic HTTP failures keep the stable wire payload shape. Chat provider
+/// classifiers use [`classify_status_only`] or a vendor envelope classifier.
+pub fn classify_http_status(status_code: u16, headers: &http::HeaderMap, body: &[u8]) -> LLMError {
+    if status_code == 499 {
+        return LLMError::Cancelled;
+    }
+
+    let (message, retry_after_secs) = status_message_and_retry(status_code, headers, body);
 
     match status_code {
         401 | 403 => LLMError::AuthError(message),
@@ -499,6 +814,18 @@ pub fn transport_error(kind: TransportErrorKind, message: impl Into<String>) -> 
     LLMError::Transport {
         kind,
         message: message.into(),
+    }
+}
+
+impl From<serde_json::Error> for LLMError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::JsonError(err.to_string())
+    }
+}
+
+impl From<url::ParseError> for LLMError {
+    fn from(err: url::ParseError) -> Self {
+        Self::InvalidUrl(err.to_string())
     }
 }
 
@@ -530,7 +857,7 @@ impl From<reqwest::Error> for LLMError {
 
 impl From<http::Error> for LLMError {
     fn from(err: http::Error) -> Self {
-        LLMError::HttpError(err.to_string())
+        LLMError::InvalidRequest(err.to_string())
     }
 }
 
@@ -756,5 +1083,396 @@ mod tests {
         let body = b"Server Error";
         let err = classify_http_status(503, &headers, body);
         assert_eq!(err.retry_after_secs(), Some(60));
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum LegacyPayload {
+        ProviderError { message: String },
+    }
+
+    #[test]
+    fn legacy_provider_payload_deserialization() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "legacy failure"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            payload,
+            LLMErrorPayload::ProviderError {
+                message: "legacy failure".to_owned(),
+                kind: None,
+                code: None,
+                error_type: None,
+                request_id: None,
+                retry_after_secs: None,
+            }
+        );
+        assert!(matches!(
+            LLMError::from_payload(payload),
+            LLMError::ProviderError(message) if message == "legacy failure"
+        ));
+    }
+
+    #[test]
+    fn classified_error_preserves_kind_and_metadata() {
+        let error = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_error_type(Some("server_error".into()))
+            .with_request_id(Some("req-1".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-1"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert!(failure.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn flat_structured_payload_is_preserved() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "plugin busy",
+            "kind": "server_overloaded",
+            "code": "server_is_overloaded",
+            "request_id": "req-plugin"
+        }))
+        .expect("structured plugin payload should deserialize");
+
+        let error = LLMError::from_payload(payload);
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "plugin busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn provider_failure_converts_directly_to_llm_error() {
+        let error = LLMError::from(ProviderFailure::new(ProviderErrorKind::RateLimited, "busy"));
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn structured_semantic_errors_round_trip_through_legacy_provider_tag() {
+        let overloaded: LLMError =
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+                .with_code(Some("server_is_overloaded".into()))
+                .with_request_id(Some("req-1".into()))
+                .into();
+        let payload = overloaded.to_payload();
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["type"], "provider_error");
+        assert_eq!(json["kind"], "server_overloaded");
+        assert_eq!(json["code"], "server_is_overloaded");
+        let legacy: LegacyPayload = serde_json::from_value(json.clone()).unwrap();
+        assert!(matches!(
+            legacy,
+            LegacyPayload::ProviderError { message } if message == "busy"
+        ));
+        let restored =
+            LLMError::from_payload(serde_json::from_value::<LLMErrorPayload>(json).unwrap());
+        assert!(matches!(
+            restored,
+            LLMError::ProviderResponseError(failure)
+                if failure.message() == "busy"
+                    && failure.kind() == ProviderErrorKind::ServerOverloaded
+                    && failure.code() == Some("server_is_overloaded")
+                    && restored.is_retryable()
+        ));
+
+        let quota: LLMError = ProviderFailure::new(ProviderErrorKind::QuotaExceeded, "no credits")
+            .with_code(Some("insufficient_quota".into()))
+            .into();
+        assert!(!quota.is_retryable());
+        assert!(matches!(
+            LLMError::from_payload(quota.to_payload()),
+            LLMError::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::QuotaExceeded
+        ));
+
+        let context: LLMError =
+            ProviderFailure::new(ProviderErrorKind::ContextWindowExceeded, "too long")
+                .with_code(Some("context_length_exceeded".into()))
+                .into();
+        assert!(!context.is_retryable());
+        assert!(matches!(
+            LLMError::from_payload(context.to_payload()),
+            LLMError::ProviderResponseError(failure)
+                if failure.kind() == ProviderErrorKind::ContextWindowExceeded
+        ));
+    }
+
+    #[test]
+    fn payload_retryability_is_owned_by_kind_alone() {
+        let overloaded = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::ServerOverloaded,
+            "busy",
+        ));
+        assert!(overloaded.is_retryable());
+
+        let quota = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::QuotaExceeded,
+            "no credits",
+        ));
+        assert!(!quota.is_retryable());
+    }
+
+    #[test]
+    fn unknown_kinds_and_metadata_are_preserved() {
+        let transient = ProviderFailure::new(ProviderErrorKind::UnknownTransient, "maybe")
+            .with_code(Some("unknown".into()));
+        assert!(transient.is_retryable());
+        assert_eq!(transient.kind(), ProviderErrorKind::UnknownTransient);
+
+        let permanent = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "nope")
+            .with_code(Some("unknown".into()));
+        assert!(!permanent.is_retryable());
+        assert_eq!(permanent.kind(), ProviderErrorKind::UnknownPermanent);
+
+        let permanent_with_hint = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "busy")
+            .with_retry_after_secs(Some(60));
+        assert!(!permanent_with_hint.is_retryable());
+        assert_eq!(
+            LLMError::from(permanent_with_hint).retry_after_secs(),
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn provider_failure_conversion_preserves_metadata() {
+        let error = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_error_type(Some("server_error".into()))
+            .with_request_id(Some("req-1".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "busy");
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.error_type(), Some("server_error"));
+                assert_eq!(failure.request_id(), Some("req-1"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+                assert!(failure.is_retryable());
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn server_overloaded_is_retryable_by_kind() {
+        let err: LLMError = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "capacity")
+            .with_code(Some("server_is_overloaded".into()))
+            .into();
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn provider_response_error_honors_unknown_transient_kind() {
+        let transient: LLMError =
+            ProviderFailure::new(ProviderErrorKind::UnknownTransient, "maybe")
+                .with_code(Some("unknown".into()))
+                .with_retry_after_secs(Some(5))
+                .into();
+        assert!(transient.is_retryable());
+        assert_eq!(transient.retry_after_secs(), Some(5));
+
+        let permanent: LLMError = ProviderFailure::new(ProviderErrorKind::UnknownPermanent, "nope")
+            .with_code(Some("unknown".into()))
+            .into();
+        assert!(!permanent.is_retryable());
+    }
+
+    #[test]
+    fn unknown_payload_kind_falls_back_to_permanent() {
+        let payload: LLMErrorPayload = serde_json::from_value(serde_json::json!({
+            "type": "provider_error",
+            "message": "future failure",
+            "kind": "future_provider_kind",
+            "code": "future_code",
+            "retry_after_secs": 90
+        }))
+        .expect("future provider kind should remain readable");
+
+        let error = LLMError::from_payload(payload);
+        assert!(!error.is_retryable());
+        match error {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::UnknownPermanent);
+                assert_eq!(failure.code(), Some("future_code"));
+                assert_eq!(failure.retry_after_secs(), Some(90));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+
+    #[test]
+    fn classify_status_only_owns_client_cancellation() {
+        let error = classify_status_only(499, &http::HeaderMap::new(), b"cancelled");
+        assert!(matches!(error, LLMError::Cancelled));
+    }
+
+    #[test]
+    fn classify_status_only_maps_status_to_unified_kinds() {
+        let headers = http::HeaderMap::new();
+
+        let rate_limited =
+            classify_status_only(429, &headers, br#"{"error":{"message":"slow down"}}"#);
+        assert!(matches!(
+            rate_limited,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::RateLimited
+                    && failure.message() == "slow down"
+        ));
+        assert!(rate_limited.is_retryable());
+
+        let auth = classify_status_only(401, &headers, b"bad key");
+        assert!(matches!(
+            auth,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::Authentication
+        ));
+        assert!(!auth.is_retryable());
+
+        let invalid = classify_status_only(422, &headers, b"bad field");
+        assert!(matches!(
+            invalid,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::InvalidRequest
+        ));
+        assert!(!invalid.is_retryable());
+
+        // Timeout-style statuses and unknown 5xx are transient.
+        for status in [408, 425, 503] {
+            let transient = classify_status_only(status, &headers, b"temporary failure");
+            assert!(matches!(
+                transient,
+                LLMError::ProviderResponseError(ref failure)
+                    if failure.kind() == ProviderErrorKind::UnknownTransient
+            ));
+            assert!(transient.is_retryable());
+        }
+
+        // Unknown 4xx: unclassified and permanent.
+        let weird = classify_status_only(418, &headers, b"teapot");
+        assert!(matches!(
+            weird,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownPermanent
+        ));
+        assert!(!weird.is_retryable());
+
+        let permanent_with_hint = classify_status_only(
+            401,
+            &http::HeaderMap::from_iter([(
+                http::header::RETRY_AFTER,
+                http::HeaderValue::from_static("30"),
+            )]),
+            b"bad key",
+        );
+        assert_eq!(permanent_with_hint.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn request_builder_errors_are_permanent_invalid_requests() {
+        let error = http::Request::builder()
+            .uri("\n")
+            .body(Vec::<u8>::new())
+            .expect_err("invalid URI must fail");
+        let error = LLMError::from(error);
+        assert!(matches!(error, LLMError::InvalidRequest(_)));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn rate_limit_info_covers_legacy_and_structured_forms() {
+        let legacy = LLMError::RateLimited {
+            message: "slow".into(),
+            retry_after_secs: Some(3),
+        };
+        assert!(legacy.is_rate_limited());
+        assert_eq!(legacy.rate_limit_info(), Some(("slow".into(), Some(3))));
+
+        let structured: LLMError = ProviderFailure::new(ProviderErrorKind::RateLimited, "slow")
+            .with_retry_after_secs(Some(4))
+            .into();
+        assert!(structured.is_rate_limited());
+        assert_eq!(structured.rate_limit_info(), Some(("slow".into(), Some(4))));
+
+        let http_429 = LLMError::HttpStatus {
+            status_code: 429,
+            message: "too many".into(),
+            retry_after_secs: Some(1),
+        };
+        assert!(http_429.is_rate_limited());
+        assert_eq!(
+            http_429.rate_limit_info(),
+            Some(("too many".into(), Some(1)))
+        );
+
+        let other = LLMError::GenericError("nope".into());
+        assert!(!other.is_rate_limited());
+        assert!(other.rate_limit_info().is_none());
+    }
+
+    #[test]
+    fn display_includes_message_and_metadata_once() {
+        let error: LLMError = ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "busy")
+            .with_code(Some("server_is_overloaded".into()))
+            .with_request_id(Some("req-9".into()))
+            .with_retry_after_secs(Some(2))
+            .into();
+        let rendered = error.to_string();
+        assert_eq!(rendered.matches("busy").count(), 1);
+        assert!(
+            rendered.contains("ServerOverloaded"),
+            "missing kind: {rendered}"
+        );
+        assert!(rendered.contains("server_is_overloaded"));
+        assert!(rendered.contains("req-9"));
+        assert!(rendered.contains("retry_after_secs=2"));
+    }
+
+    #[test]
+    fn parse_retry_after_from_message_matches_codex_style() {
+        assert_eq!(
+            parse_retry_after_from_message(
+                "Rate limit reached. Please try again in 11.054s. Visit docs."
+            ),
+            Some(12) // ceil
+        );
+        assert_eq!(
+            parse_retry_after_from_message("Please try again in 30 seconds."),
+            Some(30)
+        );
+        assert_eq!(
+            parse_retry_after_from_message("Please try again in 500ms"),
+            Some(1)
+        );
+        assert_eq!(parse_retry_after_from_message("no delay mentioned"), None);
     }
 }

--- a/crates/querymt/src/outbound.rs
+++ b/crates/querymt/src/outbound.rs
@@ -1,7 +1,22 @@
+/// Outcome of a streaming outbound HTTP call before provider classification.
+///
+/// Success and failure are distinct variants so callers cannot treat an HTTP
+/// error status as a normal byte stream (the old `(Response<()>, stream)` pair
+/// returned `Ok` for both).
+pub enum OutboundStreamResult {
+    Success {
+        stream:
+            std::pin::Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>>,
+    },
+    /// Non-success status with the full error body already buffered.
+    Failure { response: http::Response<Vec<u8>> },
+}
+
 mod http_client {
     #[cfg(not(target_arch = "wasm32"))]
     pub mod imp {
         use crate::error::{LLMError, classify_http_status};
+        use crate::outbound::OutboundStreamResult;
         use http::{Request, Response};
         use once_cell::sync::Lazy;
         use reqwest::Client;
@@ -102,14 +117,19 @@ mod http_client {
             truncate_preview(value.to_string(), max_len)
         }
 
-        pub async fn call_outbound(req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+        /// Send an HTTP request and preserve the response status, headers, and body.
+        ///
+        /// Provider adapters use this to apply provider-specific error classification.
+        pub async fn call_outbound_raw(
+            req: Request<Vec<u8>>,
+        ) -> Result<Response<Vec<u8>>, LLMError> {
             let client = &*CLIENT;
 
             let method = req
                 .method()
                 .as_str()
                 .parse::<reqwest::Method>()
-                .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
 
             #[cfg(debug_assertions)]
             {
@@ -134,7 +154,7 @@ mod http_client {
             for (name, value) in req.headers().iter() {
                 let val_str = value
                     .to_str()
-                    .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                    .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
                 rb = rb.header(name.as_str(), val_str);
             }
 
@@ -171,7 +191,6 @@ mod http_client {
                         .and_then(|v| v.to_str().ok())
                         .unwrap_or("<missing>")
                 );
-                return Err(classify_http_status(status.as_u16(), &headers, &bytes));
             }
 
             let mut builder = Response::builder().status(status.as_u16());
@@ -181,16 +200,20 @@ mod http_client {
             Ok(builder.body(bytes).unwrap())
         }
 
-        pub async fn call_outbound_stream(
+        /// Send a streaming HTTP request.
+        ///
+        /// Returns [`OutboundStreamResult`] so callers cannot mistake an HTTP
+        /// error body for a successful byte stream.
+        pub async fn call_outbound_stream_raw(
             req: Request<Vec<u8>>,
-        ) -> Result<impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>, LLMError> {
+        ) -> Result<OutboundStreamResult, LLMError> {
             let client = &*CLIENT;
 
             let method = req
                 .method()
                 .as_str()
                 .parse::<reqwest::Method>()
-                .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
 
             #[cfg(debug_assertions)]
             {
@@ -215,7 +238,7 @@ mod http_client {
             for (name, value) in req.headers().iter() {
                 let val_str = value
                     .to_str()
-                    .map_err(|e| LLMError::HttpError(e.to_string()))?;
+                    .map_err(|e| LLMError::InvalidRequest(e.to_string()))?;
                 rb = rb.header(name.as_str(), val_str);
             }
 
@@ -251,9 +274,32 @@ mod http_client {
                         .and_then(|v| v.to_str().ok())
                         .unwrap_or("<missing>")
                 );
-                return Err(classify_http_status(status.as_u16(), &headers, &bytes));
+                let mut builder = Response::builder().status(status.as_u16());
+                for (name, value) in headers.iter() {
+                    builder = builder.header(name.as_str(), value.as_bytes());
+                }
+                return Ok(OutboundStreamResult::Failure {
+                    response: builder.body(bytes).unwrap(),
+                });
             }
-            Ok(resp.bytes_stream())
+
+            Ok(OutboundStreamResult::Success {
+                stream: Box::pin(resp.bytes_stream()),
+            })
+        }
+
+        /// Send an HTTP request using the generic status classifier.
+        pub async fn call_outbound(req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+            let response = call_outbound_raw(req).await?;
+            if response.status().is_success() {
+                return Ok(response);
+            }
+
+            Err(classify_http_status(
+                response.status().as_u16(),
+                response.headers(),
+                response.body(),
+            ))
         }
     }
 
@@ -262,16 +308,26 @@ mod http_client {
         use crate::error::LLMError;
         use http::{Request, Response};
 
-        pub async fn call_outbound(_req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
+        pub async fn call_outbound_raw(
+            _req: Request<Vec<u8>>,
+        ) -> Result<Response<Vec<u8>>, LLMError> {
             Err(LLMError::InvalidRequest("".into()))
         }
 
-        pub async fn call_outbound_stream(
+        pub async fn call_outbound_stream_raw(
             _req: Request<Vec<u8>>,
-        ) -> Result<futures::stream::Empty<reqwest::Result<bytes::Bytes>>, LLMError> {
+        ) -> Result<crate::outbound::OutboundStreamResult, LLMError> {
+            Err(LLMError::InvalidRequest("".into()))
+        }
+
+        pub async fn call_outbound(_req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, LLMError> {
             Err(LLMError::InvalidRequest("".into()))
         }
     }
 }
 
-pub use http_client::imp::{call_outbound, call_outbound_stream};
+pub use http_client::imp::{call_outbound, call_outbound_raw, call_outbound_stream_raw};
+
+#[cfg(test)]
+#[path = "outbound/tests.rs"]
+mod tests;

--- a/crates/querymt/src/outbound/tests.rs
+++ b/crates/querymt/src/outbound/tests.rs
@@ -1,0 +1,116 @@
+use super::{OutboundStreamResult, call_outbound_stream_raw};
+use http::Request;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// One-shot HTTP/1.1 responder on a random localhost port.
+async fn serve_once(status_line: &str, headers: &[(&str, &str)], body: &[u8]) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let body = body.to_vec();
+    let headers: Vec<(String, String)> = headers
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+        .collect();
+    let status_line = status_line.to_owned();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+        let mut buf = vec![0u8; 8192];
+        let _ = socket.read(&mut buf).await;
+        let mut response = format!("{status_line}\r\nContent-Length: {}\r\n", body.len());
+        for (k, v) in &headers {
+            response.push_str(&format!("{k}: {v}\r\n"));
+        }
+        response.push_str("Connection: close\r\n\r\n");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write hdr");
+        socket.write_all(&body).await.expect("write body");
+    });
+
+    format!("http://{addr}/stream")
+}
+
+#[tokio::test]
+async fn stream_raw_non_success_is_failure_with_status_headers_body() {
+    let uri = serve_once(
+        "HTTP/1.1 429 Too Many Requests",
+        &[
+            ("Retry-After", "11"),
+            ("x-request-id", "req-stream-1"),
+            ("Content-Type", "application/json"),
+        ],
+        br#"{"error":{"message":"slow down","type":"rate_limit_error"}}"#,
+    )
+    .await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(&uri)
+        .body(Vec::new())
+        .expect("request");
+
+    let result = call_outbound_stream_raw(req)
+        .await
+        .expect("transport should succeed");
+
+    match result {
+        OutboundStreamResult::Failure { response } => {
+            assert_eq!(response.status().as_u16(), 429);
+            assert_eq!(
+                response
+                    .headers()
+                    .get("retry-after")
+                    .and_then(|v| v.to_str().ok()),
+                Some("11")
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get("x-request-id")
+                    .and_then(|v| v.to_str().ok()),
+                Some("req-stream-1")
+            );
+            assert!(
+                std::str::from_utf8(response.body())
+                    .unwrap_or_default()
+                    .contains("slow down"),
+                "body should be preserved: {:?}",
+                String::from_utf8_lossy(response.body())
+            );
+        }
+        OutboundStreamResult::Success { .. } => {
+            panic!("non-success status must not open a success stream")
+        }
+    }
+}
+
+#[tokio::test]
+async fn stream_raw_success_returns_stream_variant() {
+    let uri = serve_once(
+        "HTTP/1.1 200 OK",
+        &[("Content-Type", "text/event-stream")],
+        b"data: {\"ok\":true}\n\n",
+    )
+    .await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(&uri)
+        .body(Vec::new())
+        .expect("request");
+
+    let result = call_outbound_stream_raw(req)
+        .await
+        .expect("transport should succeed");
+
+    match result {
+        OutboundStreamResult::Success { stream: _ } => {}
+        OutboundStreamResult::Failure { response } => {
+            panic!("expected Success, got Failure status={}", response.status())
+        }
+    }
+}

--- a/crates/querymt/src/plugin/adapters.rs
+++ b/crates/querymt/src/plugin/adapters.rs
@@ -32,11 +32,7 @@ impl LLMProviderFactory for HTTPFactoryAdapter {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn LLMProvider>, LLMError> {
-        let sync_provider = self
-            .inner
-            .from_config(cfg)
-            .map_err(|e| LLMError::PluginError(format!("{:#}", e)))?;
-
+        let sync_provider = self.inner.from_config(cfg)?;
         let adapter = LLMProviderFromHTTP::new(sync_provider);
         Ok(Box::new(adapter))
     }
@@ -54,10 +50,99 @@ impl LLMProviderFactory for HTTPFactoryAdapter {
             let req: Request<Vec<u8>> = inner.list_models_request(&cloned_cfg)?;
             let resp: Response<Vec<u8>> = call_outbound(req).await?;
 
-            inner
-                .parse_list_models(resp)
-                .map_err(|e| LLMError::PluginError(format!("{:#}", e)))
+            inner.parse_list_models(resp)
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    struct ErrorFactory {
+        list_models_uri: Option<String>,
+    }
+
+    impl ErrorFactory {
+        fn new(list_models_uri: Option<String>) -> Self {
+            Self { list_models_uri }
+        }
+    }
+
+    impl HTTPLLMProviderFactory for ErrorFactory {
+        fn name(&self) -> &str {
+            "error-factory"
+        }
+
+        fn config_schema(&self) -> String {
+            "{}".into()
+        }
+
+        fn list_models_request(&self, _cfg: &str) -> Result<Request<Vec<u8>>, LLMError> {
+            let uri = self
+                .list_models_uri
+                .as_deref()
+                .ok_or_else(|| LLMError::NotImplemented("unused".into()))?;
+            Request::get(uri)
+                .body(Vec::new())
+                .map_err(|error| LLMError::InvalidRequest(error.to_string()))
+        }
+
+        fn parse_list_models(&self, _resp: Response<Vec<u8>>) -> Result<Vec<String>, LLMError> {
+            Err(LLMError::JsonError("bad models response".into()))
+        }
+
+        fn from_config(&self, _cfg: &str) -> Result<Box<dyn crate::HTTPLLMProvider>, LLMError> {
+            Err(LLMError::InvalidRequest("bad provider config".into()))
+        }
+    }
+
+    async fn serve_once() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut request = [0; 1024];
+            let _ = socket.read(&mut request).await;
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+                .await
+                .expect("write response");
+        });
+
+        format!("http://{addr}/models")
+    }
+
+    #[test]
+    fn from_config_preserves_typed_error() {
+        let adapter = HTTPFactoryAdapter::new(Arc::new(ErrorFactory::new(None)));
+        let error = adapter.from_config("{}").err().expect("config should fail");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(
+            error,
+            LLMError::InvalidRequest(message) if message == "bad provider config"
+        ));
+    }
+
+    #[tokio::test]
+    async fn parse_list_models_preserves_typed_error() {
+        let adapter =
+            HTTPFactoryAdapter::new(Arc::new(ErrorFactory::new(Some(serve_once().await))));
+        let error = adapter
+            .list_models("{}")
+            .await
+            .expect_err("response parsing should fail");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(
+            error,
+            LLMError::JsonError(message) if message == "bad models response"
+        ));
     }
 }

--- a/crates/querymt/src/plugin/extism_impl/host/mod.rs
+++ b/crates/querymt/src/plugin/extism_impl/host/mod.rs
@@ -57,6 +57,10 @@ fn decode_plugin_error(e: extism::Error, code: i32) -> LLMError {
     PluginError::decode(code, &raw)
 }
 
+fn parse_config_json(cfg: &str) -> Result<Value, LLMError> {
+    serde_json::from_str(cfg).map_err(LLMError::from)
+}
+
 #[cfg(debug_assertions)]
 fn header_token_hint(value: Option<&http::HeaderValue>) -> String {
     let Some(value) = value else {
@@ -81,6 +85,10 @@ fn decode_stream_item(item: Result<Vec<u8>, LLMError>) -> Result<StreamChunk, LL
             .map_err(|e| LLMError::PluginError(format!("Failed to deserialize chunk: {}", e))),
         Err(llm_err) => Err(llm_err),
     }
+}
+
+fn decode_classified_plugin_error(error: PluginError) -> LLMError {
+    LLMError::from_payload(error.payload)
 }
 
 macro_rules! with_host_functions {
@@ -337,6 +345,14 @@ impl ExtismFactory {
     fn validate_runtime_base_url(&self, cfg: &Value) -> Result<(), LLMError> {
         validate_runtime_base_url(&self.name, &self.allowed_hosts, cfg)
     }
+
+    fn validate_plugin_config(&self, cfg: &Value) -> Result<(), LLMError> {
+        let mut plug = self.plugin.lock().unwrap();
+        let _: Json<Value> = plug
+            .call_get_error_code("from_config", Json(cfg.clone()))
+            .map_err(|(e, code)| decode_plugin_error(e, code))?;
+        Ok(())
+    }
 }
 
 fn validate_runtime_base_url(
@@ -385,13 +401,10 @@ impl LLMProviderFactory for ExtismFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn LLMProvider>, LLMError> {
-        let cfg_value: Value = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("Invalid JSON config: {:#}", e)))?;
+        let cfg_value = parse_config_json(cfg)?;
         self.validate_runtime_base_url(&cfg_value)?;
 
-        let _from_cfg = self
-            .call("from_config", &cfg_value)
-            .map_err(|e| LLMError::PluginError(format!("{:#}", e)))?;
+        self.validate_plugin_config(&cfg_value)?;
 
         let provider = ExtismProvider {
             plugin: self.plugin.clone(),
@@ -411,16 +424,9 @@ impl LLMProviderFactory for ExtismFactory {
     fn list_models<'a>(&'a self, cfg: &str) -> Fut<'a, Result<Vec<String>, LLMError>> {
         // list_models can do host HTTP calls, so run the Extism VM call off the Tokio runtime
         // thread to avoid deadlocks on current-thread runtimes.
-        let cfg_value: Value = match serde_json::from_str(cfg) {
-            Ok(v) => v,
-            Err(e) => {
-                return Box::pin(async move {
-                    Err(LLMError::PluginError(format!(
-                        "Invalid JSON config: {:#}",
-                        e
-                    )))
-                });
-            }
+        let cfg_value = match parse_config_json(cfg) {
+            Ok(value) => value,
+            Err(error) => return Box::pin(async move { Err(error) }),
         };
 
         if self.supports_http_adapter_abi() {
@@ -501,13 +507,10 @@ impl HTTPLLMProviderFactory for ExtismFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn crate::HTTPLLMProvider>, LLMError> {
-        let cfg_value: Value = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("Invalid JSON config: {:#}", e)))?;
+        let cfg_value = parse_config_json(cfg)?;
         self.validate_runtime_base_url(&cfg_value)?;
 
-        let _from_cfg = self
-            .call("from_config", &cfg_value)
-            .map_err(|e| LLMError::PluginError(format!("{:#}", e)))?;
+        self.validate_plugin_config(&cfg_value)?;
 
         let provider = ExtismProvider {
             plugin: self.plugin.clone(),
@@ -519,14 +522,9 @@ impl HTTPLLMProviderFactory for ExtismFactory {
     }
 
     fn list_models_static(&self, cfg: &str) -> Option<Result<Vec<String>, LLMError>> {
-        let cfg_value: Value = match serde_json::from_str(cfg) {
-            Ok(v) => v,
-            Err(e) => {
-                return Some(Err(LLMError::PluginError(format!(
-                    "Invalid JSON config: {:#}",
-                    e
-                ))));
-            }
+        let cfg_value = match parse_config_json(cfg) {
+            Ok(value) => value,
+            Err(error) => return Some(Err(error)),
         };
 
         let mut plug = self.plugin.lock().unwrap();
@@ -548,8 +546,7 @@ impl HTTPLLMProviderFactory for ExtismFactory {
     }
 
     fn list_models_request(&self, cfg: &str) -> Result<http::Request<Vec<u8>>, LLMError> {
-        let cfg_value: Value = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("Invalid JSON config: {:#}", e)))?;
+        let cfg_value = parse_config_json(cfg)?;
         self.validate_runtime_base_url(&cfg_value)?;
 
         let mut plug = self.plugin.lock().unwrap();
@@ -613,8 +610,11 @@ impl ExtismProvider {
     where
         F: FnOnce(&mut Plugin) -> Result<T, LLMError>,
     {
-        let mut plug = self.plugin.lock().unwrap();
-        f(&mut plug).map_err(|e| LLMError::PluginError(format!("Extism {op} failed: {:#}", e)))
+        let mut plug = self
+            .plugin
+            .lock()
+            .map_err(|_| LLMError::PluginError(format!("Extism {op} mutex poisoned")))?;
+        f(&mut plug)
     }
 
     async fn call_blocking_with_cancel<T, F>(&self, op: &'static str, f: F) -> Result<T, LLMError>
@@ -1177,6 +1177,51 @@ impl ChatStreamParser for ExtismStreamParser {
 }
 
 impl HTTPChatProvider for ExtismProvider {
+    fn classify_chat_error_async<'a>(
+        &'a self,
+        response: &'a http::Response<Vec<u8>>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = LLMError> + Send + 'a>> {
+        Box::pin(async move {
+            {
+                let plug = match self.plugin.lock() {
+                    Ok(plug) => plug,
+                    Err(_) => {
+                        return LLMError::PluginError(
+                            "Extism classify_chat_error mutex poisoned".into(),
+                        );
+                    }
+                };
+                if !plug.function_exists("classify_chat_error") {
+                    return self.classify_chat_error(response);
+                }
+            }
+
+            let cfg = match self.effective_config() {
+                Ok(cfg) => cfg,
+                Err(error) => return error,
+            };
+            let response = response.clone();
+            match self
+                .call_blocking_with_cancel("classify_chat_error", move |plug| {
+                    let error: Json<PluginError> = plug
+                        .call_get_error_code(
+                            "classify_chat_error",
+                            Json(ExtismChatParseRequest {
+                                cfg,
+                                resp: SerializableHttpResponse { resp: response },
+                            }),
+                        )
+                        .map_err(|(e, code)| decode_plugin_error(e, code))?;
+                    Ok(error.0)
+                })
+                .await
+            {
+                Ok(error) => decode_classified_plugin_error(error),
+                Err(error) => error,
+            }
+        })
+    }
+
     fn chat_request(
         &self,
         messages: &[ChatMessage],
@@ -1384,6 +1429,14 @@ mod tests {
     use crate::chat::StreamChunk;
 
     #[test]
+    fn malformed_config_is_json_error() {
+        let error = parse_config_json("{").expect_err("config should be rejected");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(error, LLMError::JsonError(_)));
+    }
+
+    #[test]
     fn build_allowed_hosts_prefers_configured_base_url_over_plugin_default() {
         let config = Some(HashMap::from([(
             "base_url".to_string(),
@@ -1475,5 +1528,33 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn decode_classified_plugin_error_preserves_structured_context() {
+        let error = crate::error::ProviderFailure::new(
+            crate::error::ProviderErrorKind::ServerOverloaded,
+            "plugin busy",
+        )
+        .with_code(Some("server_is_overloaded".into()))
+        .with_request_id(Some("req-plugin".into()))
+        .with_retry_after_secs(Some(2))
+        .into();
+
+        let decoded = decode_classified_plugin_error(PluginError::from_llm_error(&error));
+
+        match decoded {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.message(), "plugin busy");
+                assert_eq!(
+                    failure.kind(),
+                    crate::error::ProviderErrorKind::ServerOverloaded
+                );
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
     }
 }

--- a/crates/querymt/src/plugin/extism_impl/interface.rs
+++ b/crates/querymt/src/plugin/extism_impl/interface.rs
@@ -67,6 +67,35 @@ impl PluginError {
     }
 }
 
+#[cfg(test)]
+mod plugin_error_tests {
+    use super::*;
+    use crate::error::{ProviderErrorKind, ProviderFailure};
+
+    #[test]
+    fn structured_provider_error_round_trips_across_plugin_boundary() {
+        let error = LLMError::from(
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "plugin busy")
+                .with_code(Some("server_is_overloaded".into()))
+                .with_request_id(Some("req-plugin".into()))
+                .with_retry_after_secs(Some(2)),
+        );
+
+        let (json, code) = PluginError::encode(&error);
+        let decoded = PluginError::decode(code, &json);
+
+        match decoded {
+            LLMError::ProviderResponseError(failure) => {
+                assert_eq!(failure.kind(), ProviderErrorKind::ServerOverloaded);
+                assert_eq!(failure.code(), Some("server_is_overloaded"));
+                assert_eq!(failure.request_id(), Some("req-plugin"));
+                assert_eq!(failure.retry_after_secs(), Some(2));
+            }
+            other => panic!("expected ProviderResponseError, got {other}"),
+        }
+    }
+}
+
 // ============================================================================
 // HTTP streaming result type
 // ============================================================================

--- a/crates/querymt/src/plugin/http.rs
+++ b/crates/querymt/src/plugin/http.rs
@@ -38,6 +38,14 @@ pub trait HTTPLLMProviderFactory: Send + Sync {
 #[allow(improper_ctypes_definitions)]
 pub type HTTPFactoryCtor = unsafe extern "C" fn() -> *mut dyn HTTPLLMProviderFactory;
 
+/// Classify a non-success HTTP response with the **generic** status classifier
+/// (legacy [`crate::error::LLMError`] variants).
+///
+/// Use this on paths the HTTP adapter does **not** pre-classify — e.g.
+/// completions, embeddings, STT/TTS, list-models.
+///
+/// **Do not** use on chat `parse_chat` / stream parsers. Chat non-success is
+/// owned by [`crate::chat::http::HTTPChatProvider::classify_chat_error`].
 #[macro_export]
 macro_rules! handle_http_error {
     ($resp:expr) => {{


### PR DESCRIPTION
## what changed

- add bounded retry policy configuration and validation
- use one physical-request budget across stream setup and parser/eof recovery
- reserve every physical attempt explicitly and preserve the final typed error on exhaustion
- route retryable setup, parser, eof, and malformed-terminal failures through one ordered wait/resume path
- preserve temporary any-stage stream recreation with post-output warning and rollback todo
- keep the reduced console-only ui event stub

## review boundary

this pr is generic agent retry policy only. it does not change provider classification or responses parsing.

## stack

#750 -> #751 -> #752 -> #754 -> **#755** -> #765
