### PR TITLE
fix(llama.cpp): correct finish reason

### DIFF
--- a/crates/providers/llama-cpp/src/generation.rs
+++ b/crates/providers/llama-cpp/src/generation.rs
@@ -8,7 +8,7 @@ use crate::context::{
 };
 use crate::messages;
 use crate::multimodal::MultimodalContext;
-use crate::response::GeneratedText;
+use crate::response::{GeneratedText, GenerationTermination};
 use crate::tools::sampler::{SamplingParams, build_fallback_sampler, build_standard_sampler};
 use futures::channel::mpsc;
 use llama_cpp_2::context::params::LlamaContextParams;
@@ -156,7 +156,7 @@ pub(crate) fn generate(
             None,
             |token| {
                 output.push_str(&decode_token_piece(model, &mut decoder, &preserved, token)?);
-                Ok(true)
+                Ok(None)
             },
         )?;
         return Ok(GeneratedText {
@@ -168,6 +168,7 @@ pub(crate) fn generate(
                 cache_write: 0,
                 reasoning_tokens: 0,
             },
+            termination: stats.termination,
         });
     }
     if cfg.speculative.is_some() && !bitmaps.is_empty() {
@@ -283,6 +284,7 @@ pub(crate) fn generate(
                     cache_write: 0,
                     reasoning_tokens: 0,
                 },
+                termination: GenerationTermination::MaxTokens,
             });
         }
 
@@ -341,6 +343,7 @@ pub(crate) fn generate(
                     cache_write: 0,
                     reasoning_tokens: 0,
                 },
+                termination: GenerationTermination::MaxTokens,
             });
         }
 
@@ -392,6 +395,7 @@ pub(crate) fn generate(
     let mut batch = LlamaBatch::new(n_batch as usize, 1);
     let mut output_tokens = 0u32;
     let mut output = String::new();
+    let mut termination = GenerationTermination::MaxTokens;
     let mut decoder = encoding_rs::UTF_8.new_decoder();
     let preserved = preserved_token_set(model, None);
     while n_cur < n_len_total {
@@ -408,6 +412,7 @@ pub(crate) fn generate(
                 fallback_used = true;
                 continue;
             }
+            termination = GenerationTermination::Eog;
             break;
         }
 
@@ -434,6 +439,7 @@ pub(crate) fn generate(
             cache_write: 0,
             reasoning_tokens: 0,
         },
+        termination,
     })
 }
 
@@ -457,7 +463,7 @@ pub(crate) fn generate_streaming_with_thinking(
     tx: &mpsc::UnboundedSender<Result<querymt::chat::StreamChunk, LLMError>>,
     mm_ctx: Option<&MultimodalContext>,
     bitmaps: &[MtmdBitmap],
-) -> Result<Usage, LLMError> {
+) -> Result<(Usage, GenerationTermination), LLMError> {
     if cfg.speculative.is_some() && bitmaps.is_empty() {
         let mut stream_state = result.streaming_state();
         let mut decoder = encoding_rs::UTF_8.new_decoder();
@@ -478,10 +484,10 @@ pub(crate) fn generate_streaming_with_thinking(
                         ParsedDelta::Thinking(v) => querymt::chat::StreamChunk::Thinking(v),
                     };
                     if tx.unbounded_send(Ok(chunk)).is_err() {
-                        return Ok(false);
+                        return Ok(Some(GenerationTermination::ConsumerClosed));
                     }
                 }
-                Ok(true)
+                Ok(None)
             },
         )?;
         for delta in stream_state.finish() {
@@ -491,13 +497,16 @@ pub(crate) fn generate_streaming_with_thinking(
             };
             let _ = tx.unbounded_send(Ok(chunk));
         }
-        return Ok(Usage {
-            input_tokens: stats.input_tokens,
-            output_tokens: stats.output_tokens,
-            cache_read: 0,
-            cache_write: 0,
-            reasoning_tokens: 0,
-        });
+        return Ok((
+            Usage {
+                input_tokens: stats.input_tokens,
+                output_tokens: stats.output_tokens,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning_tokens: 0,
+            },
+            stats.termination,
+        ));
     }
     let backend = llama_backend()?;
 
