### PR TITLE
fix(agent): enforce exactly-once delegation execution

### DIFF
--- a/crates/agent/examples/qmtcode.rs
+++ b/crates/agent/examples/qmtcode.rs
@@ -456,14 +456,10 @@ async fn run(
     } else {
         let selected_profile = selected_profile_id(&cli).to_string();
         eprintln!("Loading agent from profile: {selected_profile}");
-        let document = profile_catalog.load_profile(&selected_profile).await?;
-        let runner = from_config_value_with_infra(document.config, shared_infra.clone()).await?;
         let catalog: Arc<dyn ProfileCatalog> = Arc::new(profile_catalog);
-        runner.with_profiles(AgentProfiles::new(
-            catalog,
-            selected_profile,
-            shared_infra.clone(),
-        ))
+        let profiles = AgentProfiles::new(catalog, selected_profile, shared_infra.clone());
+        let runtime = profiles.active_runtime().await?;
+        AgentRunner::new(runtime.agent().clone()).with_profiles(profiles)
     };
 
     eprintln!("Agent loaded successfully!\n");
@@ -705,7 +701,7 @@ async fn run(
     }
 
     // Request shutdown without blocking on background drains; telemetry is finalized last.
-    runner.handle().shutdown().await;
+    runner.shutdown().await;
     #[cfg(feature = "remote")]
     if let Some(runtime) = mesh_runtime.take() {
         runtime.request_shutdown();

--- a/crates/agent/src/agent/delegation_loop_tests.rs
+++ b/crates/agent/src/agent/delegation_loop_tests.rs
@@ -130,6 +130,7 @@ struct TestHarness {
     config: Arc<AgentConfig>,
     exec_ctx: ExecutionContext,
     provider: Arc<Mutex<MockLlmProvider>>,
+    orchestrator_handle: Option<tokio::task::JoinHandle<()>>,
     _temp_dir: TempDir,
 }
 
@@ -246,7 +247,7 @@ impl TestHarness {
             )
             .with_delegate_model_overrides(config.delegate_model_overrides.clone()),
         );
-        let _orchestrator_handle = orchestrator.start_listening(config.event_sink.fanout());
+        let orchestrator_handle = Some(orchestrator.start_listening(config.event_sink.fanout()));
 
         // Create a SessionRuntime for the execution context
         let session_runtime = crate::agent::core::SessionRuntime::new(
@@ -267,7 +268,14 @@ impl TestHarness {
             config,
             exec_ctx,
             provider,
+            orchestrator_handle,
             _temp_dir: temp_dir,
+        }
+    }
+
+    fn stop_harness_orchestrator(&mut self) {
+        if let Some(handle) = self.orchestrator_handle.take() {
+            handle.abort();
         }
     }
 
