### PR TITLE
fix(agent): preserve structured provider errors in acp responses

### DIFF
--- a/crates/agent/src/agent/remote/actor_ref.rs
+++ b/crates/agent/src/agent/remote/actor_ref.rs
@@ -114,6 +114,15 @@ impl SessionActorRef {
     const REMOTE_HISTORY_REPLY_TIMEOUT: Duration = Duration::from_secs(60);
     const REMOTE_IO_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 
+    pub(super) fn map_local_prompt_send_error(
+        error: kameo::error::SendError<messages::Prompt, AgentError>,
+    ) -> AcpError {
+        AcpError::from(match error {
+            kameo::error::SendError::HandlerError(err) => err,
+            other => AgentError::RemoteActor(other.to_string()),
+        })
+    }
+
     fn map_infallible_remote_send_error(
         error: kameo::error::RemoteSendError<kameo::error::Infallible>,
     ) -> AgentError {
@@ -164,7 +173,7 @@ impl SessionActorRef {
             Self::Local(actor_ref) => actor_ref
                 .ask(messages::Prompt { req })
                 .await
-                .map_err(|e| AcpError::from(AgentError::RemoteActor(e.to_string()))),
+                .map_err(Self::map_local_prompt_send_error),
 
             #[cfg(feature = "remote")]
             Self::Remote { actor_ref, .. } => actor_ref

--- a/crates/agent/src/agent/remote/actor_ref_tests.rs
+++ b/crates/agent/src/agent/remote/actor_ref_tests.rs
@@ -1,0 +1,48 @@
+use super::SessionActorRef;
+use crate::agent::messages;
+use crate::error::AgentError;
+use agent_client_protocol::ErrorCode;
+use querymt::error::LLMErrorPayload;
+
+#[test]
+fn local_prompt_handler_error_preserves_structured_provider_data() {
+    let error = kameo::error::SendError::HandlerError(AgentError::ProviderFailure {
+        message: "LLM streaming error".to_string(),
+        provider: Some("openrouter".to_string()),
+        model: Some("qwen/qwen3.5-122b-a10b".to_string()),
+        retryable: false,
+        error: LLMErrorPayload::NotImplemented {
+            message: "Streaming request construction not supported by this HTTP provider"
+                .to_string(),
+        },
+    });
+
+    let acp = SessionActorRef::map_local_prompt_send_error(error);
+
+    assert_eq!(acp.code, ErrorCode::Other(-32010));
+    assert_eq!(
+        acp.data,
+        Some(serde_json::json!({
+            "category": "provider",
+            "kind": "unsupported_operation",
+            "message": "Streaming request construction not supported by this HTTP provider",
+            "provider": "openrouter",
+            "model": "qwen/qwen3.5-122b-a10b",
+            "retryable": false,
+            "error": {
+                "type": "not_implemented",
+                "message": "Streaming request construction not supported by this HTTP provider"
+            }
+        }))
+    );
+}
+
+#[test]
+fn local_prompt_transport_error_remains_internal() {
+    let error = kameo::error::SendError::<messages::Prompt, AgentError>::ActorStopped;
+
+    let acp = SessionActorRef::map_local_prompt_send_error(error);
+
+    assert_eq!(acp.code, ErrorCode::InternalError);
+    assert!(acp.message.contains("actor stopped"));
+}

--- a/crates/agent/src/agent/remote/actor_ref_tests.rs
+++ b/crates/agent/src/agent/remote/actor_ref_tests.rs
@@ -11,10 +11,10 @@ fn local_prompt_handler_error_preserves_structured_provider_data() {
         provider: Some("openrouter".to_string()),
         model: Some("qwen/qwen3.5-122b-a10b".to_string()),
         retryable: false,
-        error: LLMErrorPayload::NotImplemented {
+        error: Box::new(LLMErrorPayload::NotImplemented {
             message: "Streaming request construction not supported by this HTTP provider"
                 .to_string(),
-        },
+        }),
     });
 
     let acp = SessionActorRef::map_local_prompt_send_error(error);

--- a/crates/agent/src/agent/remote/mod.rs
+++ b/crates/agent/src/agent/remote/mod.rs
@@ -62,6 +62,9 @@ mod remote_actor_impl;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod actor_ref_tests;
+
 // ── Test modules (remote feature) ────────────────────────────────────────────
 
 #[cfg(all(test, feature = "remote"))]

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -24,6 +24,7 @@ use kameo::message::{Context, Message};
 use kameo::reply::DelegatedReply;
 use log::{debug, info, warn};
 use querymt::chat::{ChatRole, ReasoningEffort};
+use querymt::error::LLMError;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, oneshot};
@@ -2013,15 +2014,35 @@ async fn execute_prompt_detached(
         Ok(CycleOutcome::Cancelled) => Ok(PromptResponse::new(StopReason::Cancelled)),
         Ok(CycleOutcome::Stopped(stop_reason)) => Ok(PromptResponse::new(stop_reason)),
         Err(e) => {
+            let message = e.to_string();
             config.emit_event(
                 &session_id,
                 AgentEventKind::Error {
-                    message: e.to_string(),
+                    message: message.clone(),
                 },
             );
-            Err(AgentError::Internal(e.to_string()))
+            Err(provider_failure_from_execution_error(&e, &exec_ctx)
+                .unwrap_or(AgentError::Internal(message)))
         }
     }
+}
+
+fn provider_failure_from_execution_error(
+    error: &anyhow::Error,
+    exec_ctx: &ExecutionContext,
+) -> Option<AgentError> {
+    let llm_error = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<LLMError>())?;
+    let llm_config = exec_ctx.llm_config();
+
+    Some(AgentError::ProviderFailure {
+        message: error.to_string(),
+        provider: llm_config.map(|config| config.provider.clone()),
+        model: llm_config.map(|config| config.model.clone()),
+        retryable: llm_error.is_retryable(),
+        error: llm_error.to_payload(),
+    })
 }
 
 #[instrument(

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -2041,7 +2041,7 @@ fn provider_failure_from_execution_error(
         provider: llm_config.map(|config| config.provider.clone()),
         model: llm_config.map(|config| config.model.clone()),
         retryable: llm_error.is_retryable(),
-        error: llm_error.to_payload(),
+        error: Box::new(llm_error.to_payload()),
     })
 }
 