@@ -594,13 +603,16 @@ pub(crate) fn generate_streaming_with_thinking(
         }
 
         if max_tokens == 0 {
-            return Ok(Usage {
-                input_tokens: total_tokens as u32,
-                output_tokens: 0,
-                cache_read: 0,
-                cache_write: 0,
-                reasoning_tokens: 0,
-            });
+            return Ok((
+                Usage {
+                    input_tokens: total_tokens as u32,
+                    output_tokens: 0,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning_tokens: 0,
+                },
+                GenerationTermination::MaxTokens,
+            ));
         }
 
         let n_len_total = total_tokens as i32 + max_tokens as i32;
@@ -641,13 +653,16 @@ pub(crate) fn generate_streaming_with_thinking(
             ));
         }
         if max_tokens == 0 {
-            return Ok(Usage {
-                input_tokens: tokens.len() as u32,
-                output_tokens: 0,
-                cache_read: 0,
-                cache_write: 0,
-                reasoning_tokens: 0,
-            });
+            return Ok((
+                Usage {
+                    input_tokens: tokens.len() as u32,
+                    output_tokens: 0,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning_tokens: 0,
+                },
+                GenerationTermination::MaxTokens,
+            ));
         }
 
         let n_len_total = tokens.len() as i32 + max_tokens as i32;
@@ -692,6 +707,7 @@ pub(crate) fn generate_streaming_with_thinking(
     let mut n_cur = n_past;
     let n_len_total = n_past + max_tokens as i32;
     let mut output_tokens = 0u32;
+    let mut termination = GenerationTermination::MaxTokens;
     let mut decoder = encoding_rs::UTF_8.new_decoder();
     let preserved = preserved_token_set(model, Some(result));
 
@@ -703,6 +719,7 @@ pub(crate) fn generate_streaming_with_thinking(
                 fallback_used = true;
                 continue;
             }
+            termination = GenerationTermination::Eog;
             break;
         }
 
@@ -714,13 +731,16 @@ pub(crate) fn generate_streaming_with_thinking(
                 ParsedDelta::Thinking(thinking) => querymt::chat::StreamChunk::Thinking(thinking),
             };
             if tx.unbounded_send(Ok(stream_chunk)).is_err() {
-                return Ok(Usage {
-                    input_tokens: input_tokens as u32,
-                    output_tokens,
-                    cache_read: 0,
-                    cache_write: 0,
-                    reasoning_tokens: 0,
-                });
+                return Ok((
+                    Usage {
+                        input_tokens: input_tokens as u32,
+                        output_tokens,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning_tokens: 0,
+                    },
+                    GenerationTermination::ConsumerClosed,
+                ));
             }
         }
 
@@ -745,11 +765,14 @@ pub(crate) fn generate_streaming_with_thinking(
         }
     }
 
-    Ok(Usage {
-        input_tokens: input_tokens as u32,
-        output_tokens,
-        cache_read: 0,
-        cache_write: 0,
-        reasoning_tokens: 0,
-    })
+    Ok((
+        Usage {
+            input_tokens: input_tokens as u32,
+            output_tokens,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning_tokens: 0,
+        },
+        termination,
+    ))
 }

--- a/crates/providers/llama-cpp/src/mtp.rs
+++ b/crates/providers/llama-cpp/src/mtp.rs
@@ -1,6 +1,7 @@
 use crate::backend::llama_backend;
 use crate::config::LlamaCppConfig;
 use crate::context::{apply_context_params, resolve_n_batch, resolve_n_ubatch};
