### PR TITLE
fix(agent): preserve delegation state and resume delegate sessions

### DIFF
--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -426,6 +426,18 @@ impl LocalAgentHandle {
                         "sessionId": session_id,
                     }))
                 })?;
+            if let Some(agent_id) = binding.agent_id.as_deref() {
+                let delegate_handle = runtime.session_handle(Some(agent_id)).ok_or_else(|| {
+                    Error::invalid_params().data(serde_json::json!({
+                        "message": "Session is bound to an unknown delegate",
+                        "profileId": binding.profile_id,
+                        "agentId": agent_id,
+                        "sessionId": session_id,
+                    }))
+                })?;
+                return delegate_handle.load_session(req).await;
+            }
+
             let profile_handle = runtime.agent().handle();
             let bridge = self.bridge.lock().ok().and_then(|guard| guard.clone());
             if let Some(bridge) = bridge {

--- a/crates/agent/src/agent/handle/send_agent_lifecycle.rs
+++ b/crates/agent/src/agent/handle/send_agent_lifecycle.rs
@@ -207,14 +207,9 @@ impl LocalAgentHandle {
     ) -> Result<DeleteSessionResponse, Error> {
         let session_id = req.session_id.to_string();
 
-        let is_loaded = {
-            let registry = self.registry.lock().await;
-            registry.get(&session_id).is_some()
-        };
-        if is_loaded {
-            // Closing is best-effort: deleting persisted history is the primary intent.
-            let _ = self.stop_session(&session_id).await;
-        }
+        // Closing is best-effort: deleting persisted history is the primary intent.
+        // Route through the session binding so delegated runtimes are released too.
+        let _ = self.stop_session(&session_id).await;
 
         let exists = self
             .config
@@ -226,6 +221,9 @@ impl LocalAgentHandle {
             .is_some();
         if !exists {
             self.clear_delegate_model_overrides(&session_id).await;
+            if let Some(profiles) = self.profiles() {
+                profiles.forget_session_binding(&session_id).await;
+            }
             return Ok(DeleteSessionResponse::new());
         }
 
@@ -238,6 +236,9 @@ impl LocalAgentHandle {
                 Error::internal_error().data(serde_json::json!({"error": e.to_string()}))
             })?;
         self.clear_delegate_model_overrides(&session_id).await;
+        if let Some(profiles) = self.profiles() {
+            profiles.forget_session_binding(&session_id).await;
+        }
 
         Ok(DeleteSessionResponse::new())
     }

--- a/crates/agent/src/agent/handle/session_control.rs
+++ b/crates/agent/src/agent/handle/session_control.rs
@@ -2,36 +2,53 @@ use super::utils::format_prefixed_error_chain;
 use super::*;
 
 impl LocalAgentHandle {
+    async fn bound_session_handle(
+        &self,
+        session_id: &str,
+    ) -> Result<
+        Option<(
+            Arc<dyn crate::agent::handle::AgentHandle>,
+            crate::profiles::SessionProfileBinding,
+        )>,
+        Error,
+    > {
+        let Some(profiles) = self.profiles() else {
+            return Ok(None);
+        };
+        let Some(binding) = profiles.session_binding(session_id).await else {
+            return Ok(None);
+        };
+        let runtime = profiles
+            .runtime_for_profile(&binding.profile_id)
+            .await
+            .map_err(|err| {
+                Error::internal_error().data(serde_json::json!({
+                    "message": format_prefixed_error_chain(
+                        &format!("Failed to load profile '{}'", binding.profile_id),
+                        &err,
+                    ),
+                    "profileId": binding.profile_id,
+                    "sessionId": session_id,
+                }))
+            })?;
+        let session_handle = runtime
+            .session_handle(binding.agent_id.as_deref())
+            .ok_or_else(|| {
+                Error::invalid_params().data(serde_json::json!({
+                    "message": "session is bound to an unknown delegate",
+                    "sessionId": session_id,
+                    "profileId": binding.profile_id,
+                    "agentId": binding.agent_id,
+                }))
+            })?;
+        Ok(Some((session_handle, binding)))
+    }
+
     pub(crate) async fn session_ref_for_agent_session(
         &self,
         session_id: &str,
     ) -> Result<SessionActorRef, Error> {
-        if let Some(profiles) = self.profiles()
-            && let Some(binding) = profiles.session_binding(session_id).await
-        {
-            let runtime = profiles
-                .runtime_for_profile(&binding.profile_id)
-                .await
-                .map_err(|err| {
-                    Error::internal_error().data(serde_json::json!({
-                        "message": format_prefixed_error_chain(
-                            &format!("Failed to load profile '{}'", binding.profile_id),
-                            &err,
-                        ),
-                        "profileId": binding.profile_id,
-                        "sessionId": session_id,
-                    }))
-                })?;
-            let session_handle = runtime
-                .session_handle(binding.agent_id.as_deref())
-                .ok_or_else(|| {
-                    Error::invalid_params().data(serde_json::json!({
-                        "message": "session is bound to an unknown delegate",
-                        "sessionId": session_id,
-                        "profileId": binding.profile_id,
-                        "agentId": binding.agent_id,
-                    }))
-                })?;
+        if let Some((session_handle, binding)) = self.bound_session_handle(session_id).await? {
             let local_handle = session_handle
                 .as_any()
                 .downcast_ref::<LocalAgentHandle>()
@@ -64,6 +81,25 @@ impl LocalAgentHandle {
     }
 
     pub async fn stop_session(&self, session_id: &str) -> Result<(), Error> {
+        if let Some((session_handle, binding)) = self.bound_session_handle(session_id).await? {
+            let local_handle = session_handle
+                .as_any()
+                .downcast_ref::<LocalAgentHandle>()
+                .ok_or_else(|| {
+                    Error::internal_error().data(serde_json::json!({
+                        "message": "bound session runtime is not local",
+                        "sessionId": session_id,
+                        "profileId": binding.profile_id,
+                        "agentId": binding.agent_id,
+                    }))
+                })?;
+            return local_handle.stop_session_in_runtime(session_id).await;
+        }
+
+        self.stop_session_in_runtime(session_id).await
+    }
+
+    async fn stop_session_in_runtime(&self, session_id: &str) -> Result<(), Error> {
         use crate::agent::messages::{SessionRuntimePhase, SessionRuntimeStatus};
 
         const STOP_ESCALATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
@@ -91,38 +127,31 @@ impl LocalAgentHandle {
             .get_runtime_status()
             .await
             .unwrap_or(SessionRuntimeStatus::Running);
-        if status.phase == SessionRuntimePhase::Idle {
+        let stopped_gracefully = status.phase == SessionRuntimePhase::Idle
+            || (status.phase == SessionRuntimePhase::CancelRequested && !session_ref.is_remote());
+        if stopped_gracefully {
             tracing::debug!(
-                "Session {} stop: status=Idle, graceful shutdown — returning without force-stop",
                 session_id,
+                phase = ?status.phase,
+                "session stop completed gracefully; releasing runtime resources",
             );
-            return Ok(());
-        }
-        // For remote sessions, CancelRequested doesn't mean the prompt is done —
-        // the provider stream might still be active on the remote node.
-        if status.phase == SessionRuntimePhase::CancelRequested && !session_ref.is_remote() {
-            tracing::debug!(
-                "Session {} stop: status=CancelRequested (local), graceful shutdown — returning without force-stop",
-                session_id,
-            );
-            return Ok(());
-        }
+        } else {
+            if status.phase == SessionRuntimePhase::CancelRequested {
+                tracing::warn!(
+                    "Session {} stop: still CancelRequested after {:?}; escalating to force-stop",
+                    session_id,
+                    STOP_ESCALATION_TIMEOUT
+                );
+            }
 
-        if status.phase == SessionRuntimePhase::CancelRequested {
-            tracing::warn!(
-                "Session {} stop: still CancelRequested after {:?}; escalating to force-stop",
+            self.config.emit_event(
                 session_id,
-                STOP_ESCALATION_TIMEOUT
+                AgentEventKind::SessionForceStopped {
+                    escalated_after_ms: STOP_ESCALATION_TIMEOUT.as_millis() as u64,
+                    reason: "graceful cancellation timeout elapsed".to_string(),
+                },
             );
         }
-
-        self.config.emit_event(
-            session_id,
-            AgentEventKind::SessionForceStopped {
-                escalated_after_ms: STOP_ESCALATION_TIMEOUT.as_millis() as u64,
-                reason: "graceful cancellation timeout elapsed".to_string(),
-            },
-        );
 
         if session_ref.is_remote() {
             #[cfg(feature = "remote")]
@@ -236,8 +265,10 @@ impl LocalAgentHandle {
                 let mut registry = self.registry.lock().await;
                 registry.remove(session_id)
             };
-            if let Some(session_ref) = removed {
-                let _ = session_ref.shutdown().await;
+            if let Some(session_ref) = removed
+                && let Err(err) = session_ref.shutdown().await
+            {
+                tracing::warn!(session_id, error = %err, "failed to shut down session actor");
             }
         }
 

--- a/crates/agent/src/agent/handle/session_control.rs
+++ b/crates/agent/src/agent/handle/session_control.rs
@@ -22,13 +22,34 @@ impl LocalAgentHandle {
                         "sessionId": session_id,
                     }))
                 })?;
-            let profile_handle = runtime.agent().handle();
-            let registry = profile_handle.registry.lock().await;
+            let session_handle = runtime
+                .session_handle(binding.agent_id.as_deref())
+                .ok_or_else(|| {
+                    Error::invalid_params().data(serde_json::json!({
+                        "message": "session is bound to an unknown delegate",
+                        "sessionId": session_id,
+                        "profileId": binding.profile_id,
+                        "agentId": binding.agent_id,
+                    }))
+                })?;
+            let local_handle = session_handle
+                .as_any()
+                .downcast_ref::<LocalAgentHandle>()
+                .ok_or_else(|| {
+                    Error::internal_error().data(serde_json::json!({
+                        "message": "bound session runtime is not local",
+                        "sessionId": session_id,
+                        "profileId": binding.profile_id,
+                        "agentId": binding.agent_id,
+                    }))
+                })?;
+            let registry = local_handle.registry.lock().await;
             return registry.get(session_id).cloned().ok_or_else(|| {
                 Error::invalid_params().data(serde_json::json!({
-                    "message": "unknown session for bound profile",
+                    "message": "unknown session for bound runtime",
                     "sessionId": session_id,
                     "profileId": binding.profile_id,
+                    "agentId": binding.agent_id,
                 }))
             });
         }

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -485,6 +485,55 @@ async fn test_set_profile_config_option_rejects_different_bound_profile() {
 }
 
 #[tokio::test]
+async fn test_profile_bound_delegate_session_resolves_delegate_actor() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .expect("profiles configured")
+        .runtime_for_profile("quorum")
+        .await
+        .expect("quorum runtime");
+    let delegate_handle = runtime.agent().delegate("coder").expect("coder delegate");
+    let delegate_handle = delegate_handle
+        .as_any()
+        .downcast_ref::<LocalAgentHandle>()
+        .expect("local delegate");
+    let session_id = "delegate-session";
+    let actor = SessionActor::new(
+        delegate_handle.config.clone(),
+        session_id.to_string(),
+        crate::agent::core::SessionRuntime::new(
+            None,
+            std::collections::HashMap::new(),
+            crate::agent::core::McpToolState::empty(),
+        ),
+    );
+    let actor_ref = SessionActor::spawn(actor);
+    delegate_handle
+        .registry
+        .lock()
+        .await
+        .insert(session_id.to_string(), actor_ref);
+    let mut binding = runtime.session_binding();
+    binding.agent_id = Some("coder".to_string());
+    f.handle
+        .profiles()
+        .expect("profiles configured")
+        .set_session_binding(session_id, binding)
+        .await;
+
+    let resolved = f
+        .handle
+        .session_ref_for_agent_session(session_id)
+        .await
+        .expect("delegate actor should resolve");
+
+    assert_eq!(resolved.get_mode().await.unwrap(), AgentMode::Build);
+}
+
+#[tokio::test]
 async fn test_profile_handle_rejects_unbound_session_load() {
     let (f, _profile_dir) = profile_fixture_with_files(&[("alpha.toml", ALPHA_PROFILE_TOML)]).await;
     let session = f

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -484,6 +484,41 @@ async fn test_set_profile_config_option_rejects_different_bound_profile() {
     assert_eq!(err.code, agent_client_protocol::ErrorCode::InvalidParams);
 }
 
+async fn register_profile_bound_delegate_session(
+    f: &HandleFixture,
+    runtime: &Arc<crate::profiles::ProfileRuntime>,
+    session_id: &str,
+) -> (Arc<dyn AgentHandle>, SessionActorRef) {
+    let delegate_handle = runtime.agent().delegate("coder").expect("coder delegate");
+    let local_handle = delegate_handle
+        .as_any()
+        .downcast_ref::<LocalAgentHandle>()
+        .expect("local delegate");
+    let actor = SessionActor::new(
+        local_handle.config.clone(),
+        session_id.to_string(),
+        crate::agent::core::SessionRuntime::new(
+            None,
+            std::collections::HashMap::new(),
+            crate::agent::core::McpToolState::empty(),
+        ),
+    );
+    let actor_ref: SessionActorRef = SessionActor::spawn(actor).into();
+    local_handle
+        .registry
+        .lock()
+        .await
+        .insert(session_id.to_string(), actor_ref.clone());
+    let mut binding = runtime.session_binding();
+    binding.agent_id = Some("coder".to_string());
+    f.handle
+        .profiles()
+        .expect("profiles configured")
+        .set_session_binding(session_id, binding)
+        .await;
+    (delegate_handle, actor_ref)
+}
+
 #[tokio::test]
 async fn test_profile_bound_delegate_session_resolves_delegate_actor() {
     let (f, _profile_dir) =
@@ -495,34 +530,8 @@ async fn test_profile_bound_delegate_session_resolves_delegate_actor() {
         .runtime_for_profile("quorum")
         .await
         .expect("quorum runtime");
-    let delegate_handle = runtime.agent().delegate("coder").expect("coder delegate");
-    let delegate_handle = delegate_handle
-        .as_any()
-        .downcast_ref::<LocalAgentHandle>()
-        .expect("local delegate");
     let session_id = "delegate-session";
-    let actor = SessionActor::new(
-        delegate_handle.config.clone(),
-        session_id.to_string(),
-        crate::agent::core::SessionRuntime::new(
-            None,
-            std::collections::HashMap::new(),
-            crate::agent::core::McpToolState::empty(),
-        ),
-    );
-    let actor_ref = SessionActor::spawn(actor);
-    delegate_handle
-        .registry
-        .lock()
-        .await
-        .insert(session_id.to_string(), actor_ref);
-    let mut binding = runtime.session_binding();
-    binding.agent_id = Some("coder".to_string());
-    f.handle
-        .profiles()
-        .expect("profiles configured")
-        .set_session_binding(session_id, binding)
-        .await;
+    register_profile_bound_delegate_session(&f, &runtime, session_id).await;
 
     let resolved = f
         .handle
@@ -531,6 +540,95 @@ async fn test_profile_bound_delegate_session_resolves_delegate_actor() {
         .expect("delegate actor should resolve");
 
     assert_eq!(resolved.get_mode().await.unwrap(), AgentMode::Build);
+}
+
+#[tokio::test]
+async fn test_close_profile_bound_delegate_session_stops_delegate_actor() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .expect("profiles configured")
+        .runtime_for_profile("quorum")
+        .await
+        .expect("quorum runtime");
+    let session_id = "delegate-close-session";
+    let (delegate_handle, actor_ref) =
+        register_profile_bound_delegate_session(&f, &runtime, session_id).await;
+
+    SendAgent::close_session(
+        &f.handle,
+        CloseSessionRequest::new(SessionId::from(session_id.to_string())),
+    )
+    .await
+    .expect("close delegate session");
+
+    let delegate_handle = delegate_handle
+        .as_any()
+        .downcast_ref::<LocalAgentHandle>()
+        .expect("local delegate");
+    assert!(
+        delegate_handle
+            .registry
+            .lock()
+            .await
+            .get(session_id)
+            .is_none()
+    );
+    assert!(
+        actor_ref.get_mode().await.is_err(),
+        "delegate actor should stop"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_profile_bound_delegate_session_releases_runtime() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .expect("profiles configured")
+        .runtime_for_profile("quorum")
+        .await
+        .expect("quorum runtime");
+    let session_id = "delegate-delete-session";
+    let (delegate_handle, actor_ref) =
+        register_profile_bound_delegate_session(&f, &runtime, session_id).await;
+
+    SendAgent::delete_session(
+        &f.handle,
+        DeleteSessionRequest::new(SessionId::from(session_id.to_string())),
+    )
+    .await
+    .expect("delete delegate session");
+
+    let delegate_handle = delegate_handle
+        .as_any()
+        .downcast_ref::<LocalAgentHandle>()
+        .expect("local delegate");
+    assert!(
+        delegate_handle
+            .registry
+            .lock()
+            .await
+            .get(session_id)
+            .is_none()
+    );
+    assert!(
+        actor_ref.get_mode().await.is_err(),
+        "delegate actor should stop"
+    );
+    assert!(
+        f.handle
+            .profiles()
+            .expect("profiles configured")
+            .session_binding(session_id)
+            .await
+            .is_none(),
+        "delete should forget the runtime binding"
+    );
 }
 
 #[tokio::test]

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -471,6 +471,7 @@ impl DelegationOrchestrator {
                 let delegation_summarizer = self.delegation_summarizer.clone();
                 let delegate_model_overrides = self.delegate_model_overrides.clone();
                 let routing_snapshot = self.routing_snapshot.clone();
+                let profile_id = self.profile_id.clone();
                 let parent_session_id = session_id.to_string();
                 let parent_session_id_for_insert = parent_session_id.clone();
                 let delegation = delegation.clone();
@@ -520,6 +521,7 @@ impl DelegationOrchestrator {
                         active_delegations: active_delegations_for_spawn,
                         delegation_summarizer,
                         delegate_model_overrides,
+                        profile_id,
                         routing_snapshot,
                     };
                     execute_delegation(
@@ -633,6 +635,7 @@ struct DelegationContext {
     active_delegations: ActiveDelegations,
     delegation_summarizer: Option<Arc<super::summarizer::DelegationSummarizer>>,
     delegate_model_overrides: super::DelegateModelOverrideStore,
+    profile_id: Option<String>,
     routing_snapshot: Option<crate::agent::remote::RoutingSnapshotHandle>,
 }
 
@@ -846,6 +849,36 @@ async fn execute_delegation(
         }
     };
 
+    if let Some(profile_id) = ctx.profile_id.as_deref()
+        && let Err(err) = ctx
+            .store
+            .set_session_runtime_binding(
+                &child_session_id,
+                profile_id,
+                Some(&delegation.target_agent_id),
+            )
+            .await
+    {
+        let _ = session_ref.shutdown().await;
+        fail_delegation(
+            DelegationFailureContext {
+                event_sink: &ctx.event_sink,
+                delegator: &ctx.delegator,
+                store: &ctx.store,
+                hooks: Some(&ctx.hooks),
+                config: &ctx.config,
+                parent_session_id: &parent_session_id,
+                delegation_id: &delegation.public_id,
+                target_agent_id: Some(&delegation.target_agent_id),
+                objective: Some(&delegation.objective),
+            },
+            &format!("Failed to persist delegate session route: {err}"),
+        )
+        .await;
+        ctx.active_delegations.lock().await.remove(&delegation_id);
+        return;
+    }
+
     // Record child session info on the parent span.
     let span = tracing::Span::current();
     span.record("child_session_id", child_session_id.as_str());
@@ -1052,10 +1085,12 @@ async fn execute_delegation(
             .await;
 
             if let Some(summary) = summary {
-                // Persist to delegation record
-                let mut updated_delegation = delegation.clone();
-                updated_delegation.planning_summary = Some(summary.clone());
-                if let Err(e) = ctx.store.update_delegation(updated_delegation).await {
+                // Persist only the summary; the event copy still has the pre-claim status.
+                if let Err(e) = ctx
+                    .store
+                    .set_delegation_planning_summary(&delegation.public_id, &summary)
+                    .await
+                {
                     warn!("Failed to persist delegation summary: {}", e);
                 }
 

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -859,7 +859,15 @@ async fn execute_delegation(
             )
             .await
     {
-        let _ = session_ref.shutdown().await;
+        if let Err(shutdown_err) = session_ref.shutdown().await {
+            tracing::warn!(
+                delegation_id = %delegation.public_id,
+                child_session_id = %child_session_id,
+                target_agent_id = %delegation.target_agent_id,
+                error = %shutdown_err,
+                "Failed to shut down delegate session after runtime binding persistence failed"
+            );
+        }
         fail_delegation(
             DelegationFailureContext {
                 event_sink: &ctx.event_sink,

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -88,16 +88,13 @@ pub struct ProfileDocument {
 
 /// Binding between a session id and the profile runtime that owns it.
 ///
-/// This matters because resume/routing code must know which profile runtime owns a
-/// session; otherwise a session could be resumed under the wrong profile after the
-/// user switches profiles. Bindings are cached in memory and backed by a
-/// best-effort `profile_bindings` side table that maps session id to profile id.
-///
-/// The binding is advisory: missing or unavailable persisted profile ids are
-/// ignored so callers can fall back to the active profile behavior.
+/// This matters because resume/routing code must know which profile runtime and
+/// concrete agent own a session. Root sessions leave `agent_id` unset; delegated
+/// sessions name the sub-agent that must materialize them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionProfileBinding {
     pub profile_id: String,
+    pub agent_id: Option<String>,
     pub profile_fingerprint: Option<String>,
     pub profile_source: Option<String>,
     pub profile_config_kind: Option<String>,
@@ -121,12 +118,23 @@ impl ProfileRuntime {
     pub fn session_binding(&self) -> SessionProfileBinding {
         self.metadata.session_binding()
     }
+
+    pub fn session_handle(
+        &self,
+        agent_id: Option<&str>,
+    ) -> Option<Arc<dyn crate::agent::handle::AgentHandle>> {
+        match agent_id {
+            Some(agent_id) => self.agent.delegate(agent_id),
+            None => Some(self.agent.handle()),
+        }
+    }
 }
 
 impl ProfileMetadata {
     pub fn session_binding(&self) -> SessionProfileBinding {
         SessionProfileBinding {
             profile_id: self.id.clone(),
+            agent_id: None,
             profile_fingerprint: self.fingerprint.clone(),
             profile_source: Some(self.source.storage_label()),
             profile_config_kind: self
@@ -852,7 +860,11 @@ where
         };
         if let Err(err) = storage
             .session_store()
-            .set_profile_binding(&session_id, &binding.profile_id)
+            .set_session_runtime_binding(
+                &session_id,
+                &binding.profile_id,
+                binding.agent_id.as_deref(),
+            )
             .await
         {
             warn!(session_id, profile_id = %binding.profile_id, error = %err, "failed to persist session profile binding");
@@ -867,26 +879,27 @@ where
         let Some(storage) = &self.shared_infra.storage else {
             return None;
         };
-        let profile_id = match storage
+        let route = match storage
             .session_store()
-            .get_profile_binding(session_id)
+            .get_session_runtime_binding(session_id)
             .await
         {
-            Ok(Some(profile_id)) => profile_id,
+            Ok(Some(route)) => route,
             Ok(None) => return None,
             Err(err) => {
                 warn!(session_id, error = %err, "failed to read session profile binding");
                 return None;
             }
         };
-        let runtime = match self.runtime_for_profile(&profile_id).await {
+        let runtime = match self.runtime_for_profile(&route.profile_id).await {
             Ok(runtime) => runtime,
             Err(err) => {
-                warn!(session_id, profile_id, error = %err, "ignoring unavailable persisted session profile binding");
+                warn!(session_id, profile_id = route.profile_id, error = %err, "ignoring unavailable persisted session profile binding");
                 return None;
             }
         };
-        let binding = runtime.session_binding();
+        let mut binding = runtime.session_binding();
+        binding.agent_id = route.agent_id;
         self.session_bindings
             .lock()
             .await

--- a/crates/agent/src/session/repo_delegation.rs
+++ b/crates/agent/src/session/repo_delegation.rs
@@ -233,6 +233,31 @@ impl DelegationRepository for SqliteDelegationRepository {
         .await
     }
 
+    async fn set_delegation_planning_summary(
+        &self,
+        delegation_id: &str,
+        planning_summary: &str,
+    ) -> SessionResult<()> {
+        let delegation_id = delegation_id.to_string();
+        let delegation_id_for_update = delegation_id.clone();
+        let planning_summary = planning_summary.to_string();
+        self.run_blocking(move |conn| {
+            let affected = conn.execute(
+                "UPDATE delegations SET planning_summary = ? WHERE public_id = ?",
+                params![planning_summary, delegation_id_for_update],
+            )?;
+            if affected == 0 {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| match e {
+            SessionError::DatabaseError(_) => SessionError::DelegationNotFound(delegation_id),
+            _ => e,
+        })
+    }
+
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()> {
         let status_str = delegation.status.to_string();
         let completed_at = delegation.completed_at.as_ref().map(format_rfc3339);

--- a/crates/agent/src/session/repo_tests.rs
+++ b/crates/agent/src/session/repo_tests.rs
@@ -872,6 +872,34 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn planning_summary_update_preserves_running_status() {
+            let (_session_public_id, session_id, repo) = make_session_and_repo().await;
+            let created = repo
+                .create_delegation(make_delegation(session_id, "agent-x", "summarize safely"))
+                .await
+                .unwrap();
+            assert_eq!(
+                repo.claim_delegation(&created.public_id).await.unwrap(),
+                DelegationClaim::Claimed
+            );
+
+            repo.set_delegation_planning_summary(&created.public_id, "planning context")
+                .await
+                .unwrap();
+
+            let fetched = repo
+                .get_delegation(&created.public_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(fetched.status, DelegationStatus::Running);
+            assert_eq!(
+                fetched.planning_summary.as_deref(),
+                Some("planning context")
+            );
+        }
+
+        #[tokio::test]
         async fn guarded_transition_rejects_stale_terminal_update() {
             let (_session_public_id, session_id, repo) = make_session_and_repo().await;
             let created = repo

--- a/crates/agent/src/session/repository.rs
+++ b/crates/agent/src/session/repository.rs
@@ -223,4 +223,11 @@ pub trait DelegationRepository: Send + Sync {
 
     /// Update delegation
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()>;
+
+    /// Update only the generated planning summary without clobbering lifecycle state.
+    async fn set_delegation_planning_summary(
+        &self,
+        delegation_id: &str,
+        planning_summary: &str,
+    ) -> SessionResult<()>;
 }

--- a/crates/agent/src/session/sqlite_storage/migrations.rs
+++ b/crates/agent/src/session/sqlite_storage/migrations.rs
@@ -52,6 +52,10 @@ pub(super) const MIGRATIONS: &[Migration] = &[
         version: "0010_profile_bindings",
         apply: migration_0010_profile_bindings,
     },
+    Migration {
+        version: "0011_session_runtime_bindings",
+        apply: migration_0011_session_runtime_bindings,
+    },
 ];
 
 pub(super) fn apply_migrations(conn: &mut Connection) -> Result<(), rusqlite::Error> {
@@ -430,5 +434,10 @@ fn migration_0010_profile_bindings(conn: &mut Connection) -> Result<(), rusqlite
             );
         "#,
     )?;
+    Ok(())
+}
+
+fn migration_0011_session_runtime_bindings(conn: &mut Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch("ALTER TABLE profile_bindings ADD COLUMN agent_id TEXT;")?;
     Ok(())
 }

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -584,14 +584,27 @@ impl SessionStore for SqliteStorage {
     }
 
     async fn set_profile_binding(&self, session_id: &str, profile_id: &str) -> SessionResult<()> {
+        self.set_session_runtime_binding(session_id, profile_id, None)
+            .await
+    }
+
+    async fn set_session_runtime_binding(
+        &self,
+        session_id: &str,
+        profile_id: &str,
+        agent_id: Option<&str>,
+    ) -> SessionResult<()> {
         let session_id = session_id.to_string();
         let profile_id = profile_id.to_string();
+        let agent_id = agent_id.map(str::to_string);
         self.run_blocking(move |conn| {
             conn.execute(
-                "INSERT INTO profile_bindings (session_id, profile_id)
-                 VALUES (?1, ?2)
-                 ON CONFLICT(session_id) DO UPDATE SET profile_id = excluded.profile_id",
-                params![session_id, profile_id],
+                "INSERT INTO profile_bindings (session_id, profile_id, agent_id)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(session_id) DO UPDATE SET
+                    profile_id = excluded.profile_id,
+                    agent_id = excluded.agent_id",
+                params![session_id, profile_id, agent_id],
             )?;
             Ok(())
         })
@@ -605,6 +618,27 @@ impl SessionStore for SqliteStorage {
                 "SELECT profile_id FROM profile_bindings WHERE session_id = ?1",
                 params![session_id],
                 |row| row.get(0),
+            )
+            .optional()
+        })
+        .await
+    }
+
+    async fn get_session_runtime_binding(
+        &self,
+        session_id: &str,
+    ) -> SessionResult<Option<crate::session::store::SessionRuntimeBinding>> {
+        let session_id = session_id.to_string();
+        self.run_blocking(move |conn| {
+            conn.query_row(
+                "SELECT profile_id, agent_id FROM profile_bindings WHERE session_id = ?1",
+                params![session_id],
+                |row| {
+                    Ok(crate::session::store::SessionRuntimeBinding {
+                        profile_id: row.get(0)?,
+                        agent_id: row.get(1)?,
+                    })
+                },
             )
             .optional()
         })
@@ -1097,6 +1131,16 @@ impl SessionStore for SqliteStorage {
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()> {
         let repo = SqliteDelegationRepository::new(self.conn.clone());
         repo.update_delegation(delegation).await
+    }
+
+    async fn set_delegation_planning_summary(
+        &self,
+        delegation_id: &str,
+        planning_summary: &str,
+    ) -> SessionResult<()> {
+        let repo = SqliteDelegationRepository::new(self.conn.clone());
+        repo.set_delegation_planning_summary(delegation_id, planning_summary)
+            .await
     }
 
     async fn peek_revert_state(&self, session_id: &str) -> SessionResult<Option<RevertState>> {

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -139,6 +139,34 @@ async fn connect_with_options_without_migration_keeps_db_unmodified() {
 }
 
 #[tokio::test]
+async fn session_runtime_binding_round_trips_profile_and_delegate() {
+    let storage = SqliteStorage::connect(":memory:".into())
+        .await
+        .expect("in-memory storage");
+
+    storage
+        .set_session_runtime_binding("delegate-session", "quorum", Some("coder"))
+        .await
+        .expect("persist runtime binding");
+
+    let binding = storage
+        .get_session_runtime_binding("delegate-session")
+        .await
+        .expect("load runtime binding")
+        .expect("runtime binding");
+    assert_eq!(binding.profile_id, "quorum");
+    assert_eq!(binding.agent_id.as_deref(), Some("coder"));
+    assert_eq!(
+        storage
+            .get_profile_binding("delegate-session")
+            .await
+            .expect("load compatibility profile binding")
+            .as_deref(),
+        Some("quorum")
+    );
+}
+
+#[tokio::test]
 async fn custom_model_crud_round_trip() {
     use crate::session::store::CustomModel;
 

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -14,6 +14,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use time::OffsetDateTime;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionRuntimeBinding {
+    pub profile_id: String,
+    pub agent_id: Option<String>,
+}
+
 /// A bookmark for a remote session — enough metadata to re-discover and
 /// re-attach it after a server restart.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -257,11 +263,25 @@ pub trait SessionStore: Send + Sync {
     /// Set the LLM configuration id for a session
     async fn set_session_llm_config(&self, session_id: &str, config_id: i64) -> SessionResult<()>;
 
-    /// Persist the advisory profile binding for a session.
+    /// Persist the profile namespace for a root session.
     async fn set_profile_binding(&self, session_id: &str, profile_id: &str) -> SessionResult<()>;
 
-    /// Retrieve the advisory profile binding for a session.
+    /// Persist the profile namespace and concrete agent that owns a session runtime.
+    async fn set_session_runtime_binding(
+        &self,
+        session_id: &str,
+        profile_id: &str,
+        agent_id: Option<&str>,
+    ) -> SessionResult<()>;
+
+    /// Retrieve the profile namespace for compatibility with profile ownership checks.
     async fn get_profile_binding(&self, session_id: &str) -> SessionResult<Option<String>>;
+
+    /// Retrieve the complete runtime route for a session.
+    async fn get_session_runtime_binding(
+        &self,
+        session_id: &str,
+    ) -> SessionResult<Option<SessionRuntimeBinding>>;
 
     /// Remove the advisory profile binding for a session.
     async fn remove_profile_binding(&self, session_id: &str) -> SessionResult<()>;
@@ -414,6 +434,11 @@ pub trait SessionStore: Send + Sync {
         next: DelegationStatus,
     ) -> SessionResult<bool>;
     async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()>;
+    async fn set_delegation_planning_summary(
+        &self,
+        delegation_id: &str,
+        planning_summary: &str,
+    ) -> SessionResult<()>;
 
     // Undo/Redo methods
 

--- a/crates/agent/src/test_utils/mocks.rs
+++ b/crates/agent/src/test_utils/mocks.rs
@@ -52,10 +52,20 @@ mock! {
             session_id: &'b str,
             profile_id: &'c str,
         ) -> SessionResult<()>;
+        async fn set_session_runtime_binding<'a, 'b, 'c, 'd>(
+            &'a self,
+            session_id: &'b str,
+            profile_id: &'c str,
+            agent_id: Option<&'d str>,
+        ) -> SessionResult<()>;
         async fn get_profile_binding<'a, 'b>(
             &'a self,
             session_id: &'b str,
         ) -> SessionResult<Option<String>>;
+        async fn get_session_runtime_binding<'a, 'b>(
+            &'a self,
+            session_id: &'b str,
+        ) -> SessionResult<Option<crate::session::store::SessionRuntimeBinding>>;
         async fn remove_profile_binding<'a, 'b>(
             &'a self,
             session_id: &'b str,
@@ -170,6 +180,11 @@ mock! {
             next: DelegationStatus,
         ) -> SessionResult<bool>;
         async fn update_delegation(&self, delegation: Delegation) -> SessionResult<()>;
+        async fn set_delegation_planning_summary<'a, 'b, 'c>(
+            &'a self,
+            delegation_id: &'b str,
+            planning_summary: &'c str,
+        ) -> SessionResult<()>;
         async fn peek_revert_state(
             &self,
             session_id: &str,


### PR DESCRIPTION
## what changed

- preserve delegation lifecycle state when storing planning summaries
- persist profile and delegate ownership for delegated sessions
- route resumed sessions and subsequent operations to the owning delegate runtime

## why

this fixes issues introduced in https://github.com/querymt/querymt/pull/851. planning summary persistence could overwrite a running delegation with stale state, while resumed child sessions could be loaded through the profile root instead of their original delegate.

## validation

- `cargo fmt --all -- --check`
- `cargo check -p querymt-agent`
- focused delegation state, runtime binding, and delegate routing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can now be restored to their designated delegated agent.
  * Delegation planning summaries can be updated without changing delegation status.
  * Existing sessions retain compatibility through automatic database migration.

* **Bug Fixes**
  * Improved handling and error reporting for unknown or unsupported delegated agents.
  * Delegation failures now stop child sessions and remove failed work from active tracking.
  * Deleting sessions now releases delegated runtimes and removes stale bindings.

* **Tests**
  * Added coverage for delegated session lifecycle, runtime binding persistence, and planning-summary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->