### PR TITLE
fix(providers): preserve config parse errors

### DIFF
--- a/crates/providers/mrs/src/factory.rs
+++ b/crates/providers/mrs/src/factory.rs
@@ -47,8 +47,7 @@ impl LLMProviderFactory for MistralRSFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn querymt::LLMProvider>, LLMError> {
-        let cfg: MistralRSConfig = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("mistral.rs config error: {}", e)))?;
+        let cfg: MistralRSConfig = serde_json::from_str(cfg)?;
 
         let provider = MistralRS::new_with_cache(cfg, &self.model_cache)?;
         Ok(Box::new(provider))

--- a/crates/providers/mrs/src/tests.rs
+++ b/crates/providers/mrs/src/tests.rs
@@ -2,13 +2,12 @@ use querymt::LLMProvider;
 use querymt::chat::{ChatMessageBuilder, ChatRole};
 use querymt::completion::CompletionRequest;
 use querymt::error::LLMError;
-use querymt::plugin::LLMProviderFactory;
 
 use crate::config::MistralRSConfig;
-use crate::factory::MistralRSFactory;
+use crate::factory::create_factory;
 
 fn get_provider() -> Box<dyn LLMProvider> {
-    let factory = MistralRSFactory {};
+    let factory = create_factory();
     let cfg = MistralRSConfig {
         model: "microsoft/Phi-3.5-mini-instruct".to_string(),
         model_kind: None,
@@ -46,6 +45,17 @@ fn get_provider() -> Box<dyn LLMProvider> {
 
     let json_cfg = serde_json::to_string(&cfg).unwrap();
     factory.from_config(&json_cfg).unwrap()
+}
+
+#[test]
+fn malformed_config_is_non_retryable_json_error() {
+    let error = create_factory()
+        .from_config("{")
+        .err()
+        .expect("config should be rejected");
+
+    assert!(!error.is_retryable());
+    assert!(matches!(error, LLMError::JsonError(_)));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/providers/openrouter/src/lib.rs
+++ b/crates/providers/openrouter/src/lib.rs
@@ -241,8 +241,7 @@ impl HTTPLLMProviderFactory for OpenRouterFactory {
     }
 
     fn from_config(&self, cfg: &str) -> Result<Box<dyn HTTPLLMProvider>, LLMError> {
-        let provider: OpenRouter = serde_json::from_str(cfg)
-            .map_err(|e| LLMError::PluginError(format!("OpenRouter config error: {}", e)))?;
+        let provider: OpenRouter = serde_json::from_str(cfg)?;
 
         // 2) Done—our OpenAI::send/chat/etc methods will lazily build the Client
         Ok(Box::new(provider))
@@ -274,8 +273,9 @@ mod extism_exports {
 
 #[cfg(test)]
 mod tests {
-    use super::OpenRouter;
+    use super::{OpenRouter, OpenRouterFactory};
     use querymt::chat::{StreamChunk, http::HTTPChatProvider};
+    use querymt::{error::LLMError, plugin::HTTPLLMProviderFactory};
     use serde_json::Value;
 
     fn test_provider() -> OpenRouter {
@@ -284,6 +284,17 @@ mod tests {
             "model": "openai/gpt-4o-mini"
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn malformed_config_is_non_retryable_json_error() {
+        let error = OpenRouterFactory
+            .from_config("{")
+            .err()
+            .expect("config should be rejected");
+
+        assert!(!error.is_retryable());
+        assert!(matches!(error, LLMError::JsonError(_)));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- propagate OpenRouter config deserialization failures as `JsonError`
- propagate mistral.rs config deserialization failures as `JsonError`
- add focused regressions proving malformed configuration is non-retryable
- update the existing MRS test helper to use its public factory constructor

## Why

Both factories previously converted deterministic JSON/config parse failures into retryable `PluginError`. Classification belongs at the source, while adapter, session, and retry layers should preserve and process the resulting `LLMError` unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p qmt-openrouter --no-default-features --features native --lib malformed_config_is_non_retryable_json_error`
- `cargo test -p qmt-mrs --lib malformed_config_is_non_retryable_json_error`
- `cargo check -p qmt-openrouter --no-default-features --features native`
- `cargo check -p qmt-mrs`
- `git diff --check`

## Stack

This PR is the third corrective slice:

`split/provider-error-attribution` -> `split/provider-init-error-attribution` (#758) -> `split/extism-config-error-preservation` (#759) -> `split/provider-config-error-classification` (this PR)

It intentionally excludes response classifiers, retry-policy tests, provider/model diagnostics context, ACP/remote propagation, and stream behavior.