### PR TITLE
fix(agent): validate UUID v7 semantically

### DIFF
--- a/crates/agent/tests/hybrid_id_scheme_test.rs
+++ b/crates/agent/tests/hybrid_id_scheme_test.rs
@@ -4,7 +4,7 @@ use querymt_agent::session::store::SessionStore;
 use tempfile::TempDir;
 use time::OffsetDateTime;
 use tokio::time::{Duration, sleep};
-use uuid::Uuid;
+use uuid::{Uuid, Version};
 
 async fn create_test_store() -> (TempDir, SqliteStorage) {
     let temp_dir = TempDir::new().expect("temp dir");
@@ -23,9 +23,11 @@ async fn test_hybrid_id_scheme() {
         .expect("session");
     assert!(session.id > 0, "Should have INTEGER primary key");
     assert_eq!(session.public_id.len(), 36, "Should have UUID public_id");
-    assert!(
-        session.public_id.starts_with("019"),
-        "UUID v7 starts with timestamp"
+    let public_id = Uuid::parse_str(&session.public_id).expect("public_id must be a valid UUID");
+    assert_eq!(
+        public_id.get_version(),
+        Some(Version::SortRand),
+        "public_id must be UUID v7"
     );
 
     let retrieved = store


### PR DESCRIPTION
## what changed

- parse generated session `public_id` values as UUIDs
- assert the UUID version is v7 (`Version::SortRand`)
- remove the date-dependent `starts_with("019")` assertion

## why

UUID v7 begins with its Unix timestamp encoded as hexadecimal. The timestamp prefix rolled from `019` to `01a` in August 2026, so the existing assertion now rejects valid UUID v7 values and fails the agent test suite.

## tdd evidence

red before the change:

```text
test_hybrid_id_scheme ... FAILED
UUID v7 starts with timestamp
```

green after the change:

- exact target: 1 passed
- full integration file: 3 passed in debug
- full integration file: 3 passed in release
- focused test-target clippy with warnings denied
- formatting and diff checks