@@ -2104,6 +2104,7 @@ mod tests {
     use crate::agent::agent_config_builder::AgentConfigBuilder;
     use crate::agent::core::ToolPolicy;
     use crate::session::backend::StorageBackend;
+    use crate::session::runtime::RuntimeContext;
     use crate::session::store::SessionStore;
     use crate::test_utils::{
         MockLlmProvider, MockSessionStore, SharedLlmProvider, TestProviderFactory, mock_llm_config,
@@ -2111,6 +2112,7 @@ mod tests {
     };
     use kameo::actor::Spawn;
     use querymt::LLMParams;
+    use querymt::error::{LLMErrorPayload, ProviderErrorKind, ProviderFailure};
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -2128,6 +2130,32 @@ mod tests {
     impl ActorFixture {
         async fn new() -> Self {
             Self::with_session_id("test-session").await
+        }
+
+        async fn execution_context(&self, session_id: &str) -> ExecutionContext {
+            let session_handle = self
+                .config
+                .provider
+                .with_session(session_id)
+                .await
+                .expect("load session handle");
+            let runtime_context =
+                RuntimeContext::new(self.config.provider.history_store(), session_id.to_string())
+                    .await
+                    .expect("create runtime context");
+            let runtime = crate::agent::core::SessionRuntime::new(
+                None,
+                HashMap::new(),
+                crate::agent::core::McpToolState::empty(),
+            );
+
+            ExecutionContext::new(
+                session_id.to_string(),
+                runtime,
+                runtime_context,
+                session_handle,
+                ToolConfig::default(),
+            )
         }
 
         async fn with_session_id(session_id: &str) -> Self {
@@ -2157,6 +2185,10 @@ mod tests {
             store
                 .expect_get_llm_config()
                 .returning(move |_| Ok(Some(llm_config_for_mock.clone())))
+                .times(0..);
+            store
+                .expect_get_session_execution_config()
+                .returning(|_| Ok(None))
                 .times(0..);
             store
                 .expect_create_or_get_llm_config()
@@ -2215,6 +2247,59 @@ mod tests {
                 _temp_dir: temp_dir,
             }
         }
+    }
+
+    #[tokio::test]
+    async fn provider_failure_recovers_contextualized_llm_error() {
+        let fixture = ActorFixture::new().await;
+        let exec_ctx = fixture.execution_context("test-session").await;
+        let llm_error = LLMError::from(
+            ProviderFailure::new(ProviderErrorKind::ServerOverloaded, "provider is busy")
+                .with_code(Some("server_overloaded".to_string()))
+                .with_error_type(Some("api_error".to_string()))
+                .with_request_id(Some("req-123".to_string()))
+                .with_retry_after_secs(Some(3)),
+        );
+        let error = anyhow::Error::new(llm_error).context("execute cycle failed");
+
+        let provider_failure = provider_failure_from_execution_error(&error, &exec_ctx)
+            .expect("recover provider failure");
+
+        match provider_failure {
+            AgentError::ProviderFailure {
+                message,
+                provider,
+                model,
+                retryable,
+                error,
+            } => {
+                assert_eq!(message, "execute cycle failed");
+                assert_eq!(provider.as_deref(), Some("mock"));
+                assert_eq!(model.as_deref(), Some("mock-model"));
+                assert!(retryable);
+                assert_eq!(
+                    *error,
+                    LLMErrorPayload::ProviderError {
+                        message: "provider is busy".to_string(),
+                        kind: Some(ProviderErrorKind::ServerOverloaded),
+                        code: Some("server_overloaded".to_string()),
+                        error_type: Some("api_error".to_string()),
+                        request_id: Some("req-123".to_string()),
+                        retry_after_secs: Some(3),
+                    }
+                );
+            }
+            other => panic!("expected provider failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_failure_ignores_non_llm_error_chain() {
+        let fixture = ActorFixture::new().await;
+        let exec_ctx = fixture.execution_context("test-session").await;
+        let error = anyhow::anyhow!("storage unavailable").context("execute cycle failed");
+
+        assert!(provider_failure_from_execution_error(&error, &exec_ctx).is_none());
     }
 
     // ── Actor message handler tests ──────────────────────────────────────────

--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -5,6 +5,7 @@
 //! error code via the `From<AgentError> for AcpError` impl.
 
 use agent_client_protocol::Error as AcpError;
+use querymt::error::{LLMErrorPayload, ProviderErrorKind};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -55,6 +56,15 @@ pub enum AgentError {
     #[error("provider chat failed ({operation}): {reason}")]
     ProviderChat { operation: String, reason: String },
 
+    #[error("provider request failed: {message}")]
+    ProviderFailure {
+        message: String,
+        provider: Option<String>,
+        model: Option<String>,
+        retryable: bool,
+        error: LLMErrorPayload,
+    },
+
     // --- Client bridge ---
     #[error("client bridge closed")]
     ClientBridgeClosed,
@@ -99,6 +109,26 @@ pub enum AgentError {
 /// | -32603  | InternalError      | everything else (replaces the old -32000 catch-all) |
 impl From<AgentError> for AcpError {
     fn from(e: AgentError) -> Self {
+        if let AgentError::ProviderFailure {
+            message,
+            provider,
+            model,
+            retryable,
+            error,
+        } = &e
+        {
+            let (kind, provider_message) = provider_error_metadata(error);
+            return AcpError::new(-32010, "Provider request failed").data(serde_json::json!({
+                "category": "provider",
+                "kind": kind,
+                "message": provider_message.unwrap_or_else(|| message.clone()),
+                "provider": provider,
+                "model": model,
+                "retryable": retryable,
+                "error": error,
+            }));
+        }
+
         let code: i32 = match &e {
             AgentError::MethodNotImplemented { .. } => -32601, // MethodNotFound
             AgentError::SessionNotFound { .. }
@@ -107,6 +137,28 @@ impl From<AgentError> for AcpError {
             _ => -32603,                                       // InternalError
         };
         AcpError::new(code, e.to_string())
+    }
+}
+
+fn provider_error_metadata(error: &LLMErrorPayload) -> (Option<ProviderErrorKind>, Option<String>) {
+    match error {
+        LLMErrorPayload::ProviderError { message, kind, .. } => (*kind, Some(message.clone())),
+        LLMErrorPayload::RateLimited { message, .. } => {
+            (Some(ProviderErrorKind::RateLimited), Some(message.clone()))
+        }
+        LLMErrorPayload::AuthError { message } => (
+            Some(ProviderErrorKind::Authentication),
+            Some(message.clone()),
+        ),
+        LLMErrorPayload::InvalidRequest { message } => (
+            Some(ProviderErrorKind::InvalidRequest),
+            Some(message.clone()),
+        ),
+        LLMErrorPayload::NotImplemented { message } => (
+            Some(ProviderErrorKind::UnsupportedOperation),
+            Some(message.clone()),
+        ),
+        _ => (None, None),
     }
 }
 
@@ -224,6 +276,110 @@ mod tests {
         assert_eq!(acp.code, ErrorCode::InternalError);
         assert!(acp.message.contains("chat_with_tools"));
         assert!(acp.message.contains("rate limit"));
+    }
+
+    #[test]
+    fn structured_quota_failure_maps_to_provider_acp_error() {
+        let acp: AcpError = AgentError::ProviderFailure {
+            message: "LLM streaming error".to_string(),
+            provider: Some("codex".to_string()),
+            model: Some("gpt-5.6-sol".to_string()),
+            retryable: false,
+            error: LLMErrorPayload::ProviderError {
+                message: "The usage limit has been reached".to_string(),
+                kind: Some(ProviderErrorKind::QuotaExceeded),
+                code: Some("usage_limit_reached".to_string()),
+                error_type: Some("usage_limit_reached".to_string()),
+                request_id: None,
+                retry_after_secs: None,
+            },
+        }
+        .into();
+
+        assert_eq!(acp.code, ErrorCode::Other(-32010));
+        assert_eq!(acp.message, "Provider request failed");
+        assert_eq!(
+            acp.data,
+            Some(serde_json::json!({
+                "category": "provider",
+                "kind": "quota_exceeded",
+                "message": "The usage limit has been reached",
+                "provider": "codex",
+                "model": "gpt-5.6-sol",
+                "retryable": false,
+                "error": {
+                    "type": "provider_error",
+                    "message": "The usage limit has been reached",
+                    "kind": "quota_exceeded",
+                    "code": "usage_limit_reached",
+                    "error_type": "usage_limit_reached"
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn structured_unsupported_operation_maps_to_provider_acp_error() {
+        let acp: AcpError = AgentError::ProviderFailure {
+            message: "LLM streaming error".to_string(),
+            provider: Some("openrouter".to_string()),
+            model: Some("qwen/qwen3.5-122b-a10b".to_string()),
+            retryable: false,
+            error: LLMErrorPayload::NotImplemented {
+                message: "Streaming request construction not supported by this HTTP provider"
+                    .to_string(),
+            },
+        }
+        .into();
+
+        assert_eq!(acp.code, ErrorCode::Other(-32010));
+        assert_eq!(
+            acp.data,
+            Some(serde_json::json!({
+                "category": "provider",
+                "kind": "unsupported_operation",
+                "message": "Streaming request construction not supported by this HTTP provider",
+                "provider": "openrouter",
+                "model": "qwen/qwen3.5-122b-a10b",
+                "retryable": false,
+                "error": {
+                    "type": "not_implemented",
+                    "message": "Streaming request construction not supported by this HTTP provider"
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn structured_auth_failure_maps_to_provider_acp_error() {
+        let acp: AcpError = AgentError::ProviderFailure {
+            message: "LLM provider initialization error".to_string(),
+            provider: Some("groq".to_string()),
+            model: Some("openai/gpt-oss-20b".to_string()),
+            retryable: false,
+            error: LLMErrorPayload::AuthError {
+                message: "No API key found for provider 'groq'. Set GROQ_API_KEY or run 'qmt auth login groq'"
+                    .to_string(),
+            },
+        }
+        .into();
+
+        assert_eq!(acp.code, ErrorCode::Other(-32010));
+        assert_eq!(
+            acp.data,
+            Some(serde_json::json!({
+                "category": "provider",
+                "kind": "authentication",
+                "message": "No API key found for provider 'groq'. Set GROQ_API_KEY or run 'qmt auth login groq'",
+                "provider": "groq",
+                "model": "openai/gpt-oss-20b",
+                "retryable": false,
+                "error": {
+                    "type": "auth_error",
+                    "message": "No API key found for provider 'groq'. Set GROQ_API_KEY or run 'qmt auth login groq'"
+                }
+            }))
+        );
     }
 
     #[test]

--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -62,7 +62,7 @@ pub enum AgentError {
         provider: Option<String>,
         model: Option<String>,
         retryable: bool,
-        error: LLMErrorPayload,
+        error: Box<LLMErrorPayload>,
     },
 
     // --- Client bridge ---
@@ -285,14 +285,14 @@ mod tests {
             provider: Some("codex".to_string()),
             model: Some("gpt-5.6-sol".to_string()),
             retryable: false,
-            error: LLMErrorPayload::ProviderError {
+            error: Box::new(LLMErrorPayload::ProviderError {
                 message: "The usage limit has been reached".to_string(),
                 kind: Some(ProviderErrorKind::QuotaExceeded),
                 code: Some("usage_limit_reached".to_string()),
                 error_type: Some("usage_limit_reached".to_string()),
                 request_id: None,
                 retry_after_secs: None,
-            },
+            }),
         }
         .into();
 
@@ -325,10 +325,10 @@ mod tests {
             provider: Some("openrouter".to_string()),
             model: Some("qwen/qwen3.5-122b-a10b".to_string()),
             retryable: false,
-            error: LLMErrorPayload::NotImplemented {
+            error: Box::new(LLMErrorPayload::NotImplemented {
                 message: "Streaming request construction not supported by this HTTP provider"
                     .to_string(),
-            },
+            }),
         }
         .into();
 
@@ -357,10 +357,10 @@ mod tests {
             provider: Some("groq".to_string()),
             model: Some("openai/gpt-oss-20b".to_string()),
             retryable: false,
-            error: LLMErrorPayload::AuthError {
+            error: Box::new(LLMErrorPayload::AuthError {
                 message: "No API key found for provider 'groq'. Set GROQ_API_KEY or run 'qmt auth login groq'"
                     .to_string(),
-            },
+            }),
         }
         .into();
 

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -276,7 +276,7 @@ impl SessionStore for SqliteStorage {
                 "INSERT INTO sessions (public_id, name, cwd, created_at, updated_at, llm_config_id, parent_session_id, fork_origin, fork_point_type, fork_point_ref) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     new_session_public_id.clone(),
-                    format!("Fork of session"), // Temporary name
+                    "Fork of session", // Temporary name
                     parent_cwd,
                     now.clone(),
                     now,

--- a/crates/querymt/src/error.rs
+++ b/crates/querymt/src/error.rs
@@ -24,6 +24,7 @@ pub enum ProviderErrorKind {
     ContextWindowExceeded,
     Authentication,
     InvalidRequest,
+    UnsupportedOperation,
     /// Unclassified vendor failure treated as transient (e.g. bare 5xx).
     /// Retryability lives **only** on the kind — there is no parallel
     /// `transient` flag that can disagree.
@@ -37,7 +38,7 @@ impl ProviderErrorKind {
     /// Unified retry policy for provider failures.
     ///
     /// QueryMT product choice: overload is retried (upstream Codex marks it
-    /// non-retryable). Quota/context/auth/request failures never are.
+    /// non-retryable). Quota/context/auth/request/unsupported failures never are.
     /// [`Self::UnknownTransient`] / [`Self::UnknownPermanent`] cover unmapped
     /// vendor envelopes without a second field.
     pub fn is_retryable(self) -> bool {
@@ -1237,6 +1238,12 @@ mod tests {
             "no credits",
         ));
         assert!(!quota.is_retryable());
+
+        let unsupported = LLMError::from(ProviderFailure::new(
+            ProviderErrorKind::UnsupportedOperation,
+            "streaming is unavailable",
+        ));
+        assert!(!unsupported.is_retryable());
     }
 
     #[test]


### PR DESCRIPTION
preserve structured provider failures across prompt execution and local actor sends so acp clients receive typed error metadata.

tests: `cargo fmt --all -- --check`; `cargo test -p querymt-agent error::tests --lib`; `cargo test -p querymt-agent agent::remote::actor_ref_tests --lib`; `cargo test -p querymt error::tests --lib`