+use crate::response::GenerationTermination;
 use crate::tools::sampler::{SamplingParams, build_standard_sampler};
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::context::params::{LlamaContextParams, LlamaContextType};
@@ -22,6 +23,7 @@ pub(crate) struct MtpRunStats {
     pub rounds: u32,
     pub drafted: u32,
     pub accepted: u32,
+    pub termination: GenerationTermination,
 }
 
 fn clear_from(ctx: &mut LlamaContext<'_>, pos: i32, which: &str) -> Result<(), LLMError> {
@@ -81,7 +83,7 @@ pub(crate) fn run_mtp(
     max_tokens: u32,
     temperature: Option<f32>,
     sampler: Option<LlamaSampler>,
-    mut on_token: impl FnMut(LlamaToken) -> Result<bool, LLMError>,
+    mut on_token: impl FnMut(LlamaToken) -> Result<Option<GenerationTermination>, LLMError>,
 ) -> Result<MtpRunStats, LLMError> {
     let speculative_cfg = cfg
         .speculative
@@ -191,10 +193,15 @@ pub(crate) fn run_mtp(
 
     'generate: while stats.output_tokens < max_tokens {
         if model.is_eog_token(pending) {
+            stats.termination = GenerationTermination::Eog;
             break;
         }
         stats.output_tokens += 1;
-        if !on_token(pending)? || stats.output_tokens >= max_tokens {
+        if let Some(termination) = on_token(pending)? {
+            stats.termination = termination;
+            break;
+        }
+        if stats.output_tokens >= max_tokens {
             break;
         }
 
@@ -274,10 +281,15 @@ pub(crate) fn run_mtp(
         for token in drafts.iter().take(accepted) {
             committed_prefix.push(*token);
             if model.is_eog_token(*token) {
+                stats.termination = GenerationTermination::Eog;
                 break 'generate;
             }
             stats.output_tokens += 1;
-            if !on_token(*token)? || stats.output_tokens >= max_tokens {
+            if let Some(termination) = on_token(*token)? {
+                stats.termination = termination;
+                break 'generate;
+            }
+            if stats.output_tokens >= max_tokens {
                 break 'generate;
             }
         }

--- a/crates/providers/llama-cpp/src/provider.rs
+++ b/crates/providers/llama-cpp/src/provider.rs
@@ -18,7 +18,7 @@ use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::{LogOptions, send_logs_to_tracing};
 use querymt::LLMProvider;
-use querymt::chat::{ChatMessage, ChatProvider, ChatResponse, FinishReason, Tool};
+use querymt::chat::{ChatMessage, ChatProvider, ChatResponse, Tool};
 use querymt::completion::{CompletionProvider, CompletionRequest, CompletionResponse};
 use querymt::embedding::EmbeddingProvider;
 use querymt::error::LLMError;
@@ -360,8 +360,11 @@ impl ChatProvider for LlamaCppProvider {
                     active_multimodal,
                     &bitmaps,
                 )?;
-                let (content, thinking, tool_calls, finish_reason) =
+                let (content, thinking, tool_calls, _) =
                     parse_tool_response(&template_result, &generated.text)?;
+                let finish_reason = generated
+                    .termination
+                    .finish_reason(tool_calls.as_ref().is_some_and(|calls| !calls.is_empty()));
 
                 return Ok(Box::new(LlamaCppChatResponse {
                     text: content,
@@ -388,8 +391,9 @@ impl ChatProvider for LlamaCppProvider {
                 active_multimodal,
                 &bitmaps,
             )?;
-            let (content, thinking, _tool_calls, finish_reason) =
+            let (content, thinking, _tool_calls, _) =
                 parse_tool_response(&template_result, &generated.text)?;
+            let finish_reason = generated.termination.finish_reason(false);
             return Ok(Box::new(LlamaCppChatResponse {
                 text: content,
                 thinking,
@@ -414,8 +418,10 @@ impl ChatProvider for LlamaCppProvider {
             active_multimodal,
             &bitmaps,
         )?;
-        // Fallback handling (existing logic)
-        if generated.text.trim().is_empty() {
+        // Retry alternate prompt formats only when the model ended immediately.
+        if generated.text.trim().is_empty()
+            && generated.termination == crate::response::GenerationTermination::Eog
+        {
             if used_chat_template && self.cfg.use_chat_template.is_none() {
                 let (fallback_prompt, _) =
                     build_prompt_with(&self.model, &self.cfg, messages, false, media_marker)?;
@@ -431,7 +437,9 @@ impl ChatProvider for LlamaCppProvider {
                 )?;
             }
         }
-        if generated.text.trim().is_empty() {
+        if generated.text.trim().is_empty()
+            && generated.termination == crate::response::GenerationTermination::Eog
+        {
             let raw_prompt = build_raw_prompt(&self.cfg, messages)?;
             generated = generate(
                 &self.model,
@@ -456,7 +464,7 @@ impl ChatProvider for LlamaCppProvider {
             text: clean_text,
             thinking,
             tool_calls: None,
-            finish_reason: FinishReason::Stop,
+            finish_reason: generated.termination.finish_reason(false),
             usage: generated.usage,
         }))
     }
@@ -530,14 +538,10 @@ impl ChatProvider for LlamaCppProvider {
                         multimodal.as_deref(),
                         &bitmaps,
                     ) {
-                        Ok((usage, has_tool_calls)) => {
+                        Ok((usage, termination, has_tool_calls)) => {
                             let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Usage(usage)));
                             let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Done {
-                                finish_reason: if has_tool_calls {
-                                    FinishReason::ToolCalls
-                                } else {
-                                    FinishReason::Stop
-                                },
+                                finish_reason: termination.finish_reason(has_tool_calls),
                             }));
                         }
                         Err(err) => {
@@ -577,10 +581,10 @@ impl ChatProvider for LlamaCppProvider {
                 multimodal.as_deref(),
                 &bitmaps,
             ) {
-                Ok(usage) => {
+                Ok((usage, termination)) => {
                     let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Usage(usage)));
                     let _ = tx.unbounded_send(Ok(querymt::chat::StreamChunk::Done {
-                        finish_reason: FinishReason::Stop,
+                        finish_reason: termination.finish_reason(false),
                     }));
                 }
                 Err(err) => {

--- a/crates/providers/llama-cpp/src/response.rs
+++ b/crates/providers/llama-cpp/src/response.rs
@@ -40,8 +40,67 @@ impl ChatResponse for LlamaCppChatResponse {
     }
 }
 
+/// Reason generation stopped inside the provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GenerationTermination {
+    Eog,
+    StopSequence,
+    MaxTokens,
+    ConsumerClosed,
+}
+
+impl Default for GenerationTermination {
+    fn default() -> Self {
+        Self::MaxTokens
+    }
+}
+
+impl GenerationTermination {
+    pub(crate) fn finish_reason(self, has_tool_calls: bool) -> FinishReason {
+        match self {
+            Self::MaxTokens => FinishReason::Length,
+            Self::Eog | Self::StopSequence if has_tool_calls => FinishReason::ToolCalls,
+            Self::Eog | Self::StopSequence | Self::ConsumerClosed => FinishReason::Stop,
+        }
+    }
+}
+
 /// Generated text from a completion request.
 pub(crate) struct GeneratedText {
     pub(crate) text: String,
     pub(crate) usage: Usage,
+    pub(crate) termination: GenerationTermination,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_generation_termination_to_finish_reason() {
+        let cases = [
+            (GenerationTermination::Eog, false, FinishReason::Stop),
+            (GenerationTermination::Eog, true, FinishReason::ToolCalls),
+            (
+                GenerationTermination::StopSequence,
+                false,
+                FinishReason::Stop,
+            ),
+            (
+                GenerationTermination::StopSequence,
+                true,
+                FinishReason::ToolCalls,
+            ),
+            (
+                GenerationTermination::MaxTokens,
+                false,
+                FinishReason::Length,
+            ),
+            (GenerationTermination::MaxTokens, true, FinishReason::Length),
+        ];
+
+        for (termination, has_tool_calls, expected) in cases {
+            assert_eq!(termination.finish_reason(has_tool_calls), expected);
+        }
+    }
 }

--- a/crates/providers/llama-cpp/src/tools/generation.rs
+++ b/crates/providers/llama-cpp/src/tools/generation.rs
@@ -2,7 +2,7 @@ use crate::chat_format::parse_assistant_format_with_state;
 use crate::common_chat::ChatTemplateResult;
 use crate::config::LlamaCppConfig;
 use crate::multimodal::MultimodalContext;
-use crate::response::GeneratedText;
+use crate::response::{GeneratedText, GenerationTermination};
 use crate::tools::prefill::prefill_for_tool_generation;
 use crate::tools::sampler::{SamplingParams, build_structured_sampler, build_tool_sampler};
 use llama_cpp_2::llama_batch::LlamaBatch;
@@ -57,10 +57,11 @@ pub(crate) fn generate_with_tools(
                     .token_to_piece(token, &mut decoder, special, None)
                     .map_err(|e| LLMError::ProviderError(e.to_string()))?;
                 output.push_str(&piece);
-                Ok(!result
+                Ok(result
                     .additional_stops
                     .iter()
-                    .any(|s| !s.is_empty() && output.ends_with(s)))
+                    .any(|s| !s.is_empty() && output.ends_with(s))
+                    .then_some(GenerationTermination::StopSequence))
             },
         )?;
         for stop in &result.additional_stops {
@@ -78,6 +79,7 @@ pub(crate) fn generate_with_tools(
                 cache_write: 0,
                 reasoning_tokens: 0,
             },
+            termination: stats.termination,
         });
     }
     let mut state =
@@ -100,6 +102,7 @@ pub(crate) fn generate_with_tools(
                 cache_write: 0,
                 reasoning_tokens: 0,
             },
+            termination: GenerationTermination::MaxTokens,
         });
     }
 
@@ -127,6 +130,7 @@ pub(crate) fn generate_with_tools(
     let mut decoder = encoding_rs::UTF_8.new_decoder();
     let mut first_token_logged = false;
     let mut eog_hit = false;
+    let mut termination = GenerationTermination::MaxTokens;
 
     log::debug!(
         "generate_with_tools: sampler built, has_grammar={}, input_tokens={}, max_tokens={}",
@@ -139,6 +143,7 @@ pub(crate) fn generate_with_tools(
         let token = sampler.sample(&state.ctx, batch.n_tokens() - 1);
         if model.is_eog_token(token) {
             eog_hit = true;
+            termination = GenerationTermination::Eog;
             break;
         }
 
@@ -169,6 +174,7 @@ pub(crate) fn generate_with_tools(
             .iter()
             .any(|stop| !stop.is_empty() && output.ends_with(stop))
         {
+            termination = GenerationTermination::StopSequence;
             break;
         }
 
@@ -218,6 +224,7 @@ pub(crate) fn generate_with_tools(
             cache_write: 0,
             reasoning_tokens: 0,
         },
+        termination,
     })
 }
 

--- a/crates/providers/llama-cpp/src/tools/streaming.rs
+++ b/crates/providers/llama-cpp/src/tools/streaming.rs
@@ -56,6 +56,10 @@ pub(crate) fn generate_streaming_with_tools(
             temperature,
             Some(sampler),
             |token| {
+                if tx.is_closed() {
+                    return Ok(Some(GenerationTermination::ConsumerClosed));
+                }
+
                 let piece = model
                     .token_to_piece(token, &mut decoder, preserved.contains(&token), None)
                     .map_err(|e| LLMError::ProviderError(e.to_string()))?;
@@ -159,6 +163,20 @@ pub(crate) fn generate_streaming_with_tools(
     let mut decoder = encoding_rs::UTF_8.new_decoder();
 
     while state.n_cur < state.n_len_total {
+        if tx.is_closed() {
+            return Ok((
+                Usage {
+                    input_tokens: state.input_tokens,
+                    output_tokens,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning_tokens: 0,
+                },
+                GenerationTermination::ConsumerClosed,
+                false,
+            ));
+        }
+
         let token = sampler.sample(&state.ctx, batch.n_tokens() - 1);
         if model.is_eog_token(token) {
             termination = GenerationTermination::Eog;
@@ -235,9 +253,33 @@ pub(crate) fn generate_streaming_with_tools(
                 .unbounded_send(Ok(querymt::chat::StreamChunk::Thinking(thinking)))
                 .is_err()
             {
-                break;
+                return Ok((
+                    Usage {
+                        input_tokens: state.input_tokens,
+                        output_tokens,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning_tokens: 0,
+                    },
+                    GenerationTermination::ConsumerClosed,
+                    false,
+                ));
             }
         }
+    }
+
+    if tx.is_closed() {
+        return Ok((
+            Usage {
+                input_tokens: state.input_tokens,
+                output_tokens,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning_tokens: 0,
+            },
+            GenerationTermination::ConsumerClosed,
+            false,
+        ));
     }
 
     let (content, _, tool_calls, _) = parse_tool_response(result, &generated_text)?;

--- a/crates/providers/llama-cpp/src/tools/streaming.rs
+++ b/crates/providers/llama-cpp/src/tools/streaming.rs
@@ -2,6 +2,7 @@ use crate::chat_format::ParsedDelta;
 use crate::common_chat::ChatTemplateResult;
 use crate::config::LlamaCppConfig;
 use crate::multimodal::MultimodalContext;
+use crate::response::GenerationTermination;
 use crate::tools::generation::parse_tool_response;
 use crate::tools::prefill::prefill_for_tool_generation;
 use crate::tools::sampler::{SamplingParams, build_structured_sampler, build_tool_sampler};
@@ -15,7 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Generate text with streaming and grammar-constrained sampling for tool calls.
-/// Returns (Usage, has_tool_calls) where has_tool_calls indicates if tool calls were made.
+/// Returns usage, termination, and whether tool calls were made.
 pub(crate) fn generate_streaming_with_tools(
     model: &Arc<LlamaModel>,
     cfg: &LlamaCppConfig,
@@ -26,7 +27,7 @@ pub(crate) fn generate_streaming_with_tools(
     tx: &mpsc::UnboundedSender<Result<querymt::chat::StreamChunk, LLMError>>,
     mm_ctx: Option<&MultimodalContext>,
     bitmaps: &[MtmdBitmap],
-) -> Result<(Usage, bool), LLMError> {
+) -> Result<(Usage, GenerationTermination, bool), LLMError> {
     if cfg.speculative.is_some() && bitmaps.is_empty() {
         let params = SamplingParams::from_config(cfg, temperature);
         let sampler = if let Some(schema) = cfg.json_schema.as_ref().and_then(|s| s.schema.as_ref())
@@ -69,10 +70,10 @@ pub(crate) fn generate_streaming_with_tools(
                             .unbounded_send(Ok(querymt::chat::StreamChunk::Thinking(thinking)))
                             .is_err()
                     {
-                        return Ok(false);
+                        return Ok(Some(GenerationTermination::ConsumerClosed));
                     }
                 }
-                Ok(!stop_now)
+                Ok(stop_now.then_some(GenerationTermination::StopSequence))
             },
         )?;
         for stop in &result.additional_stops {
@@ -105,6 +106,7 @@ pub(crate) fn generate_streaming_with_tools(
                 cache_write: 0,
                 reasoning_tokens: 0,
             },
+            stats.termination,
             has_calls,
         ));
     }
@@ -127,6 +129,7 @@ pub(crate) fn generate_streaming_with_tools(
                 cache_write: 0,
                 reasoning_tokens: 0,
             },
+            GenerationTermination::MaxTokens,
             false,
         ));
     }
@@ -152,11 +155,13 @@ pub(crate) fn generate_streaming_with_tools(
     };
     let mut output_tokens = 0u32;
     let mut generated_text = String::new();
+    let mut termination = GenerationTermination::MaxTokens;
     let mut decoder = encoding_rs::UTF_8.new_decoder();
 
     while state.n_cur < state.n_len_total {
         let token = sampler.sample(&state.ctx, batch.n_tokens() - 1);
         if model.is_eog_token(token) {
+            termination = GenerationTermination::Eog;
             break;
         }
 
@@ -191,6 +196,7 @@ pub(crate) fn generate_streaming_with_tools(
                             cache_write: 0,
                             reasoning_tokens: 0,
                         },
+                        GenerationTermination::ConsumerClosed,
                         false,
                     ));
                 }
@@ -198,6 +204,7 @@ pub(crate) fn generate_streaming_with_tools(
         }
 
         if stop_now {
+            termination = GenerationTermination::StopSequence;
             break;
         }
 
@@ -262,6 +269,7 @@ pub(crate) fn generate_streaming_with_tools(
             cache_write: 0,
             reasoning_tokens: 0,
         },
+        termination,
         has_tool_calls,
     ))
 }

--- a/crates/providers/llama-cpp/src/tools/streaming.rs
+++ b/crates/providers/llama-cpp/src/tools/streaming.rs
@@ -80,6 +80,20 @@ pub(crate) fn generate_streaming_with_tools(
                 Ok(stop_now.then_some(GenerationTermination::StopSequence))
             },
         )?;
+        if stats.termination == GenerationTermination::ConsumerClosed {
+            return Ok((
+                Usage {
+                    input_tokens: stats.input_tokens,
+                    output_tokens: stats.output_tokens,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning_tokens: 0,
+                },
+                stats.termination,
+                false,
+            ));
+        }
+
         for stop in &result.additional_stops {
             if !stop.is_empty() && text.ends_with(stop) {
                 text.truncate(text.len() - stop.len());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generation responses now report why completion ended, including token limits, end-of-generation markers, stop sequences, and consumer closure.
  * Streaming and tool-assisted responses consistently include termination details.
  * Finish reasons now accurately reflect the underlying generation outcome, including tool calls.

* **Bug Fixes**
  * Improved handling of empty outputs and termination during speculative generation.
  * Corrected termination reporting for zero-token generation and early streaming exits.
  * Added coverage for termination-to-finish-reason mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->