@@ -344,6 +352,53 @@ impl TestHarness {
             .times(0..);
 
         self.run().await
+    }
+
+    async fn run_single_delegation_without_child_tool(&mut self) -> CycleOutcome {
+        let delegate_call = mock_querymt_tool_call(
+            "call-1",
+            "delegate",
+            r#"{"target_agent_id":"agent","objective":"task"}"#,
+        );
+        let mut seq = Sequence::new();
+        self.provider_mut()
+            .await
+            .expect_chat()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(move |_| {
+                Ok(Box::new(MockChatResponse::with_tools(
+                    "Delegating task",
+                    vec![delegate_call.clone()],
+                )))
+            });
+        self.provider_mut()
+            .await
+            .expect_chat()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| Ok(Box::new(MockChatResponse::text_only("Done"))));
+        self.provider_mut()
+            .await
+            .expect_call_tool()
+            .returning(|_, _| Ok(vec![querymt::chat::Content::text("ok")]))
+            .times(1);
+        self.provider_mut()
+            .await
+            .expect_tools()
+            .return_const(None)
+            .times(0..);
+
+        self.run().await
+    }
+
+    async fn child_sessions(&self) -> Vec<String> {
+        self.config
+            .provider
+            .history_store()
+            .list_child_sessions(&self.exec_ctx.session_id)
+            .await
+            .expect("child sessions")
     }
 
     async fn child_llm_params(&self) -> (String, LLMParams) {
@@ -536,6 +591,262 @@ fn agent_info(id: &str) -> AgentInfo {
 }
 
 // Helper functions moved to crate::test_utils::helpers
+
+#[tokio::test]
+async fn duplicate_orchestrators_create_one_child_for_one_request() {
+    let mut harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    let config = harness.config.clone();
+    let store = config.provider.history_store();
+    let duplicate = Arc::new(
+        DelegationOrchestrator::new(
+            Arc::new(crate::agent::LocalAgentHandle::from_config(config.clone())),
+            config.event_sink.clone(),
+            store,
+            config.agent_registry.clone(),
+            config.tool_registry_arc(),
+            config.hooks.clone(),
+            None,
+        )
+        .with_delegate_model_overrides(config.delegate_model_overrides.clone()),
+    );
+    let duplicate_listener = duplicate.start_listening(config.event_sink.fanout());
+    assert_eq!(config.event_sink.fanout().subscriber_count(), 2);
+
+    let outcome = harness.run_single_delegation().await;
+    let children = harness.child_sessions().await;
+    duplicate_listener.abort();
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    assert_eq!(children.len(), 1);
+}
+
+#[tokio::test]
+async fn profile_orchestrator_does_not_poison_unbound_session() {
+    let mut harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    let config = harness.config.clone();
+    let spectator = Arc::new(
+        DelegationOrchestrator::new(
+            Arc::new(crate::agent::LocalAgentHandle::from_config(config.clone())),
+            config.event_sink.clone(),
+            config.provider.history_store(),
+            config.agent_registry.clone(),
+            config.tool_registry_arc(),
+            config.hooks.clone(),
+            None,
+        )
+        .with_profile_id("owner"),
+    );
+    let spectator_listener = spectator.start_listening(config.event_sink.fanout());
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        harness.run_single_delegation(),
+    )
+    .await
+    .expect("unbound delegation timed out");
+    let children = harness.child_sessions().await;
+    spectator_listener.abort();
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    assert_eq!(children.len(), 1);
+}
+
+#[tokio::test]
+async fn unrelated_profile_orchestrator_does_not_claim_delegation() {
+    let mut harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    harness.stop_harness_orchestrator();
+    let config = harness.config.clone();
+    let store = config.provider.history_store();
+    store
+        .set_profile_binding(&harness.exec_ctx.session_id, "owner")
+        .await
+        .expect("bind parent profile");
+    let owner = Arc::new(
+        DelegationOrchestrator::new(
+            Arc::new(crate::agent::LocalAgentHandle::from_config(config.clone())),
+            config.event_sink.clone(),
+            store.clone(),
+            config.agent_registry.clone(),
+            config.tool_registry_arc(),
+            config.hooks.clone(),
+            None,
+        )
+        .with_profile_id("owner"),
+    );
+    let unrelated = Arc::new(
+        DelegationOrchestrator::new(
+            Arc::new(crate::agent::LocalAgentHandle::from_config(config.clone())),
+            config.event_sink.clone(),
+            store,
+            config.agent_registry.clone(),
+            config.tool_registry_arc(),
+            config.hooks.clone(),
+            None,
+        )
+        .with_profile_id("other"),
+    );
+    let owner_listener = owner.start_listening(config.event_sink.fanout());
+    let unrelated_listener = unrelated.start_listening(config.event_sink.fanout());
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        harness.run_single_delegation(),
+    )
+    .await
+    .expect("profile-isolated delegation timed out");
+    let children = harness.child_sessions().await;
+    owner_listener.abort();
+    unrelated_listener.abort();
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    assert_eq!(children.len(), 1);
+}
+
+#[tokio::test]
+async fn missing_target_fails_and_unblocks_parent() {
+    let mut harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    harness.stop_harness_orchestrator();
+    let config = harness.config.clone();
+    let missing_target = Arc::new(DelegationOrchestrator::new(
+        Arc::new(crate::agent::LocalAgentHandle::from_config(config.clone())),
+        config.event_sink.clone(),
+        config.provider.history_store(),
+        Arc::new(DefaultAgentRegistry::new()),
+        config.tool_registry_arc(),
+        config.hooks.clone(),
+        None,
+    ));
+    let listener = missing_target.start_listening(config.event_sink.fanout());
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        harness.run_single_delegation_without_child_tool(),
+    )
+    .await
+    .expect("missing target did not unblock the parent");
+    listener.abort();
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    let delegations = config
+        .provider
+        .history_store()
+        .list_delegations(&harness.exec_ctx.session_id)
+        .await
+        .expect("delegations");
+    assert_eq!(delegations.len(), 1);
+    assert_eq!(delegations[0].status, DelegationStatus::Failed);
+}
+
+#[tokio::test]
+async fn timeout_cleanup_cancels_requested_delegation_before_it_can_start() {
+    let harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    let store = harness.config.provider.history_store();
+    let session = store
+        .get_session(&harness.exec_ctx.session_id)
+        .await
+        .expect("session lookup")
+        .expect("parent session");
+    let delegation = Delegation {
+        id: 0,
+        public_id: String::new(),
+        session_id: session.id,
+        task_id: None,
+        target_agent_id: "agent".to_string(),
+        objective: "not started yet".to_string(),
+        objective_hash: crate::hash::RapidHash::new(b"not started yet"),
+        context: None,
+        constraints: None,
+        expected_output: None,
+        verification_spec: None,
+        planning_summary: None,
+        status: DelegationStatus::Requested,
+        retry_count: 0,
+        created_at: OffsetDateTime::now_utc(),
+        completed_at: None,
+    };
+    let delegation = store
+        .create_delegation(delegation)
+        .await
+        .expect("create delegation");
+
+    crate::agent::execution::cleanup_timed_out_delegations(
+        &harness.config,
+        &harness.exec_ctx,
+        std::slice::from_ref(&delegation.public_id),
+    )
+    .await;
+
+    let delegation = store
+        .get_delegation(&delegation.public_id)
+        .await
+        .expect("delegation lookup")
+        .expect("delegation");
+    assert_eq!(delegation.status, DelegationStatus::Cancelled);
+    assert_eq!(
+        store
+            .claim_delegation(&delegation.public_id)
+            .await
+            .expect("claim result"),
+        crate::session::domain::DelegationClaim::InvalidState(DelegationStatus::Cancelled)
+    );
+}
+
+#[tokio::test]
+async fn timeout_cleanup_does_not_overwrite_terminal_delegation() {
+    let harness = TestHarness::new(vec![], DelegateBehavior::AlwaysOk).await;
+    let store = harness.config.provider.history_store();
+    let session = store
+        .get_session(&harness.exec_ctx.session_id)
+        .await
+        .expect("session lookup")
+        .expect("parent session");
+    let delegation = Delegation {
+        id: 0,
+        public_id: String::new(),
+        session_id: session.id,
+        task_id: None,
+        target_agent_id: "agent".to_string(),
+        objective: "already complete".to_string(),
+        objective_hash: crate::hash::RapidHash::new(b"already complete"),
+        context: None,
+        constraints: None,
+        expected_output: None,
+        verification_spec: None,
+        planning_summary: None,
+        status: DelegationStatus::Complete,
+        retry_count: 0,
+        created_at: OffsetDateTime::now_utc(),
+        completed_at: None,
+    };
+    let delegation = store
+        .create_delegation(delegation)
+        .await
+        .expect("create delegation");
+    let mut event_rx = harness.config.event_sink.fanout().subscribe();
+
+    crate::agent::execution::cleanup_timed_out_delegations(
+        &harness.config,
+        &harness.exec_ctx,
+        std::slice::from_ref(&delegation.public_id),
+    )
+    .await;
+
+    assert_eq!(
+        store
+            .get_delegation(&delegation.public_id)
+            .await
+            .expect("delegation lookup")
+            .expect("delegation")
+            .status,
+        DelegationStatus::Complete
+    );
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), event_rx.recv())
+            .await
+            .is_err(),
+        "terminal delegations must not emit timeout cancellation events"
+    );
+}
 
 #[tokio::test]
 async fn test_delegate_inherits_parent_reasoning_effort() {

--- a/crates/agent/src/agent/execution/mod.rs
+++ b/crates/agent/src/agent/execution/mod.rs
@@ -46,6 +46,8 @@ mod maintenance;
 mod tool_calls;
 mod transitions;
 mod wait;
+#[cfg(test)]
+pub(crate) use wait::cleanup_timed_out_delegations;
 
 use crate::acp::protocol::StopReason;
 use crate::agent::execution_context::ExecutionContext;

--- a/crates/agent/src/agent/execution/wait.rs
+++ b/crates/agent/src/agent/execution/wait.rs
@@ -278,34 +278,57 @@ fn format_wait_all_summary(items: &[String]) -> String {
     msg
 }
 
-async fn cleanup_timed_out_delegations(
+pub(crate) async fn cleanup_timed_out_delegations(
     config: &AgentConfig,
     exec_ctx: &ExecutionContext,
     delegation_ids: &[String],
 ) {
     for delegation_id in delegation_ids {
+        let transitioned = match exec_ctx
+            .state
+            .store
+            .transition_delegation_status(
+                delegation_id,
+                crate::session::domain::DelegationStatus::Running,
+                crate::session::domain::DelegationStatus::Cancelled,
+            )
+            .await
+        {
+            Ok(true) => true,
+            Ok(false) => exec_ctx
+                .state
+                .store
+                .transition_delegation_status(
+                    delegation_id,
+                    crate::session::domain::DelegationStatus::Requested,
+                    crate::session::domain::DelegationStatus::Cancelled,
+                )
+                .await
+                .unwrap_or_else(|err| {
+                    warn!(
+                        "Failed to mark requested delegation '{}' as cancelled: {}",
+                        delegation_id, err
+                    );
+                    false
+                }),
+            Err(err) => {
+                warn!(
+                    "Failed to mark timed out delegation '{}' as cancelled: {}",
+                    delegation_id, err
+                );
+                false
+            }
+        };
+        if !transitioned {
+            continue;
+        }
+
         config.emit_event(
             &exec_ctx.session_id,
             AgentEventKind::DelegationCancelRequested {
                 delegation_id: delegation_id.clone(),
             },
         );
-
-        if let Err(err) = exec_ctx
-            .state
-            .store
-            .update_delegation_status(
-                delegation_id,
-                crate::session::domain::DelegationStatus::Cancelled,
-            )
-            .await
-        {
-            warn!(
-                "Failed to mark timed out delegation '{}' as cancelled: {}",
-                delegation_id, err
-            );
-        }
-
         config.emit_event(
             &exec_ctx.session_id,
             AgentEventKind::DelegationCancelled {

--- a/crates/agent/src/agent/handle/agent_handle_impl.rs
+++ b/crates/agent/src/agent/handle/agent_handle_impl.rs
@@ -68,6 +68,10 @@ impl AgentHandle for LocalAgentHandle {
         self.config.agent_registry.clone()
     }
 
+    async fn shutdown(&self) {
+        self.shutdown().await;
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -401,9 +401,13 @@ impl LocalAgentHandle {
     ) -> std::result::Result<crate::acp::protocol::LoadSessionResponse, Error> {
         let session_id = req.session_id.to_string();
 
-        if let Some(profiles) = self.profiles()
-            && let Some(binding) = profiles.session_binding(&session_id).await
-        {
+        if let Some(profiles) = self.profiles() {
+            let binding = profiles.session_binding(&session_id).await.ok_or_else(|| {
+                Error::invalid_params().data(serde_json::json!({
+                    "message": "Session has no profile binding",
+                    "sessionId": session_id,
+                }))
+            })?;
             let runtime = profiles
                 .runtime_for_profile(&binding.profile_id)
                 .await

--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -228,6 +228,11 @@ impl LocalAgentHandle {
         self.scheduler_handle.lock().clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.shutdown_done.load(Ordering::SeqCst)
+    }
+
     pub(super) fn clear_scheduler_handle(&self) {
         *self.scheduler_handle.lock() = None;
     }

--- a/crates/agent/src/agent/handle/mod.rs
+++ b/crates/agent/src/agent/handle/mod.rs
@@ -134,6 +134,8 @@ pub trait AgentHandle: Send + Sync {
 
     // --- Downcasting (transitional) ---
 
+    async fn shutdown(&self) {}
+
     /// For downcasting to concrete types. Transitional — should be eliminated
     /// over time by moving needed methods onto the trait.
     fn as_any(&self) -> &dyn Any;

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -485,6 +485,30 @@ async fn test_set_profile_config_option_rejects_different_bound_profile() {
 }
 
 #[tokio::test]
+async fn test_profile_handle_rejects_unbound_session_load() {
+    let (f, _profile_dir) = profile_fixture_with_files(&[("alpha.toml", ALPHA_PROFILE_TOML)]).await;
+    let session = f
+        .handle
+        .config
+        .provider
+        .history_store()
+        .create_session(None, None, None, None)
+        .await
+        .expect("create unbound session");
+    let req = crate::acp::protocol::LoadSessionRequest::new(
+        SessionId::from(session.public_id),
+        std::path::PathBuf::new(),
+    );
+
+    let err = f
+        .handle
+        .load_session(req)
+        .await
+        .expect_err("unbound load must fail");
+    assert!(err.to_string().contains("profile binding"));
+}
+
+#[tokio::test]
 async fn test_load_session_reports_persisted_reasoning_effort() {
     let f = RealStorageHandleFixture::new().await;
     let session_id = seed_session_with_reasoning(&f, Some(ReasoningEffort::High)).await;

--- a/crates/agent/src/api/agent.rs
+++ b/crates/agent/src/api/agent.rs
@@ -569,6 +569,7 @@ impl AgentBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct Agent {
     pub(super) inner: Arc<AgentHandle>,
     #[cfg_attr(not(feature = "api"), allow(dead_code))]
@@ -576,10 +577,10 @@ pub struct Agent {
     pub(super) default_session_id: Arc<Mutex<Option<String>>>,
     pub(super) cwd: Option<PathBuf>,
     pub(super) callbacks: Arc<EventCallbacksState>,
-    pub(super) profiles: Option<AgentProfiles>,
+    pub(super) profiles: Option<Arc<AgentProfiles>>,
     /// Present when this agent was built with `Agent::multi()`.
     /// Holds the quorum orchestrator for delegate access.
-    pub(super) quorum: Option<crate::quorum::AgentQuorum>,
+    pub(super) quorum: Option<Arc<crate::quorum::AgentQuorum>>,
 }
 
 impl Agent {
@@ -734,12 +735,26 @@ impl Agent {
             manager.set_mesh_handle(mesh);
         }
         self.inner.set_profiles(manager);
-        self.profiles = Some(profiles);
+        self.profiles = Some(Arc::new(profiles));
         self
     }
 
     pub fn profiles(&self) -> Option<ProfileRuntimeHandle> {
-        self.profiles.as_ref().map(AgentProfiles::manager)
+        self.profiles
+            .as_ref()
+            .map(|profiles| profiles.manager())
+            .or_else(|| self.inner.profiles())
+    }
+
+    pub async fn shutdown(&self) {
+        if let Some(profiles) = self.profiles() {
+            profiles.shutdown().await;
+        } else {
+            if let Some(quorum) = self.quorum() {
+                quorum.shutdown().await;
+            }
+            self.inner.shutdown().await;
+        }
     }
 
     #[cfg(feature = "api")]
@@ -808,7 +823,7 @@ impl Agent {
 
     /// Access the quorum orchestrator (returns `None` for single agents).
     pub fn quorum(&self) -> Option<&crate::quorum::AgentQuorum> {
-        self.quorum.as_ref()
+        self.quorum.as_deref()
     }
 
     /// Access the planner handle (returns `None` for single agents).

--- a/crates/agent/src/api/agent.rs
+++ b/crates/agent/src/api/agent.rs
@@ -749,12 +749,10 @@ impl Agent {
     pub async fn shutdown(&self) {
         if let Some(profiles) = self.profiles() {
             profiles.shutdown().await;
-        } else {
-            if let Some(quorum) = self.quorum() {
-                quorum.shutdown().await;
-            }
-            self.inner.shutdown().await;
+        } else if let Some(quorum) = self.quorum() {
+            quorum.shutdown().await;
         }
+        self.inner.shutdown().await;
     }
 
     #[cfg(feature = "api")]

--- a/crates/agent/src/api/agent.rs
+++ b/crates/agent/src/api/agent.rs
@@ -749,7 +749,8 @@ impl Agent {
     pub async fn shutdown(&self) {
         if let Some(profiles) = self.profiles() {
             profiles.shutdown().await;
-        } else if let Some(quorum) = self.quorum() {
+        }
+        if let Some(quorum) = self.quorum() {
             quorum.shutdown().await;
         }
         self.inner.shutdown().await;

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -88,6 +88,42 @@ async fn with_profiles_reuses_root_agent_for_active_profile() -> Result<()> {
 }
 
 #[tokio::test]
+async fn shutdown_with_profiles_also_stops_independent_root() -> Result<()> {
+    let dir = tempfile::TempDir::new()?;
+    std::fs::write(
+        dir.path().join("alpha.toml"),
+        "[agent]\nprovider = \"test\"\nmodel = \"test-model\"\nsystem = \"inline\"\n",
+    )?;
+    let storage =
+        Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
+    let root = test_agent_with_storage(Some(storage.clone())).await?;
+    assert!(!root.handle().is_shutdown());
+    let (registry, _temp_dir) = empty_plugin_registry()?;
+    let catalog: Arc<dyn ProfileCatalog> = Arc::new(
+        LocalProfileCatalog::builder()
+            .include_embedded_default(false)
+            .local_dir(dir.path())
+            .build(),
+    );
+    let profiles = AgentProfiles::new(
+        catalog,
+        "alpha",
+        AgentInfra {
+            plugin_registry: Arc::new(registry),
+            storage: Some(storage),
+            session_mcp_attachment_source: None,
+            event_fanout: None,
+        },
+    );
+    let root = root.with_profiles(profiles);
+
+    root.shutdown().await;
+
+    assert!(root.handle().is_shutdown());
+    Ok(())
+}
+
+#[tokio::test]
 async fn with_profiles_keeps_watcher_alive() -> Result<()> {
     let dir = tempfile::TempDir::new()?;
     std::fs::write(

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -43,8 +43,7 @@ async fn test_agent_with_storage(
         .await
 }
 
-async fn attach_test_profiles(
-    agent: Agent,
+async fn build_test_profile_agent(
     storage: Arc<crate::session::sqlite_storage::SqliteStorage>,
     profile_dir: &std::path::Path,
 ) -> Result<Agent> {
@@ -55,16 +54,37 @@ async fn attach_test_profiles(
             .local_dir(profile_dir)
             .build(),
     );
-    Ok(agent.with_profiles(AgentProfiles::new(
-        catalog,
-        "alpha",
-        AgentInfra {
-            plugin_registry: Arc::new(registry),
-            storage: Some(storage),
-            session_mcp_attachment_source: None,
-            event_fanout: None,
-        },
-    )))
+    let infra = AgentInfra {
+        plugin_registry: Arc::new(registry),
+        storage: Some(storage),
+        session_mcp_attachment_source: None,
+        event_fanout: None,
+    };
+    let profiles = AgentProfiles::new(catalog, "alpha", infra);
+    let runtime = profiles.active_runtime().await?;
+    Ok(runtime.agent().clone().with_profiles(profiles))
+}
+
+#[tokio::test]
+async fn with_profiles_reuses_root_agent_for_active_profile() -> Result<()> {
+    let dir = tempfile::TempDir::new()?;
+    std::fs::write(
+        dir.path().join("alpha.toml"),
+        "[agent]\nprovider = \"test\"\nmodel = \"test-model\"\nsystem = \"inline\"\n",
+    )?;
+    let storage =
+        Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
+    let agent = build_test_profile_agent(storage, dir.path()).await?;
+    let root_handle = agent.handle();
+
+    let runtime = agent
+        .profiles()
+        .expect("profiles attached")
+        .active_runtime()
+        .await?;
+
+    assert!(Arc::ptr_eq(&root_handle, &runtime.agent().handle()));
+    Ok(())
 }
 
 #[tokio::test]
@@ -76,8 +96,7 @@ async fn with_profiles_keeps_watcher_alive() -> Result<()> {
     )?;
     let storage =
         Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
-    let agent = test_agent_with_storage(Some(storage.clone())).await?;
-    let agent = attach_test_profiles(agent, storage, dir.path()).await?;
+    let agent = build_test_profile_agent(storage, dir.path()).await?;
 
     assert!(agent.profiles().is_some());
     assert!(
@@ -101,8 +120,7 @@ async fn server_inherits_attached_profiles() -> Result<()> {
     )?;
     let storage =
         Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
-    let agent = test_agent_with_storage(Some(storage.clone())).await?;
-    let agent = attach_test_profiles(agent, storage, dir.path()).await?;
+    let agent = build_test_profile_agent(storage, dir.path()).await?;
 
     let server = agent.server();
     assert!(server.profiles().is_some());

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -82,7 +82,7 @@ async fn build_test_profile_multi_agent(
         session_mcp_attachment_source: None,
         event_fanout: Some(Arc::new(crate::event_fanout::EventFanout::new())),
     };
-    let profiles = AgentProfiles::new(catalog, "alpha", infra);
+    let profiles = AgentProfiles::new(catalog, "team", infra);
     let runtime = profiles.active_runtime().await?;
     Ok(runtime.agent().clone().with_profiles(profiles))
 }
@@ -710,20 +710,19 @@ tools = []
     let planner = agent.planner().expect("planner present");
     let delegate = agent.delegate("coder").expect("delegate present");
 
-    // Verify all are running before shutdown
+    let planner = planner
+        .as_any()
+        .downcast_ref::<crate::agent::LocalAgentHandle>()
+        .expect("local planner");
+    let delegate = delegate
+        .as_any()
+        .downcast_ref::<crate::agent::LocalAgentHandle>()
+        .expect("local delegate");
     assert!(!planner.is_shutdown());
     assert!(!delegate.is_shutdown());
 
-    // Shutdown the agent - both profiles and quorum should be shut down
     agent.shutdown().await;
 
-    // Verify the planner and delegates were shut down
-    // This confirms that both quorum.shutdown() and profiles.shutdown() were called,
-    // because:
-    // 1. quorum.shutdown() cancels active delegations and shuts down the orchestrator
-    // 2. profiles.shutdown() iterates through runtimes and shuts down each agent
-    // If the bug existed (else-if instead of two separate if statements),
-    // only one of these would execute, and we'd see incomplete shutdown.
     assert!(planner.is_shutdown());
     assert!(delegate.is_shutdown());
 

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -65,6 +65,28 @@ async fn build_test_profile_agent(
     Ok(runtime.agent().clone().with_profiles(profiles))
 }
 
+async fn build_test_profile_multi_agent(
+    storage: Arc<crate::session::sqlite_storage::SqliteStorage>,
+    profile_dir: &std::path::Path,
+) -> Result<Agent> {
+    let (registry, _temp_dir) = empty_plugin_registry()?;
+    let catalog: Arc<dyn ProfileCatalog> = Arc::new(
+        LocalProfileCatalog::builder()
+            .include_embedded_default(false)
+            .local_dir(profile_dir)
+            .build(),
+    );
+    let infra = AgentInfra {
+        plugin_registry: Arc::new(registry),
+        storage: Some(storage),
+        session_mcp_attachment_source: None,
+        event_fanout: Some(Arc::new(crate::event_fanout::EventFanout::new())),
+    };
+    let profiles = AgentProfiles::new(catalog, "alpha", infra);
+    let runtime = profiles.active_runtime().await?;
+    Ok(runtime.agent().clone().with_profiles(profiles))
+}
+
 #[tokio::test]
 async fn with_profiles_reuses_root_agent_for_active_profile() -> Result<()> {
     let dir = tempfile::TempDir::new()?;
@@ -649,5 +671,61 @@ async fn list_sessions_remote_bookmarks_mode_includes_detached_bookmarks() -> Re
         .expect("remote bookmark should be present");
     assert_eq!(remote.attached, Some(false));
     assert_eq!(remote.node.as_deref(), Some("remote-peer"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn shutdown_with_profiles_and_quorum_executes_both() -> Result<()> {
+    let dir = tempfile::TempDir::new()?;
+    std::fs::write(
+        dir.path().join("team.toml"),
+        r#"
+[quorum]
+delegation = true
+verification = false
+snapshot_policy = "none"
+
+[planner]
+provider = "test"
+model = "test-planner"
+tools = ["delegate"]
+
+[[delegates]]
+id = "coder"
+provider = "test"
+model = "test-coder"
+tools = []
+"#,
+    )?;
+    let storage =
+        Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
+    let agent = build_test_profile_multi_agent(storage, dir.path()).await?;
+
+    // Verify both profiles and quorum are present
+    assert!(agent.profiles().is_some());
+    assert!(agent.quorum().is_some());
+    assert!(agent.is_multi());
+
+    // Get references before shutdown
+    let planner = agent.planner().expect("planner present");
+    let delegate = agent.delegate("coder").expect("delegate present");
+
+    // Verify all are running before shutdown
+    assert!(!planner.is_shutdown());
+    assert!(!delegate.is_shutdown());
+
+    // Shutdown the agent - both profiles and quorum should be shut down
+    agent.shutdown().await;
+
+    // Verify the planner and delegates were shut down
+    // This confirms that both quorum.shutdown() and profiles.shutdown() were called,
+    // because:
+    // 1. quorum.shutdown() cancels active delegations and shuts down the orchestrator
+    // 2. profiles.shutdown() iterates through runtimes and shuts down each agent
+    // If the bug existed (else-if instead of two separate if statements),
+    // only one of these would execute, and we'd see incomplete shutdown.
+    assert!(planner.is_shutdown());
+    assert!(delegate.is_shutdown());
+
     Ok(())
 }

--- a/crates/agent/src/api/profiles.rs
+++ b/crates/agent/src/api/profiles.rs
@@ -1,4 +1,4 @@
-use crate::profiles::{ProfileCatalog, ProfileRuntimeManager};
+use crate::profiles::{ProfileCatalog, ProfileRuntime, ProfileRuntimeManager};
 use notify::RecommendedWatcher;
 use std::sync::Arc;
 
@@ -44,6 +44,10 @@ impl AgentProfiles {
 
     pub fn manager(&self) -> ProfileRuntimeHandle {
         self.manager.clone()
+    }
+
+    pub async fn active_runtime(&self) -> anyhow::Result<Arc<ProfileRuntime>> {
+        self.manager.active_runtime().await
     }
 
     #[cfg(test)]

--- a/crates/agent/src/api/quorum.rs
+++ b/crates/agent/src/api/quorum.rs
@@ -76,6 +76,7 @@ pub struct QuorumBuilder {
 
     /// Optional pre-built infrastructure (plugin registry + storage).
     pub(super) infra: Option<super::agent::AgentInfra>,
+    pub(crate) profile_id: Option<String>,
 }
 
 impl Default for QuorumBuilder {
@@ -111,6 +112,7 @@ impl QuorumBuilder {
             #[cfg(feature = "remote")]
             peer_delegates: Vec::new(),
             infra: None,
+            profile_id: None,
         }
     }
 
@@ -171,6 +173,11 @@ impl QuorumBuilder {
     /// When not called, `build()` uses platform defaults.
     pub fn infra(mut self, infra: super::agent::AgentInfra) -> Self {
         self.infra = Some(infra);
+        self
+    }
+
+    pub fn with_profile_id(mut self, profile_id: impl Into<String>) -> Self {
+        self.profile_id = Some(profile_id.into());
         self
     }
 
@@ -548,6 +555,9 @@ impl QuorumBuilder {
             Arc::new(AgentHandle::from_config(config)) as Arc<dyn AgentHandleTrait>
         });
 
+        if let Some(profile_id) = self.profile_id {
+            builder = builder.with_profile_id(profile_id);
+        }
         builder = builder
             .with_delegation(self.delegation_enabled)
             .with_verification(self.verification_enabled)
@@ -731,7 +741,7 @@ impl QuorumBuilder {
             cwd,
             callbacks: Arc::new(EventCallbacksState::new(None)),
             profiles: None,
-            quorum: Some(quorum),
+            quorum: Some(Arc::new(quorum)),
         })
     }
 }

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -6,7 +6,9 @@ use crate::hooks::{
     DelegationFailureRequest, DelegationStartRequest, HookNotice, Hooks, PostDelegationRequest,
 };
 use crate::model::{AgentMessage, MessagePart};
-use crate::session::domain::{Delegation, DelegationStatus, ForkOrigin, ForkPointType};
+use crate::session::domain::{
+    Delegation, DelegationClaim, DelegationStatus, ForkOrigin, ForkPointType,
+};
 use crate::session::store::SessionStore;
 use crate::tools::ToolRegistry;
 use crate::verification::VerificationSpec;
@@ -109,6 +111,7 @@ pub struct DelegationOrchestrator {
     /// Optional summarizer for generating planning context
     delegation_summarizer: Option<Arc<super::summarizer::DelegationSummarizer>>,
     delegate_model_overrides: super::DelegateModelOverrideStore,
+    profile_id: Option<String>,
     /// Optional routing snapshot for per-agent routing decisions.
     routing_snapshot: Option<crate::agent::remote::RoutingSnapshotHandle>,
 }
@@ -135,6 +138,7 @@ impl DelegationOrchestrator {
             active_delegations: Arc::new(Mutex::new(HashMap::new())),
             delegation_summarizer: None,
             delegate_model_overrides: super::DelegateModelOverrideStore::default(),
+            profile_id: None,
             routing_snapshot: None,
         }
     }
@@ -187,6 +191,11 @@ impl DelegationOrchestrator {
         self
     }
 
+    pub fn with_profile_id(mut self, profile_id: impl Into<String>) -> Self {
+        self.profile_id = Some(profile_id.into());
+        self
+    }
+
     /// Set the routing snapshot handle for per-agent routing decisions.
     ///
     /// When set, the orchestrator will consult the routing table before creating
@@ -198,6 +207,29 @@ impl DelegationOrchestrator {
     ) -> Self {
         self.routing_snapshot = Some(snapshot);
         self
+    }
+
+    pub async fn cancel_active_delegations(&self) {
+        let active = std::mem::take(&mut *self.active_delegations.lock().await);
+        for (delegation_id, (_, cancel_token, mut handle)) in active {
+            cancel_token.cancel();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(1), &mut handle).await;
+            handle.abort();
+            if let Err(err) = self
+                .store
+                .transition_delegation_status(
+                    &delegation_id,
+                    DelegationStatus::Running,
+                    DelegationStatus::Cancelled,
+                )
+                .await
+            {
+                warn!(
+                    "Failed to persist cancellation for delegation {} during shutdown: {}",
+                    delegation_id, err
+                );
+            }
+        }
     }
 
     /// Start listening for events on the given `EventFanout`.
@@ -222,6 +254,22 @@ impl DelegationOrchestrator {
         })
     }
 
+    async fn claim_delegation(&self, delegation_id: &str) -> Result<DelegationClaim, String> {
+        let mut last_error = None;
+        for attempt in 0..3 {
+            match self.store.claim_delegation(delegation_id).await {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    last_error = Some(err.to_string());
+                    if attempt < 2 {
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                }
+            }
+        }
+        Err(last_error.unwrap_or_else(|| "unknown claim error".to_string()))
+    }
+
     /// Process a single event envelope.
     #[instrument(
         name = "delegation.orchestrator.handle_event",
@@ -236,6 +284,100 @@ impl DelegationOrchestrator {
         match envelope.kind() {
             AgentEventKind::DelegationRequested { delegation, .. } => {
                 tracing::Span::current().record("event_kind", "DelegationRequested");
+                if let Some(profile_id) = self.profile_id.as_deref() {
+                    match self.store.get_profile_binding(session_id).await {
+                        Ok(Some(owner)) if owner == profile_id => {}
+                        Ok(Some(_)) => return,
+                        // Live profile sessions must already be bound. Legacy support belongs in
+                        // session loading, where one deterministic profile could be backfilled.
+                        Ok(None) => {
+                            error!(
+                                "Ignoring delegation {} from unbound session {}",
+                                delegation.public_id, session_id
+                            );
+                            return;
+                        }
+                        Err(err) => {
+                            error!(
+                                "Failed to resolve profile owner for delegation {}: {}",
+                                delegation.public_id, err
+                            );
+                            return;
+                        }
+                    }
+                }
+                match self.claim_delegation(&delegation.public_id).await {
+                    Ok(DelegationClaim::Claimed) => {}
+                    Ok(DelegationClaim::AlreadyClaimed) => {
+                        debug!(
+                            "Delegation {} was already claimed; ignoring duplicate request",
+                            delegation.public_id
+                        );
+                        return;
+                    }
+                    Ok(DelegationClaim::NotFound) => {
+                        emit_delegation_event(
+                            &self.delegator,
+                            &self.event_sink,
+                            session_id,
+                            AgentEventKind::DelegationFailed {
+                                delegation_id: delegation.public_id.clone(),
+                                error: "Delegation record was not found".to_string(),
+                            },
+                        );
+                        return;
+                    }
+                    Ok(DelegationClaim::InvalidState(status)) => {
+                        debug!(
+                            "Delegation {} is already terminal ({status:?}); ignoring request",
+                            delegation.public_id
+                        );
+                        return;
+                    }
+                    Err(err) => {
+                        fail_delegation(
+                            DelegationFailureContext {
+                                event_sink: &self.event_sink,
+                                delegator: &self.delegator,
+                                store: &self.store,
+                                hooks: None,
+                                config: &self.config,
+                                parent_session_id: session_id,
+                                delegation_id: &delegation.public_id,
+                                target_agent_id: Some(&delegation.target_agent_id),
+                                objective: Some(&delegation.objective),
+                            },
+                            &format!("Failed to claim delegation before execution: {err}"),
+                        )
+                        .await;
+                        return;
+                    }
+                }
+
+                let Some(target_handle) =
+                    self.agent_registry.get_handle(&delegation.target_agent_id)
+                else {
+                    fail_delegation(
+                        DelegationFailureContext {
+                            event_sink: &self.event_sink,
+                            delegator: &self.delegator,
+                            store: &self.store,
+                            hooks: None,
+                            config: &self.config,
+                            parent_session_id: session_id,
+                            delegation_id: &delegation.public_id,
+                            target_agent_id: Some(&delegation.target_agent_id),
+                            objective: Some(&delegation.objective),
+                        },
+                        &format!(
+                            "Agent '{}' is not registered with a handle",
+                            delegation.target_agent_id
+                        ),
+                    )
+                    .await;
+                    return;
+                };
+
                 let delegator = self.delegator.clone();
                 let event_sink = self.event_sink.clone();
                 let store = self.store.clone();
@@ -256,11 +398,6 @@ impl DelegationOrchestrator {
                 // Store the cancellation token and join handle
                 let delegation_id = delegation.public_id.clone();
                 let cancel_token_clone = cancel_token.clone();
-
-                // Get the agent handle for this agent — try new `get_handle` first,
-                // fall back to `get_agent_handle` for backward compatibility.
-                let target_handle: Option<Arc<dyn crate::agent::handle::AgentHandle>> =
-                    self.agent_registry.get_handle(&delegation.target_agent_id);
 
                 let handle = tokio::spawn(async move {
                     let _permit = match max_parallel.acquire_owned().await {
@@ -297,41 +434,14 @@ impl DelegationOrchestrator {
                         delegate_model_overrides,
                         routing_snapshot,
                     };
-                    match target_handle {
-                        Some(target) => {
-                            execute_delegation(
-                                ctx,
-                                target,
-                                parent_session_id,
-                                delegation,
-                                cancel_token,
-                            )
-                            .await;
-                        }
-                        None => {
-                            // No AgentHandle registered for this agent.
-                            let error_message = format!(
-                                "Agent '{}' is not registered with a handle. \
-                                 Register it via register_handle() in the AgentRegistry.",
-                                delegation.target_agent_id
-                            );
-                            fail_delegation(
-                                DelegationFailureContext {
-                                    event_sink: &ctx.event_sink,
-                                    delegator: &ctx.delegator,
-                                    store: &ctx.store,
-                                    hooks: Some(&ctx.hooks),
-                                    config: &ctx.config,
-                                    parent_session_id: &parent_session_id,
-                                    delegation_id: &delegation.public_id,
-                                    target_agent_id: Some(&delegation.target_agent_id),
-                                    objective: Some(&delegation.objective),
-                                },
-                                &error_message,
-                            )
-                            .await;
-                        }
-                    }
+                    execute_delegation(
+                        ctx,
+                        target_handle,
+                        parent_session_id,
+                        delegation,
+                        cancel_token,
+                    )
+                    .await;
                 });
 
                 let mut active = active_delegations.lock().await;
@@ -502,14 +612,6 @@ async fn execute_delegation(
             }
         }
         Err(err) => warn!("Delegation start hook failed: {}", err),
-    }
-
-    if let Err(e) = ctx
-        .store
-        .update_delegation_status(&delegation.public_id, DelegationStatus::Running)
-        .await
-    {
-        warn!("Failed to update delegation status to Running: {}", e);
     }
 
     // Snapshot the parent's current per-session setting. UI changes persist this value
@@ -888,11 +990,21 @@ async fn execute_delegation(
             // Cancellation — cancel the child session
             let _ = session_ref.cancel().await;
 
-            if let Err(e) = ctx.store
-                .update_delegation_status(&delegation_id, DelegationStatus::Cancelled)
+            match ctx
+                .store
+                .transition_delegation_status(
+                    &delegation_id,
+                    DelegationStatus::Running,
+                    DelegationStatus::Cancelled,
+                )
                 .await
             {
-                warn!("Failed to update delegation status to Cancelled: {}", e);
+                Ok(true) => {}
+                Ok(false) => return,
+                Err(e) => {
+                    warn!("Failed to update delegation status to Cancelled: {}", e);
+                    return;
+                }
             }
 
             emit_delegation_event(
@@ -1056,12 +1168,21 @@ async fn execute_delegation(
                 Err(err) => warn!("Post-delegation hook failed: {}", err),
             }
 
-            if let Err(e) = ctx
+            match ctx
                 .store
-                .update_delegation_status(&delegation.public_id, DelegationStatus::Complete)
+                .transition_delegation_status(
+                    &delegation.public_id,
+                    DelegationStatus::Running,
+                    DelegationStatus::Complete,
+                )
                 .await
             {
-                warn!("Failed to persist delegation completion: {}", e);
+                Ok(true) => {}
+                Ok(false) => return,
+                Err(e) => {
+                    warn!("Failed to persist delegation completion: {}", e);
+                    return;
+                }
             }
 
             emit_delegation_event(
@@ -1124,12 +1245,38 @@ async fn execute_delegation(
 )]
 async fn fail_delegation(ctx: DelegationFailureContext<'_>, error_message: &str) {
     error!("{}", error_message);
-    if let Err(e) = ctx
+    let transitioned = match ctx
         .store
-        .update_delegation_status(ctx.delegation_id, DelegationStatus::Failed)
+        .transition_delegation_status(
+            ctx.delegation_id,
+            DelegationStatus::Running,
+            DelegationStatus::Failed,
+        )
         .await
     {
-        warn!("Failed to persist delegation failure: {}", e);
+        Ok(true) => true,
+        Ok(false) => match ctx
+            .store
+            .transition_delegation_status(
+                ctx.delegation_id,
+                DelegationStatus::Requested,
+                DelegationStatus::Failed,
+            )
+            .await
+        {
+            Ok(transitioned) => transitioned,
+            Err(e) => {
+                warn!("Failed to persist delegation failure: {}", e);
+                false
+            }
+        },
+        Err(e) => {
+            warn!("Failed to persist delegation failure: {}", e);
+            false
+        }
+    };
+    if !transitioned {
+        return;
     }
 
     let mut failure_message = error_message.to_string();

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -325,23 +325,46 @@ impl DelegationOrchestrator {
             AgentEventKind::DelegationRequested { delegation, .. } => {
                 tracing::Span::current().record("event_kind", "DelegationRequested");
                 if let Some(profile_id) = self.profile_id.as_deref() {
-                    match self.store.get_profile_binding(session_id).await {
-                        Ok(Some(owner)) if owner == profile_id => {}
-                        Ok(Some(_)) => return,
+                    let mut last_error = None;
+                    let mut binding_result = None;
+                    for attempt in 0..3 {
+                        match self.store.get_profile_binding(session_id).await {
+                            Ok(result) => {
+                                binding_result = Some(result);
+                                break;
+                            }
+                            Err(err) => {
+                                last_error = Some(err);
+                                if attempt < 2 {
+                                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                                }
+                            }
+                        }
+                    }
+
+                    match binding_result {
+                        Some(Some(owner)) if owner == profile_id => {}
+                        Some(Some(_)) => return,
                         // Live profile sessions must already be bound. Legacy support belongs in
                         // session loading, where one deterministic profile could be backfilled.
-                        Ok(None) => {
+                        Some(None) => {
                             error!(
                                 "Ignoring delegation {} from unbound session {}",
                                 delegation.public_id, session_id
                             );
                             return;
                         }
-                        Err(err) => {
-                            error!(
-                                "Failed to resolve profile owner for delegation {}: {}",
-                                delegation.public_id, err
+                        None => {
+                            let error_message = format!(
+                                "Failed to resolve profile owner for delegation {} after retries: {}",
+                                delegation.public_id,
+                                last_error
+                                    .as_ref()
+                                    .map(|e| e.to_string())
+                                    .unwrap_or_else(|| "unknown error".to_string())
                             );
+                            self.fail_unclaimed_delegation(delegation, session_id, &error_message)
+                                .await;
                             return;
                         }
                     }
@@ -1031,9 +1054,15 @@ async fn execute_delegation(
                 .await
             {
                 Ok(true) => {}
-                Ok(false) => return,
+                Ok(false) => {
+                    let mut active = ctx.active_delegations.lock().await;
+                    active.remove(&delegation_id);
+                    return;
+                }
                 Err(e) => {
                     warn!("Failed to update delegation status to Cancelled: {}", e);
+                    let mut active = ctx.active_delegations.lock().await;
+                    active.remove(&delegation_id);
                     return;
                 }
             }
@@ -1209,9 +1238,15 @@ async fn execute_delegation(
                 .await
             {
                 Ok(true) => {}
-                Ok(false) => return,
+                Ok(false) => {
+                    let mut active = ctx.active_delegations.lock().await;
+                    active.remove(&delegation_id);
+                    return;
+                }
                 Err(e) => {
                     warn!("Failed to persist delegation completion: {}", e);
+                    let mut active = ctx.active_delegations.lock().await;
+                    active.remove(&delegation_id);
                     return;
                 }
             }

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -20,7 +20,8 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, instrument};
@@ -108,6 +109,7 @@ pub struct DelegationOrchestrator {
     max_parallel: Arc<tokio::sync::Semaphore>,
     /// Maps delegation_id -> (parent_session_id, cancellation_token, join_handle)
     active_delegations: ActiveDelegations,
+    shutting_down: AtomicBool,
     /// Optional summarizer for generating planning context
     delegation_summarizer: Option<Arc<super::summarizer::DelegationSummarizer>>,
     delegate_model_overrides: super::DelegateModelOverrideStore,
@@ -136,6 +138,7 @@ impl DelegationOrchestrator {
             config: DelegationOrchestratorConfig::new(cwd),
             max_parallel: Arc::new(tokio::sync::Semaphore::new(5)),
             active_delegations: Arc::new(Mutex::new(HashMap::new())),
+            shutting_down: AtomicBool::new(false),
             delegation_summarizer: None,
             delegate_model_overrides: super::DelegateModelOverrideStore::default(),
             profile_id: None,
@@ -209,7 +212,31 @@ impl DelegationOrchestrator {
         self
     }
 
+    pub fn begin_shutdown(&self) {
+        self.shutting_down.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    async fn wait_until_registered(&self, delegation_id: &str) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if self
+                    .active_delegations
+                    .lock()
+                    .await
+                    .contains_key(delegation_id)
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("delegation was not registered");
+    }
+
     pub async fn cancel_active_delegations(&self) {
+        self.begin_shutdown();
         let active = std::mem::take(&mut *self.active_delegations.lock().await);
         for (delegation_id, (_, cancel_token, mut handle)) in active {
             cancel_token.cancel();
@@ -240,7 +267,7 @@ impl DelegationOrchestrator {
         let this = Arc::clone(self);
         let mut rx = fanout.subscribe();
         tokio::spawn(async move {
-            loop {
+            while !this.shutting_down.load(Ordering::Acquire) {
                 match rx.recv().await {
                     Ok(envelope) => {
                         this.handle_envelope(&envelope).await;
@@ -320,6 +347,9 @@ impl DelegationOrchestrator {
         )
     )]
     async fn handle_envelope(&self, envelope: &EventEnvelope) {
+        if self.shutting_down.load(Ordering::Acquire) {
+            return;
+        }
         let session_id = envelope.session_id();
         match envelope.kind() {
             AgentEventKind::DelegationRequested { delegation, .. } => {
@@ -448,12 +478,16 @@ impl DelegationOrchestrator {
                 let active_delegations = self.active_delegations.clone();
                 let active_delegations_for_spawn = active_delegations.clone();
                 let hooks = self.hooks.clone();
+                let (start_tx, start_rx) = oneshot::channel();
 
                 // Store the cancellation token and join handle
                 let delegation_id = delegation.public_id.clone();
                 let cancel_token_clone = cancel_token.clone();
 
                 let handle = tokio::spawn(async move {
+                    if start_rx.await.is_err() {
+                        return;
+                    }
                     let _permit = match max_parallel.acquire_owned().await {
                         Ok(permit) => permit,
                         Err(_) => {
@@ -499,10 +533,32 @@ impl DelegationOrchestrator {
                 });
 
                 let mut active = active_delegations.lock().await;
+                if self.shutting_down.load(Ordering::Acquire) {
+                    handle.abort();
+                    drop(active);
+                    fail_delegation(
+                        DelegationFailureContext {
+                            event_sink: &self.event_sink,
+                            delegator: &self.delegator,
+                            store: &self.store,
+                            hooks: None,
+                            config: &self.config,
+                            parent_session_id: session_id,
+                            delegation_id: &delegation_id,
+                            target_agent_id: None,
+                            objective: None,
+                        },
+                        "Delegation cancelled because the orchestrator is shutting down",
+                    )
+                    .await;
+                    return;
+                }
                 active.insert(
                     delegation_id,
                     (parent_session_id_for_insert, cancel_token_clone, handle),
                 );
+                drop(active);
+                let _ = start_tx.send(());
             }
             AgentEventKind::DelegationCancelRequested { delegation_id } => {
                 tracing::Span::current().record("event_kind", "DelegationCancelRequested");
@@ -1805,6 +1861,98 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_claimed_delegation_registration() {
+        let storage = Arc::new(
+            SqliteStorage::connect(":memory:".into())
+                .await
+                .expect("storage"),
+        );
+        let session = storage
+            .create_session(None, None, None, None)
+            .await
+            .expect("session");
+        let delegation = storage
+            .create_delegation(Delegation {
+                id: 0,
+                public_id: String::new(),
+                session_id: session.id,
+                task_id: None,
+                target_agent_id: "coder".to_string(),
+                objective: "test shutdown registration".to_string(),
+                objective_hash: crate::hash::RapidHash::new(b"test shutdown registration"),
+                context: None,
+                constraints: None,
+                expected_output: None,
+                verification_spec: None,
+                planning_summary: None,
+                status: DelegationStatus::Requested,
+                retry_count: 0,
+                created_at: time::OffsetDateTime::now_utc(),
+                completed_at: None,
+            })
+            .await
+            .expect("delegation");
+        let fanout = Arc::new(EventFanout::new());
+        let event_sink = Arc::new(EventSink::new(storage.event_journal(), fanout.clone()));
+        let mut registry = DefaultAgentRegistry::new();
+        registry.register(make_agent_info("coder"), StubAgentHandle::new("coder"));
+        let orchestrator = Arc::new(
+            DelegationOrchestrator::new(
+                StubAgentHandle::new("delegator"),
+                event_sink,
+                storage.session_store().clone(),
+                Arc::new(registry),
+                Arc::new(ToolRegistry::new()),
+                Hooks::default(),
+                None,
+            )
+            .with_max_parallel_delegations(NonZeroUsize::new(1).unwrap()),
+        );
+        let held_permit = orchestrator
+            .max_parallel
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("held permit");
+        let listener = orchestrator.start_listening(&fanout);
+
+        let requested = storage
+            .event_journal()
+            .append_durable(&crate::session::projection::NewDurableEvent {
+                session_id: session.public_id.clone(),
+                origin: crate::events::EventOrigin::Local,
+                source_node: None,
+                kind: AgentEventKind::DelegationRequested {
+                    delegation: delegation.clone(),
+                    tool_call_id: None,
+                },
+            })
+            .await
+            .expect("requested event");
+        fanout.publish(EventEnvelope::Durable(requested));
+        orchestrator
+            .wait_until_registered(&delegation.public_id)
+            .await;
+
+        orchestrator.begin_shutdown();
+        listener.abort();
+        listener.await.expect_err("listener should be aborted");
+        orchestrator.cancel_active_delegations().await;
+        drop(held_permit);
+
+        assert!(orchestrator.active_delegations.lock().await.is_empty());
+        assert_eq!(
+            storage
+                .get_delegation(&delegation.public_id)
+                .await
+                .expect("delegation lookup")
+                .expect("delegation")
+                .status,
+            DelegationStatus::Cancelled
+        );
     }
 
     #[tokio::test]

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -254,6 +254,46 @@ impl DelegationOrchestrator {
         })
     }
 
+    async fn fail_unclaimed_delegation(
+        &self,
+        delegation: &Delegation,
+        parent_session_id: &str,
+        error_message: &str,
+    ) {
+        match self
+            .store
+            .transition_delegation_status(
+                &delegation.public_id,
+                DelegationStatus::Requested,
+                DelegationStatus::Failed,
+            )
+            .await
+        {
+            Ok(true) => {
+                emit_delegation_event(
+                    &self.delegator,
+                    &self.event_sink,
+                    parent_session_id,
+                    AgentEventKind::DelegationFailed {
+                        delegation_id: delegation.public_id.clone(),
+                        error: error_message.to_string(),
+                    },
+                );
+                if self.config.inject_results {
+                    inject_failure(
+                        &self.delegator,
+                        parent_session_id,
+                        &delegation.public_id,
+                        error_message,
+                    )
+                    .await;
+                }
+            }
+            Ok(false) => {}
+            Err(err) => warn!("Failed to persist delegation claim failure: {}", err),
+        }
+    }
+
     async fn claim_delegation(&self, delegation_id: &str) -> Result<DelegationClaim, String> {
         let mut last_error = None;
         for attempt in 0..3 {
@@ -335,18 +375,9 @@ impl DelegationOrchestrator {
                         return;
                     }
                     Err(err) => {
-                        fail_delegation(
-                            DelegationFailureContext {
-                                event_sink: &self.event_sink,
-                                delegator: &self.delegator,
-                                store: &self.store,
-                                hooks: None,
-                                config: &self.config,
-                                parent_session_id: session_id,
-                                delegation_id: &delegation.public_id,
-                                target_agent_id: Some(&delegation.target_agent_id),
-                                objective: Some(&delegation.objective),
-                            },
+                        self.fail_unclaimed_delegation(
+                            delegation,
+                            session_id,
                             &format!("Failed to claim delegation before execution: {err}"),
                         )
                         .await;
@@ -1664,7 +1695,12 @@ mod tests {
     use crate::agent::handle::AgentHandle;
     use crate::agent::remote::SessionActorRef;
     use crate::event_fanout::EventFanout;
+    use crate::event_sink::EventSink;
     use crate::events::EventEnvelope;
+    use crate::hooks::Hooks;
+    use crate::session::backend::StorageBackend;
+    use crate::session::sqlite_storage::SqliteStorage;
+    use crate::test_utils::MockSessionStore;
     use async_trait::async_trait;
 
     // ── Minimal stub AgentHandle ──────────────────────────────────────────────
@@ -1734,6 +1770,59 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
+    }
+
+    #[tokio::test]
+    async fn claim_error_does_not_fail_running_winner() {
+        let mut store = MockSessionStore::new();
+        store
+            .expect_transition_delegation_status()
+            .withf(|id, expected, next| {
+                id == "delegation-1"
+                    && *expected == DelegationStatus::Requested
+                    && *next == DelegationStatus::Failed
+            })
+            .times(1)
+            .returning(|_, _, _| Ok(false));
+        let store: Arc<dyn SessionStore> = Arc::new(store);
+        let storage = Arc::new(
+            SqliteStorage::connect(":memory:".into())
+                .await
+                .expect("storage"),
+        );
+        let fanout = Arc::new(EventFanout::new());
+        let event_sink = Arc::new(EventSink::new(storage.event_journal(), fanout));
+        let orchestrator = DelegationOrchestrator::new(
+            StubAgentHandle::new("delegator"),
+            event_sink,
+            store,
+            Arc::new(DefaultAgentRegistry::new()),
+            Arc::new(ToolRegistry::new()),
+            Hooks::default(),
+            None,
+        );
+        let delegation = Delegation {
+            id: 1,
+            public_id: "delegation-1".to_string(),
+            session_id: 1,
+            task_id: None,
+            target_agent_id: "coder".to_string(),
+            objective: "test".to_string(),
+            objective_hash: crate::hash::RapidHash::new(b"test"),
+            context: None,
+            constraints: None,
+            expected_output: None,
+            verification_spec: None,
+            planning_summary: None,
+            status: DelegationStatus::Requested,
+            retry_count: 0,
+            created_at: time::OffsetDateTime::now_utc(),
+            completed_at: None,
+        };
+
+        orchestrator
+            .fail_unclaimed_delegation(&delegation, "session-1", "claim failed")
+            .await;
     }
 
     fn make_agent_info(id: &str) -> AgentInfo {

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -937,7 +937,7 @@ where
             let debounce = Duration::from_millis(350);
             while let Some(event) = rx.recv().await {
                 match event {
-                    Ok(event) if event.paths.iter().any(|path| is_profile_toml_path(path)) => {
+                    Ok(event) if should_reload_profiles(&event) => {
                         debug!(?event.kind, "profile file change detected");
                         while tokio::time::timeout(debounce, rx.recv()).await.is_ok() {}
                         manager.reload_profiles_logged().await;
@@ -1079,6 +1079,19 @@ async fn build_profile_runtime(
     };
 
     Ok(ProfileRuntime { metadata, agent })
+}
+
+fn should_reload_profiles(event: &notify::Event) -> bool {
+    use notify::EventKind::{Create, Modify, Remove};
+    use notify::event::{MetadataKind, ModifyKind};
+
+    let mutates_profile = match event.kind {
+        Create(_) | Remove(_) => true,
+        Modify(ModifyKind::Metadata(MetadataKind::AccessTime)) => false,
+        Modify(_) => true,
+        _ => false,
+    };
+    mutates_profile && event.paths.iter().any(|path| is_profile_toml_path(path))
 }
 
 fn is_profile_toml_path(path: &Path) -> bool {
@@ -1485,6 +1498,36 @@ system = "inline"
                 .to_string()
                 .contains("requires name")
         );
+    }
+
+    #[test]
+    fn profile_watcher_ignores_file_access_events() {
+        let event = notify::Event::new(notify::EventKind::Access(notify::event::AccessKind::Open(
+            notify::event::AccessMode::Read,
+        )))
+        .add_path(PathBuf::from("profile.toml"));
+
+        assert!(!should_reload_profiles(&event));
+    }
+
+    #[test]
+    fn profile_watcher_ignores_access_time_metadata_updates() {
+        let event = notify::Event::new(notify::EventKind::Modify(
+            notify::event::ModifyKind::Metadata(notify::event::MetadataKind::AccessTime),
+        ))
+        .add_path(PathBuf::from("profile.toml"));
+
+        assert!(!should_reload_profiles(&event));
+    }
+
+    #[test]
+    fn profile_watcher_accepts_profile_mutations() {
+        let event = notify::Event::new(notify::EventKind::Modify(notify::event::ModifyKind::Data(
+            notify::event::DataChange::Content,
+        )))
+        .add_path(PathBuf::from("profile.toml"));
+
+        assert!(should_reload_profiles(&event));
     }
 
     #[tokio::test]
@@ -1896,6 +1939,82 @@ system = "inline"
         assert_eq!(manager.cached_runtime_count().await, 1);
         let cached = manager.runtime_for_profile("alpha").await.unwrap();
         assert!(Arc::ptr_eq(&current, &cached));
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn profile_reads_do_not_reload_live_quorum_runtime() {
+        let dir = temp_profile_dir();
+        write_profile(
+            dir.path(),
+            "team.toml",
+            r#"
+[quorum]
+delegation = true
+verification = false
+snapshot_policy = "none"
+
+[planner]
+provider = "test"
+model = "planner-model"
+system = "plan"
+tools = ["delegate"]
+
+[[delegates]]
+id = "coder"
+provider = "test"
+model = "coder-model"
+system = "code"
+capabilities = ["coding"]
+"#,
+        );
+        let (mut infra, _registry_dir) = test_infra().await;
+        let fanout = Arc::new(crate::event_fanout::EventFanout::new());
+        infra.event_fanout = Some(fanout.clone());
+        let catalog = LocalProfileCatalog::builder()
+            .include_embedded_default(false)
+            .local_dir(dir.path())
+            .build();
+        let manager = Arc::new(ProfileRuntimeManager::with_infra(catalog, "team", infra));
+        let _watcher = manager.start_profile_watcher().expect("profile watcher");
+
+        let first = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            manager.runtime_for_profile("team"),
+        )
+        .await
+        .expect("initial quorum runtime build hung")
+        .expect("initial quorum runtime");
+        assert!(first.agent().quorum().is_some());
+        assert!(
+            first
+                .agent()
+                .handle()
+                .agent_registry()
+                .get_handle("coder")
+                .is_some()
+        );
+        let subscriber_count = fanout.subscriber_count();
+        for _ in 0..3 {
+            let document = manager
+                .catalog
+                .load_profile("team")
+                .await
+                .expect("profile read");
+            assert_eq!(document.metadata.id, "team");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            manager.runtime_for_profile("team"),
+        )
+        .await
+        .expect("cached quorum runtime lookup hung")
+        .expect("cached quorum runtime");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.cached_runtime_count().await, 1);
+        assert_eq!(fanout.subscriber_count(), subscriber_count);
         manager.shutdown().await;
     }
 

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -16,8 +16,9 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 #[cfg(feature = "remote")]
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, UNIX_EPOCH};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OnceCell};
 use tracing::{debug, info, warn};
 
 /// Embedded profile key used for the qmtcode default single-agent profile.
@@ -631,8 +632,12 @@ pub struct ProfileRuntimeManager<C = Arc<dyn ProfileCatalog>> {
     // profile resolution for new sessions; existing session bindings should remain authoritative.
     active_profile_id: Mutex<String>,
     runtimes: Mutex<HashMap<String, Arc<ProfileRuntime>>>,
+    building_runtimes: Mutex<HashMap<String, Arc<OnceCell<Arc<ProfileRuntime>>>>>,
     runtime_fingerprints: Mutex<HashMap<String, Option<String>>>,
     session_bindings: Mutex<HashMap<String, SessionProfileBinding>>,
+    shutdown: AtomicBool,
+    generation: AtomicU64,
+    lifecycle: Mutex<()>,
     #[cfg(feature = "remote")]
     mesh: StdMutex<Option<crate::agent::remote::MeshHandle>>,
 }
@@ -657,13 +662,18 @@ where
         active_profile_id: impl Into<String>,
         shared_infra: AgentInfra,
     ) -> Self {
+        let active_profile_id = active_profile_id.into();
         Self {
             catalog,
             shared_infra,
-            active_profile_id: Mutex::new(active_profile_id.into()),
+            active_profile_id: Mutex::new(active_profile_id),
             runtimes: Mutex::new(HashMap::new()),
+            building_runtimes: Mutex::new(HashMap::new()),
             runtime_fingerprints: Mutex::new(HashMap::new()),
             session_bindings: Mutex::new(HashMap::new()),
+            shutdown: AtomicBool::new(false),
+            generation: AtomicU64::new(0),
+            lifecycle: Mutex::new(()),
             #[cfg(feature = "remote")]
             mesh: StdMutex::new(None),
         }
@@ -675,6 +685,8 @@ where
 
     pub async fn reload_profiles(&self) -> Result<Vec<ProfileMetadata>> {
         let profiles = self.catalog.list_profiles().await?;
+        let lifecycle = self.lifecycle.lock().await;
+        self.generation.fetch_add(1, Ordering::AcqRel);
         let profile_fingerprints = profiles
             .iter()
             .map(|profile| (profile.id.clone(), profile.fingerprint.clone()))
@@ -689,17 +701,30 @@ where
 
         let mut runtime_fingerprints = self.runtime_fingerprints.lock().await;
         let mut runtimes = self.runtimes.lock().await;
-        runtimes.retain(|profile_id, _| {
-            let Some(current_fingerprint) = profile_fingerprints.get(profile_id) else {
+        let stale_profile_ids = runtimes
+            .keys()
+            .filter(|profile_id| {
+                profile_fingerprints.get(*profile_id) != runtime_fingerprints.get(*profile_id)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let stale_runtimes = stale_profile_ids
+            .iter()
+            .filter_map(|profile_id| {
                 runtime_fingerprints.remove(profile_id);
-                return false;
-            };
-            if runtime_fingerprints.get(profile_id) != Some(current_fingerprint) {
-                runtime_fingerprints.remove(profile_id);
-                return false;
+                runtimes.remove(profile_id)
+            })
+            .collect::<Vec<_>>();
+        drop(runtimes);
+        drop(runtime_fingerprints);
+        self.building_runtimes.lock().await.clear();
+        drop(lifecycle);
+        for runtime in stale_runtimes {
+            if let Some(quorum) = runtime.agent.quorum() {
+                quorum.shutdown().await;
             }
-            true
-        });
+            runtime.agent.handle().shutdown().await;
+        }
         Ok(profiles)
     }
 
@@ -729,30 +754,67 @@ where
     }
 
     pub async fn runtime_for_profile(&self, profile_id: &str) -> Result<Arc<ProfileRuntime>> {
-        if let Some(runtime) = self.runtimes.lock().await.get(profile_id).cloned() {
+        loop {
+            if self.shutdown.load(Ordering::Acquire) {
+                return Err(anyhow!("profile runtime manager is shut down"));
+            }
+            if let Some(runtime) = self.runtimes.lock().await.get(profile_id).cloned() {
+                return Ok(runtime);
+            }
+
+            // Runtime startup stays outside the cache lock; the per-generation cell coalesces
+            // concurrent lookups without blocking unrelated cached profiles.
+            let generation = self.generation.load(Ordering::Acquire);
+            let cell = self
+                .building_runtimes
+                .lock()
+                .await
+                .entry(profile_id.to_string())
+                .or_default()
+                .clone();
+            let runtime = cell
+                .get_or_try_init(|| async {
+                    let document = self.catalog.load_profile(profile_id).await?;
+                    let runtime =
+                        Arc::new(build_profile_runtime(document, self.shared_infra.clone()).await?);
+                    #[cfg(feature = "remote")]
+                    if let Some(mesh) = self.mesh_handle() {
+                        runtime.agent().handle().set_mesh(mesh);
+                    }
+                    Ok::<_, anyhow::Error>(runtime)
+                })
+                .await?
+                .clone();
+
+            let lifecycle = self.lifecycle.lock().await;
+            if self.shutdown.load(Ordering::Acquire) {
+                drop(lifecycle);
+                if let Some(quorum) = runtime.agent.quorum() {
+                    quorum.shutdown().await;
+                }
+                runtime.agent.handle().shutdown().await;
+                return Err(anyhow!("profile runtime manager is shut down"));
+            }
+            if self.generation.load(Ordering::Acquire) != generation {
+                drop(lifecycle);
+                if let Some(quorum) = runtime.agent.quorum() {
+                    quorum.shutdown().await;
+                }
+                runtime.agent.handle().shutdown().await;
+                continue;
+            }
+
+            self.runtime_fingerprints
+                .lock()
+                .await
+                .insert(profile_id.to_string(), runtime.metadata.fingerprint.clone());
+            self.runtimes
+                .lock()
+                .await
+                .insert(profile_id.to_string(), runtime.clone());
+            drop(lifecycle);
             return Ok(runtime);
         }
-
-        // Do profile I/O/runtime startup outside the cache lock so slow profile startup does not
-        // block unrelated cached runtime reads or event-forwarder polling. Re-check before insert
-        // in case another task won the race.
-        let document = self.catalog.load_profile(profile_id).await?;
-        let runtime = Arc::new(build_profile_runtime(document, self.shared_infra.clone()).await?);
-
-        let mut runtimes = self.runtimes.lock().await;
-        if let Some(existing) = runtimes.get(profile_id) {
-            return Ok(existing.clone());
-        }
-        #[cfg(feature = "remote")]
-        if let Some(mesh) = self.mesh_handle() {
-            runtime.agent().handle().set_mesh(mesh);
-        }
-        self.runtime_fingerprints
-            .lock()
-            .await
-            .insert(profile_id.to_string(), runtime.metadata.fingerprint.clone());
-        runtimes.insert(profile_id.to_string(), runtime.clone());
-        Ok(runtime)
     }
 
     pub async fn bind_session_to_profile(
@@ -924,8 +986,15 @@ where
     }
 
     pub async fn shutdown(&self) {
+        let lifecycle = self.lifecycle.lock().await;
+        self.shutdown.store(true, Ordering::Release);
+        self.generation.fetch_add(1, Ordering::AcqRel);
         let runtimes = std::mem::take(&mut *self.runtimes.lock().await);
+        drop(lifecycle);
         for runtime in runtimes.into_values() {
+            if let Some(quorum) = runtime.agent.quorum() {
+                quorum.shutdown().await;
+            }
             runtime.agent.handle().shutdown().await;
         }
     }
@@ -933,6 +1002,11 @@ where
     #[cfg(test)]
     async fn cached_runtime_count(&self) -> usize {
         self.runtimes.lock().await.len()
+    }
+
+    #[cfg(test)]
+    async fn building_runtime_count(&self) -> usize {
+        self.building_runtimes.lock().await.len()
     }
 }
 
@@ -953,13 +1027,27 @@ impl ProfileRuntimeManager<Arc<dyn ProfileCatalog>> {
         active_profile_id: impl Into<String>,
         shared_infra: AgentInfra,
     ) -> Self {
+        Self::with_infra(catalog, active_profile_id, shared_infra)
+    }
+
+    pub fn with_runtime(
+        catalog: Arc<dyn ProfileCatalog>,
+        shared_infra: AgentInfra,
+        runtime: ProfileRuntime,
+    ) -> Self {
+        let profile_id = runtime.profile_id().to_string();
+        let fingerprint = runtime.metadata.fingerprint.clone();
         Self {
             catalog,
             shared_infra,
-            active_profile_id: Mutex::new(active_profile_id.into()),
-            runtimes: Mutex::new(HashMap::new()),
-            runtime_fingerprints: Mutex::new(HashMap::new()),
+            active_profile_id: Mutex::new(profile_id.clone()),
+            runtimes: Mutex::new(HashMap::from([(profile_id.clone(), Arc::new(runtime))])),
+            building_runtimes: Mutex::new(HashMap::new()),
+            runtime_fingerprints: Mutex::new(HashMap::from([(profile_id, fingerprint)])),
             session_bindings: Mutex::new(HashMap::new()),
+            shutdown: AtomicBool::new(false),
+            generation: AtomicU64::new(0),
+            lifecycle: Mutex::new(()),
             #[cfg(feature = "remote")]
             mesh: StdMutex::new(None),
         }
@@ -981,7 +1069,12 @@ async fn build_profile_runtime(
             #[cfg(not(feature = "remote"))]
             let infra = shared_infra;
 
-            Agent::from_quorum_config_with_infra(*config, infra).await?
+            let builder = Agent::builder_from_quorum_config(*config, None)?;
+            builder
+                .with_profile_id(metadata.id.clone())
+                .infra(infra)
+                .build()
+                .await?
         }
     };
 
@@ -1077,6 +1170,8 @@ mod tests {
     #[cfg(feature = "remote")]
     use querymt::error::LLMError;
     use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::Notify;
 
     #[cfg(feature = "remote")]
     use std::time::Duration;
@@ -1714,6 +1809,191 @@ unknown = true
             .await
             .expect_err("missing profile should fail");
         assert!(err.to_string().contains("was not found"));
+    }
+
+    #[derive(Clone)]
+    struct BlockingCatalog {
+        inner: LocalProfileCatalog,
+        load_started: Arc<Notify>,
+        release_load: Arc<Notify>,
+        load_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ProfileCatalog for BlockingCatalog {
+        async fn list_profiles(&self) -> Result<Vec<ProfileMetadata>> {
+            self.inner.list_profiles().await
+        }
+
+        async fn load_profile(&self, id: &str) -> Result<ProfileDocument> {
+            let document = self.inner.load_profile(id).await?;
+            self.load_count.fetch_add(1, Ordering::AcqRel);
+            self.load_started.notify_one();
+            self.release_load.notified().await;
+            Ok(document)
+        }
+    }
+
+    #[tokio::test]
+    async fn reload_does_not_reinsert_in_flight_stale_runtime() {
+        let dir = temp_profile_dir();
+        write_profile(
+            dir.path(),
+            "alpha.toml",
+            r#"
+[agent]
+provider = "test"
+model = "first-model"
+system = "inline"
+"#,
+        );
+        let load_started = Arc::new(Notify::new());
+        let release_load = Arc::new(Notify::new());
+        let load_count = Arc::new(AtomicUsize::new(0));
+        let catalog = BlockingCatalog {
+            inner: LocalProfileCatalog::builder()
+                .include_embedded_default(false)
+                .local_dir(dir.path())
+                .build(),
+            load_started: load_started.clone(),
+            release_load: release_load.clone(),
+            load_count: load_count.clone(),
+        };
+        let (infra, _registry_dir) = test_infra().await;
+        let manager = Arc::new(ProfileRuntimeManager::with_infra(catalog, "alpha", infra));
+        let build = {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.runtime_for_profile("alpha").await })
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), load_started.notified())
+            .await
+            .expect("runtime build did not start");
+
+        write_profile(
+            dir.path(),
+            "alpha.toml",
+            r#"
+[agent]
+provider = "test"
+model = "second-model"
+system = "inline"
+"#,
+        );
+        manager.reload_profiles().await.unwrap();
+        release_load.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(5), load_started.notified())
+            .await
+            .expect("replacement runtime build did not start");
+        release_load.notify_one();
+        let current = tokio::time::timeout(std::time::Duration::from_secs(5), build)
+            .await
+            .expect("runtime build hung")
+            .expect("runtime task panicked")
+            .expect("generation change should retry runtime startup");
+
+        assert_eq!(current.profile_id(), "alpha");
+        assert_eq!(load_count.load(Ordering::Acquire), 2);
+        assert_eq!(manager.cached_runtime_count().await, 1);
+        let cached = manager.runtime_for_profile("alpha").await.unwrap();
+        assert!(Arc::ptr_eq(&current, &cached));
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_runtime_lookup_builds_one_quorum_listener() {
+        let dir = temp_profile_dir();
+        write_profile(
+            dir.path(),
+            "team.toml",
+            r#"
+[quorum]
+delegation = true
+verification = false
+snapshot_policy = "none"
+
+[planner]
+provider = "test"
+model = "planner-model"
+system = "plan"
+tools = ["delegate"]
+
+[[delegates]]
+id = "coder"
+provider = "test"
+model = "coder-model"
+system = "code"
+capabilities = ["coding"]
+"#,
+        );
+        let (mut infra, _registry_dir) = test_infra().await;
+        let fanout = Arc::new(crate::event_fanout::EventFanout::new());
+        infra.event_fanout = Some(fanout.clone());
+        let catalog = LocalProfileCatalog::builder()
+            .include_embedded_default(false)
+            .local_dir(dir.path())
+            .build();
+        let manager = Arc::new(ProfileRuntimeManager::with_infra(catalog, "team", infra));
+
+        let (first, second) = tokio::join!(
+            manager.runtime_for_profile("team"),
+            manager.runtime_for_profile("team")
+        );
+        let first = first.expect("first runtime");
+        let second = second.expect("second runtime");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            fanout.subscriber_count(),
+            2,
+            "one orchestrator and one model-inventory subscriber should be materialized"
+        );
+        assert_eq!(
+            manager.building_runtime_count().await,
+            1,
+            "the initialized cell remains the per-profile single-flight lock"
+        );
+        manager.shutdown().await;
+        tokio::task::yield_now().await;
+        assert_eq!(fanout.subscriber_count(), 0);
+        assert!(manager.runtime_for_profile("team").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn reload_rebuilds_changed_profile_runtime() {
+        let dir = temp_profile_dir();
+        write_profile(
+            dir.path(),
+            "alpha.toml",
+            r#"
+[agent]
+provider = "test"
+model = "first-model"
+system = "inline"
+"#,
+        );
+        let (infra, _registry_dir) = test_infra().await;
+        let catalog = LocalProfileCatalog::builder()
+            .include_embedded_default(false)
+            .local_dir(dir.path())
+            .build();
+        let manager = ProfileRuntimeManager::with_infra(catalog, "alpha", infra);
+        let first = manager.runtime_for_profile("alpha").await.unwrap();
+
+        write_profile(
+            dir.path(),
+            "alpha.toml",
+            r#"
+[agent]
+provider = "test"
+model = "second-model"
+system = "inline"
+"#,
+        );
+        manager.reload_profiles().await.unwrap();
+        let second = manager.runtime_for_profile("alpha").await.unwrap();
+
+        assert!(!Arc::ptr_eq(&first, &second));
+        manager.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -1953,7 +1953,24 @@ capabilities = ["coding"]
             "the initialized cell remains the per-profile single-flight lock"
         );
         manager.shutdown().await;
-        tokio::task::yield_now().await;
+
+        // Wait for subscriber_count to reach zero with timeout
+        let timeout = std::time::Duration::from_secs(5);
+        let start = std::time::Instant::now();
+        loop {
+            if fanout.subscriber_count() == 0 {
+                break;
+            }
+            if start.elapsed() >= timeout {
+                panic!(
+                    "Timeout waiting for subscribers to drop: {} remaining after {:?}",
+                    fanout.subscriber_count(),
+                    timeout
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
         assert_eq!(fanout.subscriber_count(), 0);
         assert!(manager.runtime_for_profile("team").await.is_err());
     }

--- a/crates/agent/src/quorum.rs
+++ b/crates/agent/src/quorum.rs
@@ -124,7 +124,12 @@ impl AgentQuorum {
     }
 
     pub async fn shutdown(&self) {
-        if let Some(handle) = self.listener_handle.lock().unwrap().take() {
+        let listener = self
+            .listener_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(handle) = listener {
             handle.abort();
         }
         if let Some(orchestrator) = &self.orchestrator {

--- a/crates/agent/src/quorum.rs
+++ b/crates/agent/src/quorum.rs
@@ -11,7 +11,7 @@ use crate::session::store::SessionStore;
 use crate::tools::CapabilityRequirement;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 type DelegateFactory =
     Box<dyn FnOnce(Arc<dyn StorageBackend>, Arc<EventFanout>) -> Arc<dyn AgentHandle> + Send>;
@@ -49,7 +49,16 @@ pub struct AgentQuorum {
     planner: Arc<dyn AgentHandle>,
     delegates: Vec<DelegateAgent>,
     orchestrator: Option<Arc<DelegationOrchestrator>>,
+    listener_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     cwd: Option<PathBuf>,
+}
+
+impl Drop for AgentQuorum {
+    fn drop(&mut self) {
+        if let Some(handle) = self.listener_handle.lock().unwrap().take() {
+            handle.abort();
+        }
+    }
 }
 
 impl AgentQuorum {
@@ -108,6 +117,15 @@ impl AgentQuorum {
     pub fn cwd(&self) -> Option<&PathBuf> {
         self.cwd.as_ref()
     }
+
+    pub async fn shutdown(&self) {
+        if let Some(handle) = self.listener_handle.lock().unwrap().take() {
+            handle.abort();
+        }
+        if let Some(orchestrator) = &self.orchestrator {
+            orchestrator.cancel_active_delegations().await;
+        }
+    }
 }
 
 pub struct AgentQuorumBuilder {
@@ -130,6 +148,7 @@ pub struct AgentQuorumBuilder {
     preregistered: Vec<(AgentInfo, Arc<dyn AgentHandle>)>,
     /// Optional routing snapshot handle for per-agent routing decisions.
     routing_snapshot: Option<crate::agent::remote::RoutingSnapshotHandle>,
+    profile_id: Option<String>,
 }
 
 impl AgentQuorumBuilder {
@@ -149,6 +168,7 @@ impl AgentQuorumBuilder {
             delegation_summarizer: None,
             preregistered: Vec::new(),
             routing_snapshot: None,
+            profile_id: None,
         }
     }
 
@@ -178,6 +198,7 @@ impl AgentQuorumBuilder {
             delegation_summarizer: None,
             preregistered: Vec::new(),
             routing_snapshot: None,
+            profile_id: None,
         }
     }
 
@@ -268,6 +289,11 @@ impl AgentQuorumBuilder {
         snapshot: crate::agent::remote::RoutingSnapshotHandle,
     ) -> Self {
         self.routing_snapshot = Some(snapshot);
+        self
+    }
+
+    pub fn with_profile_id(mut self, profile_id: impl Into<String>) -> Self {
+        self.profile_id = Some(profile_id.into());
         self
     }
 
@@ -370,16 +396,19 @@ impl AgentQuorumBuilder {
             if let Some(snap) = self.routing_snapshot {
                 orch = orch.with_routing_snapshot(snap);
             }
+            if let Some(profile_id) = self.profile_id {
+                orch = orch.with_profile_id(profile_id);
+            }
             let orchestrator = Arc::new(orch);
-
-            // All local agents are validated against this fanout above.
-            let _listener_handle = orchestrator.start_listening(&self.event_fanout);
 
             Some(orchestrator)
         } else {
             None
         };
 
+        let listener_handle = orchestrator
+            .as_ref()
+            .map(|orchestrator| orchestrator.start_listening(&self.event_fanout));
         Ok(AgentQuorum {
             storage: self.storage,
             event_fanout: self.event_fanout,
@@ -387,6 +416,7 @@ impl AgentQuorumBuilder {
             planner,
             delegates,
             orchestrator,
+            listener_handle: Mutex::new(listener_handle),
             cwd: self.cwd,
         })
     }

--- a/crates/agent/src/quorum.rs
+++ b/crates/agent/src/quorum.rs
@@ -55,7 +55,12 @@ pub struct AgentQuorum {
 
 impl Drop for AgentQuorum {
     fn drop(&mut self) {
-        if let Some(handle) = self.listener_handle.lock().unwrap().take() {
+        // Recover the mutex guard even if poisoned to avoid panicking in Drop
+        let mut guard = match self.listener_handle.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(handle) = guard.take() {
             handle.abort();
         }
     }

--- a/crates/agent/src/quorum.rs
+++ b/crates/agent/src/quorum.rs
@@ -124,13 +124,22 @@ impl AgentQuorum {
     }
 
     pub async fn shutdown(&self) {
+        if let Some(orchestrator) = &self.orchestrator {
+            orchestrator.begin_shutdown();
+        }
         let listener = self
             .listener_handle
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take();
-        if let Some(handle) = listener {
-            handle.abort();
+        if let Some(mut handle) = listener {
+            tokio::select! {
+                _ = &mut handle => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                    handle.abort();
+                    let _ = handle.await;
+                }
+            }
         }
         if let Some(orchestrator) = &self.orchestrator {
             orchestrator.cancel_active_delegations().await;

--- a/crates/agent/src/quorum.rs
+++ b/crates/agent/src/quorum.rs
@@ -130,6 +130,10 @@ impl AgentQuorum {
         if let Some(orchestrator) = &self.orchestrator {
             orchestrator.cancel_active_delegations().await;
         }
+        self.planner.shutdown().await;
+        for delegate in &self.delegates {
+            delegate.agent.shutdown().await;
+        }
     }
 }
 

--- a/crates/agent/src/runner.rs
+++ b/crates/agent/src/runner.rs
@@ -218,6 +218,10 @@ impl AgentRunner {
         self.0.profiles()
     }
 
+    pub async fn shutdown(&self) {
+        self.0.shutdown().await;
+    }
+
     /// Access the underlying `AgentHandle` for advanced use cases.
     pub fn handle(&self) -> std::sync::Arc<crate::agent::LocalAgentHandle> {
         self.0.handle()

--- a/crates/agent/src/session/domain.rs
+++ b/crates/agent/src/session/domain.rs
@@ -185,6 +185,14 @@ pub enum DelegationStatus {
     Cancelled,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelegationClaim {
+    Claimed,
+    AlreadyClaimed,
+    NotFound,
+    InvalidState(DelegationStatus),
+}
+
 /// Agent-to-agent delegation record
 #[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/agent/src/session/repo_delegation.rs
+++ b/crates/agent/src/session/repo_delegation.rs
@@ -1,6 +1,6 @@
 //! SQLite implementation of DelegationRepository
 
-use crate::session::domain::{Delegation, DelegationStatus};
+use crate::session::domain::{Delegation, DelegationClaim, DelegationStatus};
 use crate::session::error::{SessionError, SessionResult};
 use crate::session::repository::DelegationRepository;
 use async_trait::async_trait;
@@ -161,29 +161,76 @@ impl DelegationRepository for SqliteDelegationRepository {
         .await
     }
 
-    async fn update_delegation_status(
-        &self,
-        delegation_id: &str,
-        status: DelegationStatus,
-    ) -> SessionResult<()> {
-        let delegation_id_owned = delegation_id.to_string();
+    async fn claim_delegation(&self, delegation_id: &str) -> SessionResult<DelegationClaim> {
+        let delegation_id = delegation_id.to_string();
         self.run_blocking(move |conn| {
             let affected = conn.execute(
-                "UPDATE delegations SET status = ? WHERE public_id = ?",
-                params![status.to_string(), delegation_id_owned],
+                "UPDATE delegations SET status = ? WHERE public_id = ? AND status = ?",
+                params![
+                    DelegationStatus::Running.to_string(),
+                    delegation_id,
+                    DelegationStatus::Requested.to_string()
+                ],
             )?;
-            if affected == 0 {
-                return Err(rusqlite::Error::QueryReturnedNoRows);
+            if affected == 1 {
+                return Ok(DelegationClaim::Claimed);
             }
-            Ok(())
+
+            let status = conn
+                .query_row(
+                    "SELECT status FROM delegations WHERE public_id = ?",
+                    params![delegation_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            match status {
+                None => Ok(DelegationClaim::NotFound),
+                Some(status) => {
+                    let status = status.parse().map_err(|message: String| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            message.into(),
+                        )
+                    })?;
+                    if status == DelegationStatus::Running {
+                        Ok(DelegationClaim::AlreadyClaimed)
+                    } else {
+                        Ok(DelegationClaim::InvalidState(status))
+                    }
+                }
+            }
         })
         .await
-        .map_err(|e| match e {
-            SessionError::DatabaseError(_) => {
-                SessionError::DelegationNotFound(delegation_id.to_string())
-            }
-            _ => e,
+    }
+
+    async fn transition_delegation_status(
+        &self,
+        delegation_id: &str,
+        expected: DelegationStatus,
+        next: DelegationStatus,
+    ) -> SessionResult<bool> {
+        let delegation_id = delegation_id.to_string();
+        self.run_blocking(move |conn| {
+            let completed_at = matches!(
+                next,
+                DelegationStatus::Complete
+                    | DelegationStatus::Failed
+                    | DelegationStatus::Cancelled
+            )
+            .then(|| format_rfc3339(&OffsetDateTime::now_utc()));
+            conn.execute(
+                "UPDATE delegations SET status = ?, completed_at = ? WHERE public_id = ? AND status = ?",
+                params![
+                    next.to_string(),
+                    completed_at,
+                    delegation_id,
+                    expected.to_string()
+                ],
+            )
+            .map(|affected| affected == 1)
         })
+        .await
     }
 
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()> {

--- a/crates/agent/src/session/repo_tests.rs
+++ b/crates/agent/src/session/repo_tests.rs
@@ -13,8 +13,8 @@ mod tests {
 
     use crate::session::domain::{
         Alternative, AlternativeStatus, Artifact, Decision, DecisionStatus, Delegation,
-        DelegationStatus, ForkOrigin, ForkPointType, IntentSnapshot, ProgressEntry, ProgressKind,
-        Task, TaskKind, TaskStatus,
+        DelegationClaim, DelegationStatus, ForkOrigin, ForkPointType, IntentSnapshot,
+        ProgressEntry, ProgressKind, Task, TaskKind, TaskStatus,
     };
     use crate::session::repository::{
         ArtifactRepository, DecisionRepository, DelegationRepository, IntentRepository,
@@ -809,16 +809,21 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn update_delegation_status() {
-            let (session_public_id, session_id, repo) = make_session_and_repo().await;
+        async fn delegation_claim_distinguishes_claimed_and_already_running() {
+            let (_session_public_id, session_id, repo) = make_session_and_repo().await;
             let created = repo
-                .create_delegation(make_delegation(session_id, "agent-x", "run task"))
+                .create_delegation(make_delegation(session_id, "agent-x", "run once"))
                 .await
                 .unwrap();
 
-            repo.update_delegation_status(&created.public_id, DelegationStatus::Running)
-                .await
-                .unwrap();
+            assert_eq!(
+                repo.claim_delegation(&created.public_id).await.unwrap(),
+                DelegationClaim::Claimed
+            );
+            assert_eq!(
+                repo.claim_delegation(&created.public_id).await.unwrap(),
+                DelegationClaim::AlreadyClaimed
+            );
 
             let fetched = repo
                 .get_delegation(&created.public_id)
@@ -826,19 +831,84 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(fetched.status, DelegationStatus::Running);
+        }
 
-            repo.update_delegation_status(&created.public_id, DelegationStatus::Complete)
+        #[tokio::test]
+        async fn delegation_claim_reports_missing_and_terminal_rows() {
+            let (_session_public_id, session_id, repo) = make_session_and_repo().await;
+            assert_eq!(
+                repo.claim_delegation("missing").await.unwrap(),
+                DelegationClaim::NotFound
+            );
+
+            let mut terminal = make_delegation(session_id, "agent-x", "already done");
+            terminal.status = DelegationStatus::Complete;
+            let terminal = repo.create_delegation(terminal).await.unwrap();
+            assert_eq!(
+                repo.claim_delegation(&terminal.public_id).await.unwrap(),
+                DelegationClaim::InvalidState(DelegationStatus::Complete)
+            );
+        }
+
+        #[tokio::test]
+        async fn concurrent_delegation_claim_has_one_winner() {
+            let (_session_public_id, session_id, repo) = make_session_and_repo().await;
+            let created = repo
+                .create_delegation(make_delegation(session_id, "agent-x", "run once"))
                 .await
                 .unwrap();
 
-            let fetched2 = repo
+            let first = repo.claim_delegation(&created.public_id);
+            let second = repo.claim_delegation(&created.public_id);
+            let (first, second) = tokio::join!(first, second);
+
+            assert_eq!(
+                [first.unwrap(), second.unwrap()]
+                    .into_iter()
+                    .filter(|result| *result == DelegationClaim::Claimed)
+                    .count(),
+                1
+            );
+        }
+
+        #[tokio::test]
+        async fn guarded_transition_rejects_stale_terminal_update() {
+            let (_session_public_id, session_id, repo) = make_session_and_repo().await;
+            let created = repo
+                .create_delegation(make_delegation(session_id, "agent-x", "run once"))
+                .await
+                .unwrap();
+            assert_eq!(
+                repo.claim_delegation(&created.public_id).await.unwrap(),
+                DelegationClaim::Claimed
+            );
+            assert!(
+                repo.transition_delegation_status(
+                    &created.public_id,
+                    DelegationStatus::Running,
+                    DelegationStatus::Complete,
+                )
+                .await
+                .unwrap()
+            );
+            assert!(
+                !repo
+                    .transition_delegation_status(
+                        &created.public_id,
+                        DelegationStatus::Running,
+                        DelegationStatus::Failed,
+                    )
+                    .await
+                    .unwrap()
+            );
+
+            let completed = repo
                 .get_delegation(&created.public_id)
                 .await
                 .unwrap()
                 .unwrap();
-            assert_eq!(fetched2.status, DelegationStatus::Complete);
-
-            let _ = session_public_id;
+            assert_eq!(completed.status, DelegationStatus::Complete);
+            assert!(completed.completed_at.is_some());
         }
 
         #[tokio::test]

--- a/crates/agent/src/session/repository.rs
+++ b/crates/agent/src/session/repository.rs
@@ -207,12 +207,19 @@ pub trait DelegationRepository: Send + Sync {
     /// List delegations for a session
     async fn list_delegations(&self, session_id: &str) -> SessionResult<Vec<Delegation>>;
 
-    /// Update delegation status
-    async fn update_delegation_status(
+    /// Atomically transition a requested delegation to running.
+    async fn claim_delegation(
         &self,
         delegation_id: &str,
-        status: DelegationStatus,
-    ) -> SessionResult<()>;
+    ) -> SessionResult<crate::session::domain::DelegationClaim>;
+
+    /// Atomically transition a delegation from the expected status.
+    async fn transition_delegation_status(
+        &self,
+        delegation_id: &str,
+        expected: DelegationStatus,
+        next: DelegationStatus,
+    ) -> SessionResult<bool>;
 
     /// Update delegation
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()>;

--- a/crates/agent/src/session/runtime.rs
+++ b/crates/agent/src/session/runtime.rs
@@ -312,18 +312,6 @@ impl RuntimeContext {
         Ok(stored_delegation)
     }
 
-    /// Update delegation status
-    pub async fn update_delegation_status(
-        &self,
-        delegation_id: &str,
-        status: DelegationStatus,
-    ) -> SessionResult<()> {
-        self.store
-            .update_delegation_status(delegation_id, status)
-            .await?;
-        Ok(())
-    }
-
     /// Update task status
     pub async fn update_task_status(&mut self, status: TaskStatus) -> SessionResult<()> {
         if let Some(task) = &mut self.active_task {

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -1075,13 +1075,23 @@ impl SessionStore for SqliteStorage {
         repo.list_delegations(session_id).await
     }
 
-    async fn update_delegation_status(
+    async fn claim_delegation(
         &self,
         delegation_id: &str,
-        status: DelegationStatus,
-    ) -> SessionResult<()> {
+    ) -> SessionResult<crate::session::domain::DelegationClaim> {
         let repo = SqliteDelegationRepository::new(self.conn.clone());
-        repo.update_delegation_status(delegation_id, status).await
+        repo.claim_delegation(delegation_id).await
+    }
+
+    async fn transition_delegation_status(
+        &self,
+        delegation_id: &str,
+        expected: DelegationStatus,
+        next: DelegationStatus,
+    ) -> SessionResult<bool> {
+        let repo = SqliteDelegationRepository::new(self.conn.clone());
+        repo.transition_delegation_status(delegation_id, expected, next)
+            .await
     }
 
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()> {

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -403,11 +403,16 @@ pub trait SessionStore: Send + Sync {
     async fn create_delegation(&self, delegation: Delegation) -> SessionResult<Delegation>;
     async fn get_delegation(&self, delegation_id: &str) -> SessionResult<Option<Delegation>>;
     async fn list_delegations(&self, session_id: &str) -> SessionResult<Vec<Delegation>>;
-    async fn update_delegation_status(
+    async fn claim_delegation(
         &self,
         delegation_id: &str,
-        status: DelegationStatus,
-    ) -> SessionResult<()>;
+    ) -> SessionResult<crate::session::domain::DelegationClaim>;
+    async fn transition_delegation_status(
+        &self,
+        delegation_id: &str,
+        expected: DelegationStatus,
+        next: DelegationStatus,
+    ) -> SessionResult<bool>;
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()>;
 
     // Undo/Redo methods

--- a/crates/agent/src/test_utils/mocks.rs
+++ b/crates/agent/src/test_utils/mocks.rs
@@ -159,11 +159,16 @@ mock! {
         async fn create_delegation(&self, delegation: Delegation) -> SessionResult<Delegation>;
         async fn get_delegation(&self, delegation_id: &str) -> SessionResult<Option<Delegation>>;
         async fn list_delegations(&self, session_id: &str) -> SessionResult<Vec<Delegation>>;
-        async fn update_delegation_status(
+        async fn claim_delegation(
             &self,
             delegation_id: &str,
-            status: DelegationStatus,
-        ) -> SessionResult<()>;
+        ) -> SessionResult<crate::session::domain::DelegationClaim>;
+        async fn transition_delegation_status(
+            &self,
+            delegation_id: &str,
+            expected: DelegationStatus,
+            next: DelegationStatus,
+        ) -> SessionResult<bool>;
         async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()>;
         async fn peek_revert_state(
             &self,

--- a/crates/querymt-mobile-ffi/src/agent.rs
+++ b/crates/querymt-mobile-ffi/src/agent.rs
@@ -8,8 +8,8 @@ use crate::types::FfiErrorCode;
 use querymt::plugin::host::PluginRegistry;
 use querymt_agent::config::{Config, ConfigSource};
 use querymt_agent::profiles::{
-    DEFAULT_EMBEDDED_PROFILE_KEY, LocalProfileCatalog, ProfileCatalog, ProfileRuntimeManager,
-    standard_embedded_profile_catalog_builder,
+    DEFAULT_EMBEDDED_PROFILE_KEY, LocalProfileCatalog, ProfileCatalog, ProfileRuntime,
+    ProfileRuntimeManager, standard_embedded_profile_catalog_builder,
 };
 use std::ffi::CStr;
 use std::path::PathBuf;
@@ -124,15 +124,22 @@ async fn init_agent_async(config: Config) -> Result<u64, FfiErrorCode> {
             );
             FfiErrorCode::RuntimeError
         })?;
-    let profile_manager = Arc::new(ProfileRuntimeManager::with_infra_boxed(
-        Arc::new(profile_catalog) as Arc<dyn ProfileCatalog>,
-        DEFAULT_EMBEDDED_PROFILE_KEY,
-        infra.clone(),
-    ));
+    let profile_catalog: Arc<dyn ProfileCatalog> = Arc::new(profile_catalog);
+    let root_metadata = profile_catalog
+        .load_profile(DEFAULT_EMBEDDED_PROFILE_KEY)
+        .await
+        .map_err(|e| {
+            set_last_error(
+                FfiErrorCode::RuntimeError,
+                format!("Failed to load default profile metadata: {:#}", e),
+            );
+            FfiErrorCode::RuntimeError
+        })?
+        .metadata;
 
     let agent = match config {
         Config::Single(single) => {
-            querymt_agent::api::Agent::from_single_config_with_infra(*single, infra)
+            querymt_agent::api::Agent::from_single_config_with_infra(*single, infra.clone())
                 .await
                 .map_err(|e| {
                     set_last_error(
@@ -144,7 +151,18 @@ async fn init_agent_async(config: Config) -> Result<u64, FfiErrorCode> {
         }
         Config::Multi(quorum) => {
             log::info!("Initializing multi-agent/quorum config");
-            querymt_agent::api::Agent::from_quorum_config_with_infra(*quorum, infra)
+            let builder = querymt_agent::api::Agent::builder_from_quorum_config(*quorum, None)
+                .map_err(|e| {
+                    set_last_error(
+                        FfiErrorCode::RuntimeError,
+                        format!("Quorum configuration failed: {:#}", e),
+                    );
+                    FfiErrorCode::RuntimeError
+                })?;
+            builder
+                .with_profile_id(DEFAULT_EMBEDDED_PROFILE_KEY)
+                .infra(infra.clone())
+                .build()
                 .await
                 .map_err(|e| {
                     set_last_error(
@@ -155,6 +173,14 @@ async fn init_agent_async(config: Config) -> Result<u64, FfiErrorCode> {
                 })?
         }
     };
+    let profile_manager = Arc::new(ProfileRuntimeManager::with_runtime(
+        profile_catalog,
+        infra,
+        ProfileRuntime {
+            metadata: root_metadata,
+            agent: agent.clone(),
+        },
+    ));
 
     let (handle, reused_runtime) = state::attach_or_insert_runtime_agent(agent, storage);
 


### PR DESCRIPTION
prevent duplicate delegation execution by sharing profile runtimes, atomically claiming requests, and scoping execution to the bound profile.

clean up quorum listeners and active delegations across reload and shutdown, guard timeout and terminal status transitions, and always shut down independently built root agents when profiles are attached.

claim failures only fail unclaimed requests, so a listener with storage errors cannot overwrite another listener's running delegation.

note: reloading a changed materialized profile cancels active delegations owned by its stale runtime before replacement.

tests: `cargo test -p querymt-agent --lib --features dashboard,oauth`; focused delegation, profile, repository, shutdown, and remote profile tests; `cargo clippy -p querymt-agent --lib --tests --features dashboard,oauth,remote -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profile-aware agent and quorum initialization.
  - Added profile-specific delegation routing and validation.
  - Added graceful shutdown for agents, quorums, and active delegations.
  - Added safer profile runtime reloading and lifecycle management.

- **Bug Fixes**
  - Prevented unbound or mismatched sessions from starting delegations.
  - Improved delegation state handling to avoid duplicate claims and conflicting updates.
  - Timed-out or shutting-down delegations are now cancelled only when appropriate.
  - Loading a session without its required profile now returns a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->