### PR TITLE
feat: add support for pinning a provider for a profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11382,6 +11382,7 @@ dependencies = [
  "schemars 1.2.2",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "similarity-core",
  "similarity-py",
  "similarity-rs",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -83,6 +83,7 @@ regex.workspace = true
 tokio-util = { version = "0.7", features = ["compat", "rt"] }
 base64.workspace = true
 hex = "0.4"
+sha2 = "0.11"
 infer = "0.22"
 rayon = "1.11"
 

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -856,6 +856,9 @@ async fn execute_delegation(
                 &child_session_id,
                 profile_id,
                 Some(&delegation.target_agent_id),
+                None,
+                None,
+                None,
             )
             .await
     {

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -850,17 +850,14 @@ async fn execute_delegation(
     };
 
     if let Some(profile_id) = ctx.profile_id.as_deref()
-        && let Err(err) = ctx
-            .store
-            .set_session_runtime_binding(
-                &child_session_id,
-                profile_id,
-                Some(&delegation.target_agent_id),
-                None,
-                None,
-                None,
-            )
-            .await
+        && let Err(err) = persist_delegate_runtime_binding(
+            ctx.store.as_ref(),
+            &parent_session_id,
+            &child_session_id,
+            profile_id,
+            &delegation.target_agent_id,
+        )
+        .await
     {
         if let Err(shutdown_err) = session_ref.shutdown().await {
             tracing::warn!(
@@ -1403,6 +1400,29 @@ async fn execute_delegation(
     }
 }
 
+async fn persist_delegate_runtime_binding(
+    store: &dyn SessionStore,
+    parent_session_id: &str,
+    child_session_id: &str,
+    profile_id: &str,
+    agent_id: &str,
+) -> crate::session::error::SessionResult<()> {
+    let parent_binding = store.get_session_runtime_binding(parent_session_id).await?;
+    let matching_binding = parent_binding
+        .as_ref()
+        .filter(|binding| binding.profile_id == profile_id);
+    store
+        .set_session_runtime_binding(
+            child_session_id,
+            profile_id,
+            Some(agent_id),
+            matching_binding.and_then(|binding| binding.profile_fingerprint.as_deref()),
+            matching_binding.and_then(|binding| binding.provider_lock_digest.as_deref()),
+            matching_binding.and_then(|binding| binding.provider_locks_json.as_deref()),
+        )
+        .await
+}
+
 #[instrument(
     name = "delegation.fail",
     skip(ctx),
@@ -1839,6 +1859,74 @@ mod tests {
     use crate::session::sqlite_storage::SqliteStorage;
     use crate::test_utils::MockSessionStore;
     use async_trait::async_trait;
+
+    #[tokio::test]
+    async fn locked_profile_delegation_persists_restorable_provider_lock() {
+        let storage = SqliteStorage::connect(":memory:".into())
+            .await
+            .expect("in-memory storage");
+        storage
+            .set_session_runtime_binding(
+                "parent",
+                "locked-profile",
+                None,
+                Some("profile-fingerprint"),
+                Some("provider-lock"),
+                Some("{\"llama_cpp\":{}}"),
+            )
+            .await
+            .expect("persist parent binding");
+
+        persist_delegate_runtime_binding(&storage, "parent", "child", "locked-profile", "coder")
+            .await
+            .expect("persist delegate binding");
+
+        let restored = storage
+            .get_session_runtime_binding("child")
+            .await
+            .expect("restore delegate binding")
+            .expect("delegate binding");
+        assert_eq!(restored.profile_id, "locked-profile");
+        assert_eq!(restored.agent_id.as_deref(), Some("coder"));
+        assert_eq!(
+            restored.profile_fingerprint.as_deref(),
+            Some("profile-fingerprint")
+        );
+        assert_eq!(
+            restored.provider_lock_digest.as_deref(),
+            Some("provider-lock")
+        );
+        assert_eq!(
+            restored.provider_locks_json.as_deref(),
+            Some("{\"llama_cpp\":{}}")
+        );
+    }
+
+    #[tokio::test]
+    async fn unbound_profile_delegation_persists_null_provider_lock() {
+        let storage = SqliteStorage::connect(":memory:".into())
+            .await
+            .expect("in-memory storage");
+        persist_delegate_runtime_binding(
+            &storage,
+            "missing-parent",
+            "child",
+            "legacy-profile",
+            "coder",
+        )
+        .await
+        .expect("persist legacy delegate binding");
+
+        let restored = storage
+            .get_session_runtime_binding("child")
+            .await
+            .expect("restore delegate binding")
+            .expect("delegate binding");
+        assert_eq!(restored.profile_id, "legacy-profile");
+        assert_eq!(restored.profile_fingerprint, None);
+        assert_eq!(restored.provider_lock_digest, None);
+        assert_eq!(restored.provider_locks_json, None);
+    }
 
     // ── Minimal stub AgentHandle ──────────────────────────────────────────────
 

--- a/crates/agent/src/model_registry.rs
+++ b/crates/agent/src/model_registry.rs
@@ -244,8 +244,22 @@ async fn fetch_catalog_models(
     provider_name: &str,
 ) -> Vec<ModelEntry> {
     let registry = config.provider.plugin_registry();
+    let binding =
+        match querymt::plugin::host::ProviderResolver::resolve(registry.as_ref(), provider_name)
+            .await
+        {
+            Ok(binding) => binding,
+            Err(err) => {
+                log::debug!(
+                    "fetch_catalog_models: skipping provider='{}' because resolution failed: {}",
+                    provider_name,
+                    err
+                );
+                return Vec::new();
+            }
+        };
     let resolved = match resolve_provider_config(
-        &registry,
+        &binding,
         config.provider.initial_config(),
         factory,
         provider_name,

--- a/crates/agent/src/model_registry.rs
+++ b/crates/agent/src/model_registry.rs
@@ -9,10 +9,8 @@
 
 use futures_util::future;
 use moka::future::Cache;
-use querymt::plugin::LLMProviderFactory;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::time::Duration;
 use typeshare::typeshare;
 
@@ -191,7 +189,7 @@ pub(crate) async fn enumerate_local_models(config: &AgentConfig) -> Vec<ModelEnt
             let config = config.clone();
             async move {
                 let provider_name = factory.name().to_string();
-                let mut models = fetch_catalog_models(&config, &factory, &provider_name).await;
+                let mut models = fetch_catalog_models(&config, &provider_name).await;
                 let catalog_count = models.len();
 
                 if factory.supports_custom_models() {
@@ -238,31 +236,23 @@ pub(crate) async fn enumerate_local_models(config: &AgentConfig) -> Vec<ModelEnt
 
 // ── Provider-level helpers ────────────────────────────────────────────────────
 
-async fn fetch_catalog_models(
-    config: &AgentConfig,
-    factory: &Arc<dyn LLMProviderFactory>,
-    provider_name: &str,
-) -> Vec<ModelEntry> {
-    let registry = config.provider.plugin_registry();
-    let binding =
-        match querymt::plugin::host::ProviderResolver::resolve(registry.as_ref(), provider_name)
-            .await
-        {
-            Ok(binding) => binding,
-            Err(err) => {
-                log::debug!(
-                    "fetch_catalog_models: skipping provider='{}' because resolution failed: {}",
-                    provider_name,
-                    err
-                );
-                return Vec::new();
-            }
-        };
+async fn fetch_catalog_models(config: &AgentConfig, provider_name: &str) -> Vec<ModelEntry> {
+    let resolver = config.provider.provider_resolver();
+    let binding = match resolver.resolve(provider_name).await {
+        Ok(binding) => binding,
+        Err(err) => {
+            log::debug!(
+                "fetch_catalog_models: skipping provider='{}' because resolution failed: {}",
+                provider_name,
+                err
+            );
+            return Vec::new();
+        }
+    };
+    let factory = binding.factory.clone();
     let resolved = match resolve_provider_config(
         &binding,
         config.provider.initial_config(),
-        factory,
-        provider_name,
         ProviderConfigMode::CatalogListing,
     )
     .await

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -701,9 +701,14 @@ fn validate_profile_provider_requirements(
                 "Profile '{profile_id}' provider '{logical_name}' must use an oci:// artifact"
             ));
         };
-        let Some((_, digest)) = reference.rsplit_once("@sha256:") else {
+        let Some((image, digest)) = reference.rsplit_once("@sha256:") else {
             return Err(anyhow!(
                 "Profile '{profile_id}' provider '{logical_name}' must pin an immutable @sha256 digest"
+            ));
+        };
+        if image.trim().is_empty() {
+            return Err(anyhow!(
+                "Profile '{profile_id}' provider '{logical_name}' has an empty OCI image reference"
             ));
         };
         if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
@@ -1622,6 +1627,26 @@ model = "model.gguf"
         )
         .expect_err("tag must be rejected");
         assert!(error.to_string().contains("immutable @sha256"));
+
+        providers.insert(
+            "llama_cpp".to_string(),
+            ProfileProviderRequirement {
+                artifact: format!("oci://@sha256:{}", "a".repeat(64)),
+                factory: "llama_cpp".to_string(),
+                kind: "native".to_string(),
+                plugin_api: None,
+                features: Vec::new(),
+                signer: None,
+            },
+        );
+        let error = validate_profile_provider_requirements(
+            "locked",
+            ProfileProviderMode::Locked,
+            &providers,
+            &config,
+        )
+        .expect_err("empty OCI image reference must be rejected");
+        assert!(error.to_string().contains("empty OCI image reference"));
 
         providers.clear();
         let error = validate_profile_provider_requirements(

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -540,7 +540,7 @@ impl LocalProfileCatalog {
     ) -> Result<ProfileFileMetadata> {
         let content = match &metadata.source {
             ProfileSource::Embedded { key } if key == DEFAULT_EMBEDDED_PROFILE_KEY => {
-                std::fs::read_to_string(DEFAULT_EMBEDDED_PROFILE_PATH)?
+                tokio::fs::read_to_string(DEFAULT_EMBEDDED_PROFILE_PATH).await?
             }
             ProfileSource::EmbeddedToml { key } => self
                 .embedded_toml_profiles
@@ -548,7 +548,7 @@ impl LocalProfileCatalog {
                 .ok_or_else(|| anyhow!("Unknown embedded TOML profile '{key}'"))?
                 .toml
                 .clone(),
-            ProfileSource::LocalPath { path } => std::fs::read_to_string(path)?,
+            ProfileSource::LocalPath { path } => tokio::fs::read_to_string(path).await?,
             ProfileSource::Embedded { key } => {
                 return Err(anyhow!("Unknown embedded profile '{key}'"));
             }
@@ -1289,15 +1289,18 @@ async fn build_profile_runtime(
     mut shared_infra: AgentInfra,
 ) -> Result<ProfileRuntime> {
     let metadata = document.metadata;
-    let provider_lock =
-        resolved_profile_provider_lock(document.provider_mode, &document.providers)?;
-    if document.provider_mode != ProfileProviderMode::Legacy {
-        shared_infra.plugin_registry = provision_profile_registry(
+    let provider_lock = if document.provider_mode == ProfileProviderMode::Legacy {
+        None
+    } else {
+        let registry = provision_profile_registry(
             document.provider_mode,
             &document.providers,
             shared_infra.plugin_registry.clone(),
         )?;
-    }
+        let lock = resolved_profile_provider_lock(document.provider_mode, &registry.config)?;
+        shared_infra.plugin_registry = registry;
+        lock
+    };
     let agent = match document.config {
         Config::Single(config) => {
             Agent::from_single_config_with_infra(*config, shared_infra).await?
@@ -1326,24 +1329,28 @@ async fn build_profile_runtime(
 
 fn resolved_profile_provider_lock(
     mode: ProfileProviderMode,
-    providers: &BTreeMap<String, ProfileProviderRequirement>,
+    config: &PluginConfig,
 ) -> Result<Option<ResolvedProfileProviderLock>> {
     if mode == ProfileProviderMode::Legacy {
         return Ok(None);
     }
-    let entries = providers
+    let entries = config
+        .providers
         .iter()
-        .map(|(logical_name, requirement)| {
+        .map(|provider| {
             (
-                logical_name.clone(),
+                provider.name.clone(),
                 ResolvedProviderLockEntry {
-                    logical_name: logical_name.clone(),
-                    factory: requirement.factory.clone(),
-                    artifact: requirement.artifact.clone(),
-                    kind: requirement.kind.clone(),
-                    plugin_api: requirement.plugin_api,
-                    features: requirement.features.clone(),
-                    signer: requirement.signer.clone(),
+                    logical_name: provider.name.clone(),
+                    factory: provider
+                        .factory
+                        .clone()
+                        .unwrap_or_else(|| provider.name.clone()),
+                    artifact: provider.path.clone(),
+                    kind: provider.kind.clone().unwrap_or_default(),
+                    plugin_api: provider.plugin_api,
+                    features: provider.features.clone(),
+                    signer: provider.signer.clone(),
                 },
             )
         })

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -8,8 +8,12 @@ use crate::config::{Config, load_config};
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+#[cfg(feature = "plugin-loaders")]
+use querymt::dynamic::PluginRegistryDynamicExt;
+use querymt::plugin::host::{PluginConfig, PluginRegistry, ProviderConfig};
 use rust_embed::RustEmbed;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::path::{Component, Path, PathBuf};
@@ -65,13 +69,45 @@ pub struct ProfileMetadata {
 }
 
 /// Optional top-level `[profile]` TOML metadata used only by local catalogs.
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileProviderMode {
+    #[default]
+    Legacy,
+    Overlay,
+    Locked,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileProviderRequirement {
+    pub artifact: String,
+    pub factory: String,
+    #[serde(default = "default_native_provider_kind")]
+    pub kind: String,
+    #[serde(default)]
+    pub plugin_api: Option<u32>,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub signer: Option<String>,
+}
+
+fn default_native_provider_kind() -> String {
+    "native".to_string()
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProfileFileMetadata {
     pub id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
+    #[serde(default, rename = "provider_mode")]
+    pub provider_mode: ProfileProviderMode,
+    #[serde(default)]
+    pub providers: BTreeMap<String, ProfileProviderRequirement>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
@@ -83,6 +119,8 @@ struct ProfileMetadataEnvelope {
 #[derive(Debug)]
 pub struct ProfileDocument {
     pub metadata: ProfileMetadata,
+    pub provider_mode: ProfileProviderMode,
+    pub providers: BTreeMap<String, ProfileProviderRequirement>,
     pub config: Config,
 }
 
@@ -98,12 +136,32 @@ pub struct SessionProfileBinding {
     pub profile_fingerprint: Option<String>,
     pub profile_source: Option<String>,
     pub profile_config_kind: Option<String>,
+    pub provider_lock_digest: Option<String>,
+    pub provider_locks_json: Option<String>,
 }
 
 /// Materialized runtime for a selected profile.
 pub struct ProfileRuntime {
     pub metadata: ProfileMetadata,
     pub agent: Agent,
+    pub provider_lock: Option<ResolvedProfileProviderLock>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedProviderLockEntry {
+    pub logical_name: String,
+    pub factory: String,
+    pub artifact: String,
+    pub kind: String,
+    pub plugin_api: Option<u32>,
+    pub features: Vec<String>,
+    pub signer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedProfileProviderLock {
+    pub digest: String,
+    pub providers: BTreeMap<String, ResolvedProviderLockEntry>,
 }
 
 impl ProfileRuntime {
@@ -116,7 +174,12 @@ impl ProfileRuntime {
     }
 
     pub fn session_binding(&self) -> SessionProfileBinding {
-        self.metadata.session_binding()
+        let mut binding = self.metadata.session_binding();
+        if let Some(lock) = &self.provider_lock {
+            binding.provider_lock_digest = Some(lock.digest.clone());
+            binding.provider_locks_json = serde_json::to_string(lock).ok();
+        }
+        binding
     }
 
     pub fn session_handle(
@@ -140,6 +203,8 @@ impl ProfileMetadata {
             profile_config_kind: self
                 .config_kind
                 .map(|kind| kind.storage_label().to_string()),
+            provider_lock_digest: None,
+            provider_locks_json: None,
         }
     }
 }
@@ -469,6 +534,28 @@ impl LocalProfileCatalog {
         })
     }
 
+    async fn load_profile_file_metadata(
+        &self,
+        metadata: &ProfileMetadata,
+    ) -> Result<ProfileFileMetadata> {
+        let content = match &metadata.source {
+            ProfileSource::Embedded { key } if key == DEFAULT_EMBEDDED_PROFILE_KEY => {
+                std::fs::read_to_string(DEFAULT_EMBEDDED_PROFILE_PATH)?
+            }
+            ProfileSource::EmbeddedToml { key } => self
+                .embedded_toml_profiles
+                .get(key)
+                .ok_or_else(|| anyhow!("Unknown embedded TOML profile '{key}'"))?
+                .toml
+                .clone(),
+            ProfileSource::LocalPath { path } => std::fs::read_to_string(path)?,
+            ProfileSource::Embedded { key } => {
+                return Err(anyhow!("Unknown embedded profile '{key}'"));
+            }
+        };
+        Ok(parse_profile_file_metadata(&content)?.unwrap_or_default())
+    }
+
     async fn load_metadata_source(&self, metadata: &ProfileMetadata) -> Result<Config> {
         match &metadata.source {
             ProfileSource::Embedded { key } if key == DEFAULT_EMBEDDED_PROFILE_KEY => {
@@ -573,16 +660,122 @@ impl ProfileCatalog for LocalProfileCatalog {
         match matches.as_slice() {
             [] => Err(anyhow!("Profile '{id}' was not found")),
             [metadata] => {
+                let profile_spec = self.load_profile_file_metadata(metadata).await?;
                 let config = self.load_metadata_source(metadata).await?;
+                validate_profile_provider_requirements(
+                    &metadata.id,
+                    profile_spec.provider_mode,
+                    &profile_spec.providers,
+                    &config,
+                )?;
                 let mut metadata = metadata.clone();
                 metadata.config_kind = Some(ProfileConfigKind::from_config(&config));
-                Ok(ProfileDocument { metadata, config })
+                Ok(ProfileDocument {
+                    metadata,
+                    provider_mode: profile_spec.provider_mode,
+                    providers: profile_spec.providers,
+                    config,
+                })
             }
             _ => Err(anyhow!(
                 "Duplicate profile id '{id}' found; rename one [profile].id or local TOML filename"
             )),
         }
     }
+}
+
+fn validate_profile_provider_requirements(
+    profile_id: &str,
+    mode: ProfileProviderMode,
+    providers: &BTreeMap<String, ProfileProviderRequirement>,
+    config: &Config,
+) -> Result<()> {
+    for (logical_name, requirement) in providers {
+        if logical_name.trim().is_empty() || requirement.factory.trim().is_empty() {
+            return Err(anyhow!(
+                "Profile '{profile_id}' has a provider requirement with an empty name or factory"
+            ));
+        }
+        let Some(reference) = requirement.artifact.strip_prefix("oci://") else {
+            return Err(anyhow!(
+                "Profile '{profile_id}' provider '{logical_name}' must use an oci:// artifact"
+            ));
+        };
+        let Some((_, digest)) = reference.rsplit_once("@sha256:") else {
+            return Err(anyhow!(
+                "Profile '{profile_id}' provider '{logical_name}' must pin an immutable @sha256 digest"
+            ));
+        };
+        if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(anyhow!(
+                "Profile '{profile_id}' provider '{logical_name}' has an invalid SHA-256 digest"
+            ));
+        }
+        if !matches!(requirement.kind.as_str(), "native" | "wasm") {
+            return Err(anyhow!(
+                "Profile '{profile_id}' provider '{logical_name}' has unsupported kind '{}'",
+                requirement.kind
+            ));
+        }
+    }
+
+    let references = profile_provider_references(config);
+    if mode == ProfileProviderMode::Locked {
+        for (path, provider) in references {
+            if !providers.contains_key(&provider) {
+                return Err(anyhow!(
+                    "Profile '{profile_id}' is locked, but {path} refers to undeclared provider '{provider}'"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn profile_provider_references(config: &Config) -> Vec<(String, String)> {
+    let mut references = Vec::new();
+    match config {
+        Config::Single(config) => {
+            references.push(("agent.provider".to_string(), config.agent.provider.clone()));
+            if let Some(provider) = &config.agent.execution.compaction.provider {
+                references.push((
+                    "agent.execution.compaction.provider".to_string(),
+                    provider.clone(),
+                ));
+            }
+        }
+        Config::Multi(config) => {
+            references.push((
+                "planner.provider".to_string(),
+                config.planner.provider.clone(),
+            ));
+            if let Some(provider) = &config.planner.execution.compaction.provider {
+                references.push((
+                    "planner.execution.compaction.provider".to_string(),
+                    provider.clone(),
+                ));
+            }
+            for (index, delegate) in config.delegates.iter().enumerate() {
+                references.push((
+                    format!("delegates[{index}].provider"),
+                    delegate.provider.clone(),
+                ));
+                if let Some(provider) = &delegate.execution.compaction.provider {
+                    references.push((
+                        format!("delegates[{index}].execution.compaction.provider"),
+                        provider.clone(),
+                    ));
+                }
+            }
+            if let Some(summary) = &config.quorum.delegation_summary {
+                references.push((
+                    "quorum.delegation_summary.provider".to_string(),
+                    summary.provider.clone(),
+                ));
+            }
+        }
+    }
+    references
 }
 
 impl ProfileConfigKind {
@@ -858,8 +1051,8 @@ where
             warn!(session_id, profile_id = %binding.profile_id, "session profile binding is memory-only because shared storage is unavailable");
             return;
         };
-        if let Err(err) = storage
-            .session_store()
+        let store = storage.session_store();
+        if let Err(err) = store
             .set_session_runtime_binding(
                 &session_id,
                 &binding.profile_id,
@@ -868,6 +1061,16 @@ where
             .await
         {
             warn!(session_id, profile_id = %binding.profile_id, error = %err, "failed to persist session profile binding");
+        } else if let Err(err) = store
+            .set_session_provider_lock(
+                &session_id,
+                binding.profile_fingerprint.as_deref(),
+                binding.provider_lock_digest.as_deref(),
+                binding.provider_locks_json.as_deref(),
+            )
+            .await
+        {
+            warn!(session_id, profile_id = %binding.profile_id, error = %err, "failed to persist session provider lock");
         }
     }
 
@@ -899,7 +1102,21 @@ where
             }
         };
         let mut binding = runtime.session_binding();
+        if let Some(expected) = route.provider_lock_digest.as_deref()
+            && binding.provider_lock_digest.as_deref() != Some(expected)
+        {
+            warn!(
+                session_id,
+                profile_id = route.profile_id,
+                expected_provider_lock = expected,
+                current_provider_lock = ?binding.provider_lock_digest,
+                "refusing to resume session with a different profile provider lock"
+            );
+            return None;
+        }
         binding.agent_id = route.agent_id;
+        binding.profile_fingerprint = route.profile_fingerprint.or(binding.profile_fingerprint);
+        binding.provider_locks_json = route.provider_locks_json.or(binding.provider_locks_json);
         self.session_bindings
             .lock()
             .await
@@ -1069,9 +1286,18 @@ impl ProfileRuntimeManager<Arc<dyn ProfileCatalog>> {
 
 async fn build_profile_runtime(
     document: ProfileDocument,
-    shared_infra: AgentInfra,
+    mut shared_infra: AgentInfra,
 ) -> Result<ProfileRuntime> {
     let metadata = document.metadata;
+    let provider_lock =
+        resolved_profile_provider_lock(document.provider_mode, &document.providers)?;
+    if document.provider_mode != ProfileProviderMode::Legacy {
+        shared_infra.plugin_registry = provision_profile_registry(
+            document.provider_mode,
+            &document.providers,
+            shared_infra.plugin_registry.clone(),
+        )?;
+    }
     let agent = match document.config {
         Config::Single(config) => {
             Agent::from_single_config_with_infra(*config, shared_infra).await?
@@ -1091,7 +1317,82 @@ async fn build_profile_runtime(
         }
     };
 
-    Ok(ProfileRuntime { metadata, agent })
+    Ok(ProfileRuntime {
+        metadata,
+        agent,
+        provider_lock,
+    })
+}
+
+fn resolved_profile_provider_lock(
+    mode: ProfileProviderMode,
+    providers: &BTreeMap<String, ProfileProviderRequirement>,
+) -> Result<Option<ResolvedProfileProviderLock>> {
+    if mode == ProfileProviderMode::Legacy {
+        return Ok(None);
+    }
+    let entries = providers
+        .iter()
+        .map(|(logical_name, requirement)| {
+            (
+                logical_name.clone(),
+                ResolvedProviderLockEntry {
+                    logical_name: logical_name.clone(),
+                    factory: requirement.factory.clone(),
+                    artifact: requirement.artifact.clone(),
+                    kind: requirement.kind.clone(),
+                    plugin_api: requirement.plugin_api,
+                    features: requirement.features.clone(),
+                    signer: requirement.signer.clone(),
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let canonical = serde_json::to_vec(&entries)?;
+    Ok(Some(ResolvedProfileProviderLock {
+        digest: format!("sha256:{}", hex::encode(Sha256::digest(canonical))),
+        providers: entries,
+    }))
+}
+
+fn provision_profile_registry(
+    mode: ProfileProviderMode,
+    providers: &BTreeMap<String, ProfileProviderRequirement>,
+    global: Arc<PluginRegistry>,
+) -> Result<Arc<PluginRegistry>> {
+    let mut entries = providers
+        .iter()
+        .map(|(logical_name, requirement)| ProviderConfig {
+            name: logical_name.clone(),
+            path: requirement.artifact.clone(),
+            config: None,
+            locked: true,
+            factory: Some(requirement.factory.clone()),
+            plugin_api: requirement.plugin_api,
+            kind: Some(requirement.kind.clone()),
+            features: requirement.features.clone(),
+            signer: requirement.signer.clone(),
+        })
+        .collect::<Vec<_>>();
+    if mode == ProfileProviderMode::Overlay {
+        entries.extend(
+            global
+                .config
+                .providers
+                .iter()
+                .filter(|entry| !providers.contains_key(&entry.name))
+                .cloned(),
+        );
+    }
+    let config = PluginConfig {
+        providers: entries,
+        #[cfg(feature = "plugin-loaders")]
+        oci: global.config.oci.clone(),
+    };
+    let registry = PluginRegistry::from_config_with_cache_path(config, global.cache_path.clone())?;
+    #[cfg(feature = "plugin-loaders")]
+    let registry = registry.with_dynamic_loaders();
+    Ok(Arc::new(registry))
 }
 
 fn should_reload_profiles(event: &notify::Event) -> bool {
@@ -1258,6 +1559,83 @@ mod tests {
             Err(LLMError::ProviderError(message)) => message,
             other => panic!("expected provider error from mesh lookup; got: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn locked_profile_requires_declared_digest_pinned_provider() {
+        let content = r#"
+[profile]
+id = "locked"
+provider_mode = "locked"
+
+[profile.providers.llama_cpp]
+artifact = "oci://ghcr.io/querymt/llama-cpp@sha256:35b306b544905162426a5a6f23f6676a0fe2f846fd7bc82e394c5fa83f01b45f"
+factory = "llama_cpp"
+kind = "native"
+features = ["cuda12.8"]
+
+[agent]
+provider = "llama_cpp"
+model = "model.gguf"
+"#;
+        let metadata = parse_profile_file_metadata(content)
+            .expect("metadata")
+            .expect("profile");
+        let config =
+            crate::config::load_config(crate::config::ConfigSource::Toml(content.to_string()))
+                .await
+                .expect("config");
+        validate_profile_provider_requirements(
+            "locked",
+            metadata.provider_mode,
+            &metadata.providers,
+            &config,
+        )
+        .expect("valid locked profile");
+    }
+
+    #[test]
+    fn locked_profile_rejects_mutable_tag_and_undeclared_provider() {
+        let config = Config::Single(Box::new(
+            toml::from_str::<crate::config::SingleAgentConfig>(
+                "[agent]\nprovider = \"llama_cpp\"\nmodel = \"model.gguf\"",
+            )
+            .expect("config"),
+        ));
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "other".to_string(),
+            ProfileProviderRequirement {
+                artifact: "oci://ghcr.io/querymt/llama-cpp:latest".to_string(),
+                factory: "llama_cpp".to_string(),
+                kind: "native".to_string(),
+                plugin_api: None,
+                features: Vec::new(),
+                signer: None,
+            },
+        );
+        let error = validate_profile_provider_requirements(
+            "locked",
+            ProfileProviderMode::Locked,
+            &providers,
+            &config,
+        )
+        .expect_err("tag must be rejected");
+        assert!(error.to_string().contains("immutable @sha256"));
+
+        providers.clear();
+        let error = validate_profile_provider_requirements(
+            "locked",
+            ProfileProviderMode::Locked,
+            &providers,
+            &config,
+        )
+        .expect_err("undeclared provider must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("undeclared provider 'llama_cpp'")
+        );
     }
 
     #[test]

--- a/crates/agent/src/profiles.rs
+++ b/crates/agent/src/profiles.rs
@@ -1057,20 +1057,13 @@ where
                 &session_id,
                 &binding.profile_id,
                 binding.agent_id.as_deref(),
-            )
-            .await
-        {
-            warn!(session_id, profile_id = %binding.profile_id, error = %err, "failed to persist session profile binding");
-        } else if let Err(err) = store
-            .set_session_provider_lock(
-                &session_id,
                 binding.profile_fingerprint.as_deref(),
                 binding.provider_lock_digest.as_deref(),
                 binding.provider_locks_json.as_deref(),
             )
             .await
         {
-            warn!(session_id, profile_id = %binding.profile_id, error = %err, "failed to persist session provider lock");
+            warn!(session_id, profile_id = %binding.profile_id, error = %err, "failed to persist session profile binding");
         }
     }
 

--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -105,6 +105,10 @@ impl SessionProvider {
         self
     }
 
+    pub(crate) fn provider_resolver(&self) -> Arc<dyn ProviderResolver> {
+        self.provider_resolver.clone()
+    }
+
     /// Set the agent identifier used for `{{ agent_id }}` in system prompt
     /// templates.  Call at build time before wrapping in `Arc`.
     pub fn with_agent_id(mut self, id: Option<String>) -> Self {
@@ -530,8 +534,6 @@ impl SessionProvider {
         let resolved_cfg = resolve_provider_config(
             &binding,
             &self.initial_config,
-            &factory,
-            provider_name,
             ProviderConfigMode::Runtime {
                 model,
                 params,

--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -7,7 +7,7 @@ use crate::session::provider_config::{ProviderConfigMode, resolve_provider_confi
 use crate::session::store::{LLMConfig, Session, SessionExecutionConfig, SessionStore};
 use arc_swap::ArcSwap;
 use querymt::LLMParams;
-use querymt::plugin::host::PluginRegistry;
+use querymt::plugin::host::{PluginRegistry, ProviderResolver};
 use querymt::providers::ModelPricing;
 use querymt::{
     LLMProvider,
@@ -54,6 +54,7 @@ fn is_non_billable_oauth_provider(provider: &str) -> bool {
 /// next `run_prompt` call), not mid-turn.
 pub struct SessionProvider {
     plugin_registry: Arc<PluginRegistry>,
+    provider_resolver: Arc<dyn ProviderResolver>,
     history_store: Arc<dyn SessionStore>,
     initial_config: LLMParams,
     /// Lock-free single-entry provider cache keyed on `LLMConfig.id`.
@@ -84,8 +85,10 @@ impl SessionProvider {
         store: Arc<dyn SessionStore>,
         initial_config: LLMParams,
     ) -> Self {
+        let provider_resolver: Arc<dyn ProviderResolver> = plugin_registry.clone();
         Self {
             plugin_registry,
+            provider_resolver,
             history_store: store,
             initial_config,
             cached_provider: Arc::new(ArcSwap::from_pointee(None)),
@@ -95,6 +98,11 @@ impl SessionProvider {
             #[cfg(feature = "remote")]
             allow_mesh_fallback: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn with_provider_resolver(mut self, resolver: Arc<dyn ProviderResolver>) -> Self {
+        self.provider_resolver = resolver;
+        self
     }
 
     /// Set the agent identifier used for `{{ agent_id }}` in system prompt
@@ -413,6 +421,12 @@ impl SessionProvider {
         if let Some(node_id) = req.provider_node_id
             && node_id != "local"
         {
+            if !self.provider_resolver.allows_remote_fallback() {
+                return Err(SessionError::InvalidOperation(format!(
+                    "Provider '{}' is profile-locked and cannot be routed to mesh node '{}'",
+                    provider_name, node_id
+                )));
+            }
             let mesh_guard = self.mesh.load();
             let mesh = mesh_guard.as_deref().ok_or_else(|| {
                 SessionError::InvalidOperation(format!(
@@ -451,26 +465,26 @@ impl SessionProvider {
         }
 
         // ── Case 2: Try local provider ─────────────────────────────────────────
-        let plugin_registry = &self.plugin_registry;
-        let factory = plugin_registry.get(provider_name).await;
+        let binding = self.provider_resolver.resolve(provider_name).await;
 
         #[cfg(not(feature = "remote"))]
-        let factory = factory.ok_or_else(|| {
-            SessionError::InvalidOperation(format!("Unknown provider: {}", provider_name))
-        })?;
+        let binding = binding.map_err(SessionError::ProviderError)?;
 
         // With the remote feature enabled we may optionally fall back to the mesh
         // (Case 3 below), so we don't error-out immediately.
         #[cfg(feature = "remote")]
-        let factory = match factory {
-            Some(f) => f,
-            None => {
+        let binding = match binding {
+            Ok(binding) => binding,
+            Err(local_error) => {
                 // ── Case 3: Not available locally → optional mesh fallback ─────
                 let allow_mesh_fallback = self.allow_mesh_fallback.load(Ordering::Relaxed);
                 let mesh_guard = self.mesh.load();
                 let mesh_handle = mesh_guard.as_deref();
 
-                if allow_mesh_fallback && let Some(mesh) = mesh_handle {
+                if self.provider_resolver.allows_remote_fallback()
+                    && allow_mesh_fallback
+                    && let Some(mesh) = mesh_handle
+                {
                     log::debug!(
                         "build_provider: provider '{}' not found locally, searching mesh",
                         provider_name
@@ -508,15 +522,13 @@ impl SessionProvider {
                         ));
                     }
                 }
-                return Err(SessionError::InvalidOperation(format!(
-                    "Unknown provider: {}",
-                    provider_name
-                )));
+                return Err(SessionError::ProviderError(local_error));
             }
         };
 
+        let factory = binding.factory.clone();
         let resolved_cfg = resolve_provider_config(
-            plugin_registry,
+            &binding,
             &self.initial_config,
             &factory,
             provider_name,
@@ -621,6 +633,7 @@ impl Clone for SessionProvider {
     fn clone(&self) -> Self {
         Self {
             plugin_registry: self.plugin_registry.clone(),
+            provider_resolver: self.provider_resolver.clone(),
             history_store: Arc::clone(&self.history_store),
             initial_config: self.initial_config.clone(),
             cached_provider: Arc::clone(&self.cached_provider),

--- a/crates/agent/src/session/provider_config.rs
+++ b/crates/agent/src/session/provider_config.rs
@@ -3,7 +3,7 @@ use crate::session::error::SessionError;
 use querymt::LLMParams;
 use querymt::error::LLMError;
 use querymt::plugin::LLMProviderFactory;
-use querymt::plugin::host::PluginRegistry;
+use querymt::plugin::host::ProviderBinding;
 use querymt::provider_config::{
     ConfigOverrideMode, ProviderConfigBuilder,
     ResolvedProviderConfig as SharedResolvedProviderConfig,
@@ -88,13 +88,13 @@ fn missing_credentials_error(provider_name: &str, env_var_name: Option<&str>) ->
 }
 
 pub(crate) async fn resolve_provider_config(
-    registry: &PluginRegistry,
+    binding: &ProviderBinding,
     initial_config: &LLMParams,
     factory: &Arc<dyn LLMProviderFactory>,
     provider_name: &str,
     mode: ProviderConfigMode<'_>,
 ) -> Result<ResolvedProviderConfig, SessionError> {
-    let mut builder = ProviderConfigBuilder::from_registry_provider(registry, provider_name)?;
+    let mut builder = ProviderConfigBuilder::from_binding(binding);
     let mut use_oauth_resolver = false;
 
     match mode {
@@ -218,7 +218,7 @@ mod tests {
     use querymt::chat::{ChatMessage, ChatResponse, Tool};
     use querymt::completion::{CompletionRequest, CompletionResponse};
     use querymt::error::LLMError;
-    use querymt::plugin::host::PluginRegistry;
+    use querymt::plugin::host::{PluginRegistry, ProviderBinding};
     use querymt::plugin::{HTTPLLMProviderFactory, LLMProviderFactory};
     use std::sync::Arc;
 
@@ -316,6 +316,18 @@ mod tests {
         registry
     }
 
+    fn binding(registry: &PluginRegistry, factory: Arc<dyn LLMProviderFactory>) -> ProviderBinding {
+        ProviderBinding {
+            logical_name: "xiaomi".to_string(),
+            factory,
+            static_config: querymt::provider_config::provider_static_config_json(
+                registry, "xiaomi",
+            )
+            .expect("static config"),
+            implementation_id: None,
+        }
+    }
+
     fn adapted_factory(
         api_key_name: Option<&str>,
         schema: &'static str,
@@ -339,8 +351,9 @@ mod tests {
             r#"{"properties":{"base_url":{},"api_key":{}}}"#,
         );
 
+        let binding = binding(&registry, factory.clone());
         let resolved = resolve_provider_config(
-            &registry,
+            &binding,
             &initial,
             &factory,
             "xiaomi",
@@ -375,8 +388,9 @@ mod tests {
 
         #[cfg(feature = "oauth")]
         {
+            let binding = binding(&registry, factory.clone());
             let resolved = resolve_provider_config(
-                &registry,
+                &binding,
                 &initial,
                 &factory,
                 "xiaomi",
@@ -393,8 +407,9 @@ mod tests {
 
         #[cfg(not(feature = "oauth"))]
         {
+            let binding = binding(&registry, factory.clone());
             let _ = resolve_provider_config(
-                &registry,
+                &binding,
                 &initial,
                 &factory,
                 "xiaomi",
@@ -416,8 +431,9 @@ mod tests {
             r#"{"properties":{"api_key":{},"model":{}}}"#,
         );
 
+        let binding = binding(&registry, factory.clone());
         let resolved = resolve_provider_config(
-            &registry,
+            &binding,
             &initial,
             &factory,
             "xiaomi",

--- a/crates/agent/src/session/provider_config.rs
+++ b/crates/agent/src/session/provider_config.rs
@@ -2,14 +2,12 @@ use crate::model_heuristics::ModelDefaults;
 use crate::session::error::SessionError;
 use querymt::LLMParams;
 use querymt::error::LLMError;
-use querymt::plugin::LLMProviderFactory;
 use querymt::plugin::host::ProviderBinding;
 use querymt::provider_config::{
     ConfigOverrideMode, ProviderConfigBuilder,
     ResolvedProviderConfig as SharedResolvedProviderConfig,
 };
 use serde_json::Value;
-use std::sync::Arc;
 
 pub(crate) enum ProviderConfigMode<'a> {
     Runtime {
@@ -90,11 +88,11 @@ fn missing_credentials_error(provider_name: &str, env_var_name: Option<&str>) ->
 pub(crate) async fn resolve_provider_config(
     binding: &ProviderBinding,
     initial_config: &LLMParams,
-    factory: &Arc<dyn LLMProviderFactory>,
-    provider_name: &str,
     mode: ProviderConfigMode<'_>,
 ) -> Result<ResolvedProviderConfig, SessionError> {
     let mut builder = ProviderConfigBuilder::from_binding(binding);
+    let factory = &binding.factory;
+    let provider_name = binding.logical_name.as_str();
     let mut use_oauth_resolver = false;
 
     match mode {
@@ -220,6 +218,7 @@ mod tests {
     use querymt::error::LLMError;
     use querymt::plugin::host::{PluginRegistry, ProviderBinding};
     use querymt::plugin::{HTTPLLMProviderFactory, LLMProviderFactory};
+    #[cfg(test)]
     use std::sync::Arc;
 
     struct DummyHttpProvider;
@@ -352,15 +351,10 @@ mod tests {
         );
 
         let binding = binding(&registry, factory.clone());
-        let resolved = resolve_provider_config(
-            &binding,
-            &initial,
-            &factory,
-            "xiaomi",
-            ProviderConfigMode::CatalogListing,
-        )
-        .await
-        .expect("resolved config");
+        let resolved =
+            resolve_provider_config(&binding, &initial, ProviderConfigMode::CatalogListing)
+                .await
+                .expect("resolved config");
 
         #[cfg(feature = "oauth")]
         {
@@ -389,15 +383,10 @@ mod tests {
         #[cfg(feature = "oauth")]
         {
             let binding = binding(&registry, factory.clone());
-            let resolved = resolve_provider_config(
-                &binding,
-                &initial,
-                &factory,
-                "xiaomi",
-                ProviderConfigMode::CatalogListing,
-            )
-            .await
-            .expect("resolved config");
+            let resolved =
+                resolve_provider_config(&binding, &initial, ProviderConfigMode::CatalogListing)
+                    .await
+                    .expect("resolved config");
 
             assert_eq!(
                 resolved.builder_config["base_url"],
@@ -408,15 +397,9 @@ mod tests {
         #[cfg(not(feature = "oauth"))]
         {
             let binding = binding(&registry, factory.clone());
-            let _ = resolve_provider_config(
-                &binding,
-                &initial,
-                &factory,
-                "xiaomi",
-                ProviderConfigMode::CatalogListing,
-            )
-            .await
-            .expect("resolved config");
+            let _ = resolve_provider_config(&binding, &initial, ProviderConfigMode::CatalogListing)
+                .await
+                .expect("resolved config");
         }
     }
 
@@ -431,12 +414,10 @@ mod tests {
             r#"{"properties":{"api_key":{},"model":{}}}"#,
         );
 
-        let binding = binding(&registry, factory.clone());
+        let binding = binding(&registry, factory);
         let resolved = resolve_provider_config(
             &binding,
             &initial,
-            &factory,
-            "xiaomi",
             ProviderConfigMode::Runtime {
                 model: "gpt-4o-mini",
                 params: None,

--- a/crates/agent/src/session/sqlite_storage/migrations.rs
+++ b/crates/agent/src/session/sqlite_storage/migrations.rs
@@ -60,6 +60,10 @@ pub(super) const MIGRATIONS: &[Migration] = &[
         version: "0012_task_and_intent_revisions",
         apply: migration_0012_task_and_intent_revisions,
     },
+    Migration {
+        version: "0013_session_provider_locks",
+        apply: migration_0013_session_provider_locks,
+    },
 ];
 
 pub(super) fn apply_migrations(conn: &mut Connection) -> Result<(), rusqlite::Error> {
@@ -447,6 +451,21 @@ fn migration_0011_session_runtime_bindings(conn: &mut Connection) -> Result<(), 
         Err(error) if error.to_string().contains("duplicate column name") => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+fn migration_0013_session_provider_locks(conn: &mut Connection) -> Result<(), rusqlite::Error> {
+    for statement in [
+        "ALTER TABLE profile_bindings ADD COLUMN profile_fingerprint TEXT",
+        "ALTER TABLE profile_bindings ADD COLUMN provider_lock_digest TEXT",
+        "ALTER TABLE profile_bindings ADD COLUMN provider_locks_json TEXT",
+    ] {
+        match conn.execute(statement, []) {
+            Ok(_) => {}
+            Err(error) if error.to_string().contains("duplicate column name") => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 fn migration_0012_task_and_intent_revisions(conn: &mut Connection) -> Result<(), rusqlite::Error> {

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -602,7 +602,7 @@ impl SessionStore for SqliteStorage {
     }
 
     async fn set_profile_binding(&self, session_id: &str, profile_id: &str) -> SessionResult<()> {
-        self.set_session_runtime_binding(session_id, profile_id, None)
+        self.set_session_runtime_binding(session_id, profile_id, None, None, None, None)
             .await
     }
 
@@ -611,48 +611,41 @@ impl SessionStore for SqliteStorage {
         session_id: &str,
         profile_id: &str,
         agent_id: Option<&str>,
-    ) -> SessionResult<()> {
-        let session_id = session_id.to_string();
-        let profile_id = profile_id.to_string();
-        let agent_id = agent_id.map(str::to_string);
-        self.run_blocking(move |conn| {
-            conn.execute(
-                "INSERT INTO profile_bindings (session_id, profile_id, agent_id)
-                 VALUES (?1, ?2, ?3)
-                 ON CONFLICT(session_id) DO UPDATE SET
-                    profile_id = excluded.profile_id,
-                    agent_id = excluded.agent_id",
-                params![session_id, profile_id, agent_id],
-            )?;
-            Ok(())
-        })
-        .await
-    }
-
-    async fn set_session_provider_lock(
-        &self,
-        session_id: &str,
         profile_fingerprint: Option<&str>,
         provider_lock_digest: Option<&str>,
         provider_locks_json: Option<&str>,
     ) -> SessionResult<()> {
         let session_id = session_id.to_string();
+        let profile_id = profile_id.to_string();
+        let agent_id = agent_id.map(str::to_string);
         let profile_fingerprint = profile_fingerprint.map(str::to_string);
         let provider_lock_digest = provider_lock_digest.map(str::to_string);
         let provider_locks_json = provider_locks_json.map(str::to_string);
-        let lookup_id = session_id.clone();
-        let updated = self
-            .run_blocking(move |conn| {
-                conn.execute(
-                    "UPDATE profile_bindings SET profile_fingerprint = ?2, provider_lock_digest = ?3, provider_locks_json = ?4 WHERE session_id = ?1",
-                    params![session_id, profile_fingerprint, provider_lock_digest, provider_locks_json],
-                )
-            })
-            .await?;
-        if updated == 0 {
-            return Err(crate::session::SessionError::SessionNotFound(lookup_id));
-        }
-        Ok(())
+        self.run_blocking(move |conn| {
+            let transaction = conn.transaction()?;
+            transaction.execute(
+                "INSERT INTO profile_bindings (
+                    session_id, profile_id, agent_id, profile_fingerprint,
+                    provider_lock_digest, provider_locks_json
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(session_id) DO UPDATE SET
+                    profile_id = excluded.profile_id,
+                    agent_id = excluded.agent_id,
+                    profile_fingerprint = excluded.profile_fingerprint,
+                    provider_lock_digest = excluded.provider_lock_digest,
+                    provider_locks_json = excluded.provider_locks_json",
+                params![
+                    session_id,
+                    profile_id,
+                    agent_id,
+                    profile_fingerprint,
+                    provider_lock_digest,
+                    provider_locks_json
+                ],
+            )?;
+            transaction.commit()
+        })
+        .await
     }
 
     async fn get_profile_binding(&self, session_id: &str) -> SessionResult<Option<String>> {

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -629,6 +629,27 @@ impl SessionStore for SqliteStorage {
         .await
     }
 
+    async fn set_session_provider_lock(
+        &self,
+        session_id: &str,
+        profile_fingerprint: Option<&str>,
+        provider_lock_digest: Option<&str>,
+        provider_locks_json: Option<&str>,
+    ) -> SessionResult<()> {
+        let session_id = session_id.to_string();
+        let profile_fingerprint = profile_fingerprint.map(str::to_string);
+        let provider_lock_digest = provider_lock_digest.map(str::to_string);
+        let provider_locks_json = provider_locks_json.map(str::to_string);
+        self.run_blocking(move |conn| {
+            conn.execute(
+                "UPDATE profile_bindings SET profile_fingerprint = ?2, provider_lock_digest = ?3, provider_locks_json = ?4 WHERE session_id = ?1",
+                params![session_id, profile_fingerprint, provider_lock_digest, provider_locks_json],
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
     async fn get_profile_binding(&self, session_id: &str) -> SessionResult<Option<String>> {
         let session_id = session_id.to_string();
         self.run_blocking(move |conn| {
@@ -649,12 +670,15 @@ impl SessionStore for SqliteStorage {
         let session_id = session_id.to_string();
         self.run_blocking(move |conn| {
             conn.query_row(
-                "SELECT profile_id, agent_id FROM profile_bindings WHERE session_id = ?1",
+                "SELECT profile_id, agent_id, profile_fingerprint, provider_lock_digest, provider_locks_json FROM profile_bindings WHERE session_id = ?1",
                 params![session_id],
                 |row| {
                     Ok(crate::session::store::SessionRuntimeBinding {
                         profile_id: row.get(0)?,
                         agent_id: row.get(1)?,
+                        profile_fingerprint: row.get(2)?,
+                        provider_lock_digest: row.get(3)?,
+                        provider_locks_json: row.get(4)?,
                     })
                 },
             )

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -640,14 +640,19 @@ impl SessionStore for SqliteStorage {
         let profile_fingerprint = profile_fingerprint.map(str::to_string);
         let provider_lock_digest = provider_lock_digest.map(str::to_string);
         let provider_locks_json = provider_locks_json.map(str::to_string);
-        self.run_blocking(move |conn| {
-            conn.execute(
-                "UPDATE profile_bindings SET profile_fingerprint = ?2, provider_lock_digest = ?3, provider_locks_json = ?4 WHERE session_id = ?1",
-                params![session_id, profile_fingerprint, provider_lock_digest, provider_locks_json],
-            )?;
-            Ok(())
-        })
-        .await
+        let lookup_id = session_id.clone();
+        let updated = self
+            .run_blocking(move |conn| {
+                conn.execute(
+                    "UPDATE profile_bindings SET profile_fingerprint = ?2, provider_lock_digest = ?3, provider_locks_json = ?4 WHERE session_id = ?1",
+                    params![session_id, profile_fingerprint, provider_lock_digest, provider_locks_json],
+                )
+            })
+            .await?;
+        if updated == 0 {
+            return Err(crate::session::SessionError::SessionNotFound(lookup_id));
+        }
+        Ok(())
     }
 
     async fn get_profile_binding(&self, session_id: &str) -> SessionResult<Option<String>> {

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -1,7 +1,6 @@
 use rusqlite::Connection;
 
 use crate::events::{AgentEventKind, EventOrigin};
-use crate::session::SessionError;
 use crate::session::domain::ForkOrigin;
 use crate::session::projection::{
     EventJournal, NewDurableEvent, RecentModelEntry, SessionScope, ViewStore,
@@ -285,7 +284,14 @@ async fn session_runtime_binding_round_trips_profile_and_delegate() {
         .expect("in-memory storage");
 
     storage
-        .set_session_runtime_binding("delegate-session", "quorum", Some("coder"))
+        .set_session_runtime_binding(
+            "delegate-session",
+            "quorum",
+            Some("coder"),
+            Some("profile-sha"),
+            Some("lock-sha"),
+            Some("{}"),
+        )
         .await
         .expect("persist runtime binding");
 
@@ -305,27 +311,66 @@ async fn session_runtime_binding_round_trips_profile_and_delegate() {
         Some("quorum")
     );
 
+    assert_eq!(binding.profile_fingerprint.as_deref(), Some("profile-sha"));
+    assert_eq!(binding.provider_lock_digest.as_deref(), Some("lock-sha"));
+    assert_eq!(binding.provider_locks_json.as_deref(), Some("{}"));
+}
+
+#[tokio::test]
+async fn session_runtime_binding_transaction_rolls_back_on_failure() {
+    let storage = SqliteStorage::connect(":memory:".into())
+        .await
+        .expect("in-memory storage");
     storage
-        .set_session_provider_lock(
-            "delegate-session",
-            Some("profile-sha"),
-            Some("lock-sha"),
+        .set_session_runtime_binding(
+            "session-1",
+            "old-profile",
+            None,
+            Some("old-fingerprint"),
+            Some("old-lock"),
             Some("{}"),
         )
         .await
-        .expect("update existing provider lock");
-    let binding = storage
-        .get_session_runtime_binding("delegate-session")
+        .expect("seed binding");
+    storage
+        .run_blocking(|conn| {
+            conn.execute_batch(
+                "CREATE TRIGGER reject_provider_lock_update
+                 BEFORE UPDATE ON profile_bindings
+                 WHEN NEW.provider_locks_json = 'reject'
+                 BEGIN
+                    SELECT RAISE(ABORT, 'rejected provider lock');
+                 END;",
+            )
+        })
         .await
-        .expect("load updated binding")
-        .expect("updated binding");
-    assert_eq!(binding.provider_lock_digest.as_deref(), Some("lock-sha"));
+        .expect("install failure trigger");
 
-    let error = storage
-        .set_session_provider_lock("missing-session", None, Some("lock-sha"), None)
+    storage
+        .set_session_runtime_binding(
+            "session-1",
+            "new-profile",
+            Some("coder"),
+            Some("new-fingerprint"),
+            Some("new-lock"),
+            Some("reject"),
+        )
         .await
-        .expect_err("missing binding must fail");
-    assert!(matches!(error, SessionError::SessionNotFound(id) if id == "missing-session"));
+        .expect_err("transaction must fail");
+
+    let binding = storage
+        .get_session_runtime_binding("session-1")
+        .await
+        .expect("load binding")
+        .expect("original binding remains");
+    assert_eq!(binding.profile_id, "old-profile");
+    assert_eq!(binding.agent_id, None);
+    assert_eq!(
+        binding.profile_fingerprint.as_deref(),
+        Some("old-fingerprint")
+    );
+    assert_eq!(binding.provider_lock_digest.as_deref(), Some("old-lock"));
+    assert_eq!(binding.provider_locks_json.as_deref(), Some("{}"));
 }
 
 #[tokio::test]

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -1,6 +1,7 @@
 use rusqlite::Connection;
 
 use crate::events::{AgentEventKind, EventOrigin};
+use crate::session::SessionError;
 use crate::session::domain::ForkOrigin;
 use crate::session::projection::{
     EventJournal, NewDurableEvent, RecentModelEntry, SessionScope, ViewStore,
@@ -303,6 +304,28 @@ async fn session_runtime_binding_round_trips_profile_and_delegate() {
             .as_deref(),
         Some("quorum")
     );
+
+    storage
+        .set_session_provider_lock(
+            "delegate-session",
+            Some("profile-sha"),
+            Some("lock-sha"),
+            Some("{}"),
+        )
+        .await
+        .expect("update existing provider lock");
+    let binding = storage
+        .get_session_runtime_binding("delegate-session")
+        .await
+        .expect("load updated binding")
+        .expect("updated binding");
+    assert_eq!(binding.provider_lock_digest.as_deref(), Some("lock-sha"));
+
+    let error = storage
+        .set_session_provider_lock("missing-session", None, Some("lock-sha"), None)
+        .await
+        .expect_err("missing binding must fail");
+    assert!(matches!(error, SessionError::SessionNotFound(id) if id == "missing-session"));
 }
 
 #[tokio::test]

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -277,24 +277,16 @@ pub trait SessionStore: Send + Sync {
     /// Persist the profile namespace for a root session.
     async fn set_profile_binding(&self, session_id: &str, profile_id: &str) -> SessionResult<()>;
 
-    /// Persist the profile namespace and concrete agent that owns a session runtime.
+    /// Persist the complete profile runtime route and provider lock atomically.
     async fn set_session_runtime_binding(
         &self,
         session_id: &str,
         profile_id: &str,
         agent_id: Option<&str>,
+        profile_fingerprint: Option<&str>,
+        provider_lock_digest: Option<&str>,
+        provider_locks_json: Option<&str>,
     ) -> SessionResult<()>;
-
-    /// Persist the exact provider lock used by a profile-owned session.
-    async fn set_session_provider_lock(
-        &self,
-        _session_id: &str,
-        _profile_fingerprint: Option<&str>,
-        _provider_lock_digest: Option<&str>,
-        _provider_locks_json: Option<&str>,
-    ) -> SessionResult<()> {
-        Ok(())
-    }
 
     /// Retrieve the profile namespace for compatibility with profile ownership checks.
     async fn get_profile_binding(&self, session_id: &str) -> SessionResult<Option<String>>;

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -18,6 +18,9 @@ use time::OffsetDateTime;
 pub struct SessionRuntimeBinding {
     pub profile_id: String,
     pub agent_id: Option<String>,
+    pub profile_fingerprint: Option<String>,
+    pub provider_lock_digest: Option<String>,
+    pub provider_locks_json: Option<String>,
 }
 
 /// A bookmark for a remote session — enough metadata to re-discover and
@@ -281,6 +284,17 @@ pub trait SessionStore: Send + Sync {
         profile_id: &str,
         agent_id: Option<&str>,
     ) -> SessionResult<()>;
+
+    /// Persist the exact provider lock used by a profile-owned session.
+    async fn set_session_provider_lock(
+        &self,
+        _session_id: &str,
+        _profile_fingerprint: Option<&str>,
+        _provider_lock_digest: Option<&str>,
+        _provider_locks_json: Option<&str>,
+    ) -> SessionResult<()> {
+        Ok(())
+    }
 
     /// Retrieve the profile namespace for compatibility with profile ownership checks.
     async fn get_profile_binding(&self, session_id: &str) -> SessionResult<Option<String>>;

--- a/crates/agent/src/test_utils/mocks.rs
+++ b/crates/agent/src/test_utils/mocks.rs
@@ -52,11 +52,14 @@ mock! {
             session_id: &'b str,
             profile_id: &'c str,
         ) -> SessionResult<()>;
-        async fn set_session_runtime_binding<'a, 'b, 'c, 'd>(
+        async fn set_session_runtime_binding<'a, 'b, 'c, 'd, 'e, 'f, 'g>(
             &'a self,
             session_id: &'b str,
             profile_id: &'c str,
             agent_id: Option<&'d str>,
+            profile_fingerprint: Option<&'e str>,
+            provider_lock_digest: Option<&'f str>,
+            provider_locks_json: Option<&'g str>,
         ) -> SessionResult<()>;
         async fn get_profile_binding<'a, 'b>(
             &'a self,

--- a/crates/providers/llama-cpp/src/lib.rs
+++ b/crates/providers/llama-cpp/src/lib.rs
@@ -86,6 +86,18 @@ impl LLMProviderFactory for LlamaCppFactory {
 
 #[cfg(feature = "native")]
 #[unsafe(no_mangle)]
+pub extern "C" fn querymt_plugin_api() -> u32 {
+    1
+}
+
+#[cfg(feature = "native")]
+#[unsafe(no_mangle)]
+pub extern "C" fn querymt_plugin_name() -> *const std::os::raw::c_char {
+    c"llama_cpp".as_ptr()
+}
+
+#[cfg(feature = "native")]
+#[unsafe(no_mangle)]
 // SAFETY: While trait objects aren't technically FFI-safe, this is a well-established
 // plugin pattern where both sides of the FFI boundary are Rust code compiled with the
 // same ABI. The host process will cast this back to `Box<dyn LLMProviderFactory>` using

--- a/crates/querymt/src/builder.rs
+++ b/crates/querymt/src/builder.rs
@@ -10,8 +10,11 @@ use crate::{
         Tool, ToolChoice,
     },
     error::LLMError,
-    plugin::{LLMProviderFactory, host::PluginRegistry},
-    provider_config::prune_config_by_schema,
+    plugin::{
+        LLMProviderFactory,
+        host::{PluginRegistry, ProviderResolver},
+    },
+    provider_config::{prune_config_by_schema, resolve_binding_provider_config},
     tool_decorator::{CallFunctionTool, ToolEnabledProvider},
 };
 use serde::Serialize;
@@ -153,14 +156,21 @@ impl LLMBuilder<Unbound> {
         self,
         registry: &PluginRegistry,
     ) -> Result<Box<dyn LLMProvider>, LLMError> {
-        self.build_with_registry(registry).await
+        self.build_with_resolver(registry).await
+    }
+
+    pub async fn build_with_resolver(
+        self,
+        resolver: &dyn ProviderResolver,
+    ) -> Result<Box<dyn LLMProvider>, LLMError> {
+        self.build_from_resolver(resolver).await
     }
 }
 
 impl<'a> LLMBuilder<BoundRegistry<'a>> {
     pub async fn build(self) -> Result<Box<dyn LLMProvider>, LLMError> {
         let registry = self.state.registry;
-        self.build_with_registry(registry).await
+        self.build_from_resolver(registry).await
     }
 }
 
@@ -355,19 +365,17 @@ impl<State> LLMBuilder<State> {
         self
     }
 
-    #[cfg_attr(feature = "tracing", instrument(name = "llm_builder.build", skip(self, registry), fields(provider = self.provider.as_deref().unwrap_or("unknown"))))]
-    async fn build_with_registry(
+    #[cfg_attr(feature = "tracing", instrument(name = "llm_builder.build", skip(self, resolver), fields(provider = self.provider.as_deref().unwrap_or("unknown"))))]
+    async fn build_from_resolver(
         self,
-        registry: &PluginRegistry,
+        resolver: &dyn ProviderResolver,
     ) -> Result<Box<dyn LLMProvider>, LLMError> {
         let provider_name = self
             .provider
             .clone()
             .ok_or_else(|| LLMError::InvalidRequest("No provider specified".to_string()))?;
-        let factory: Arc<dyn LLMProviderFactory> =
-            registry.get(&provider_name).await.ok_or_else(|| {
-                LLMError::InvalidRequest(format!("Unknown provider: {}", provider_name))
-            })?;
+        let binding = resolver.resolve(&provider_name).await?;
+        let factory: Arc<dyn LLMProviderFactory> = binding.factory.clone();
 
         let tool_list: Vec<Tool> = self
             .tool_registry
@@ -375,11 +383,7 @@ impl<State> LLMBuilder<State> {
             .map(|t| t.descriptor())
             .collect();
 
-        let resolved_cfg = crate::provider_config::resolve_registry_provider_config(
-            registry,
-            &provider_name,
-            factory.as_ref(),
-        )?;
+        let resolved_cfg = resolve_binding_provider_config(&binding)?;
 
         let mut full_cfg = match resolved_cfg.full_config {
             Value::Object(map) => map,

--- a/crates/querymt/src/plugin/host/config.rs
+++ b/crates/querymt/src/plugin/host/config.rs
@@ -9,18 +9,31 @@ use std::{
 #[cfg(feature = "extism_host")]
 use super::oci::OciDownloaderConfig;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct PluginConfig {
     pub providers: Vec<ProviderConfig>,
     #[cfg(feature = "extism_host")]
     pub oci: Option<OciDownloaderConfig>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ProviderConfig {
     pub name: String,
     pub path: String,
     pub config: Option<HashMap<String, toml::Value>>,
+    /// Locked entries come from a profile and must match the expected implementation.
+    #[serde(default)]
+    pub locked: bool,
+    #[serde(default)]
+    pub factory: Option<String>,
+    #[serde(default)]
+    pub plugin_api: Option<u32>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub signer: Option<String>,
 }
 
 impl PluginConfig {

--- a/crates/querymt/src/plugin/host/mod.rs
+++ b/crates/querymt/src/plugin/host/mod.rs
@@ -2,7 +2,7 @@ use crate::{LLMBuilder, builder::BoundRegistry, error::LLMError, plugin::LLMProv
 use async_trait::async_trait;
 use futures::lock::Mutex;
 use futures::stream::{FuturesUnordered, StreamExt};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -20,6 +20,16 @@ pub use config::{PluginConfig, ProviderConfig};
 pub enum PluginType {
     Wasm,
     Native,
+}
+
+fn expected_scalar_feature(features: &[String]) -> Result<Option<&str>, String> {
+    match features {
+        [] => Ok(None),
+        [feature] => Ok(Some(feature.as_str())),
+        features => Err(format!(
+            "declares multiple features {features:?}, but OCI artifacts expose one scalar feature tag"
+        )),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -86,16 +96,7 @@ pub struct PluginRegistry {
 
 impl PluginRegistry {
     fn static_config(&self, provider: &str) -> Result<Value, LLMError> {
-        Ok(self
-            .config
-            .providers
-            .iter()
-            .find(|entry| entry.name == provider)
-            .and_then(|entry| entry.config.as_ref())
-            .map(serde_json::to_value)
-            .transpose()?
-            .filter(Value::is_object)
-            .unwrap_or_else(|| Value::Object(Map::new())))
+        crate::provider_config::provider_static_config_json(self, provider)
     }
 
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, LLMError> {
@@ -319,6 +320,7 @@ impl PluginRegistry {
         }
 
         if provider_cfg.locked {
+            #[cfg(feature = "extism_host")]
             if let Some(expected_signer) = provider_cfg.signer.as_deref()
                 && self.oci_downloader.trusted_github_repository() != Some(expected_signer)
             {
@@ -361,15 +363,22 @@ impl PluginRegistry {
                     provider_cfg.name, expected_kind, actual_kind
                 )));
             }
-            for feature in &provider_cfg.features {
+            let expected_feature =
+                expected_scalar_feature(&provider_cfg.features).map_err(|error| {
+                    LLMError::PluginError(format!(
+                        "Locked provider '{}' {error}",
+                        provider_cfg.name
+                    ))
+                })?;
+            if let Some(expected_feature) = expected_feature {
                 let actual = provider_plugin
                     .annotations
                     .get("mt.query.plugin.feature")
                     .map(String::as_str);
-                if actual != Some(feature.as_str()) {
+                if actual != Some(expected_feature) {
                     return Err(LLMError::PluginError(format!(
                         "Locked provider '{}' requires feature '{}', but artifact reports {:?}",
-                        provider_cfg.name, feature, actual
+                        provider_cfg.name, expected_feature, actual
                     )));
                 }
             }
@@ -483,11 +492,19 @@ impl ProviderResolver for PluginRegistry {
             .get(logical_name)
             .await
             .ok_or_else(|| LLMError::InvalidRequest(format!("Unknown provider: {logical_name}")))?;
+        let implementation_id = Some(
+            self.config
+                .providers
+                .iter()
+                .find(|provider| provider.name == logical_name)
+                .map(|provider| provider.path.clone())
+                .unwrap_or_else(|| format!("static:{}", factory.name())),
+        );
         Ok(ProviderBinding {
             logical_name: logical_name.to_string(),
             factory,
             static_config: self.static_config(logical_name)?,
-            implementation_id: None,
+            implementation_id,
         })
     }
 
@@ -501,6 +518,18 @@ mod tests {
     use super::*;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn scalar_feature_contract_rejects_multiple_configured_features() {
+        assert_eq!(expected_scalar_feature(&[]).expect("empty features"), None);
+        assert_eq!(
+            expected_scalar_feature(&["cuda12.8".to_string()]).expect("single feature"),
+            Some("cuda12.8")
+        );
+        let error = expected_scalar_feature(&["cuda12.8".to_string(), "dflash2".to_string()])
+            .expect_err("multiple features must be rejected");
+        assert!(error.contains("one scalar feature tag"));
+    }
 
     fn unique_tmp_path(suffix: &str) -> PathBuf {
         let pid = std::process::id();

--- a/crates/querymt/src/plugin/host/mod.rs
+++ b/crates/querymt/src/plugin/host/mod.rs
@@ -2,10 +2,14 @@ use crate::{LLMBuilder, builder::BoundRegistry, error::LLMError, plugin::LLMProv
 use async_trait::async_trait;
 use futures::lock::Mutex;
 use futures::stream::{FuturesUnordered, StreamExt};
+use serde_json::{Map, Value};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
@@ -22,6 +26,30 @@ pub enum PluginType {
 pub struct ProviderPlugin {
     pub plugin_type: PluginType,
     pub file_path: PathBuf,
+    /// Immutable OCI manifest digest when the plugin came from an OCI artifact.
+    pub manifest_digest: Option<String>,
+    /// SHA-256 of the extracted plugin file, used to detect cache tampering.
+    pub file_sha256: Option<String>,
+    /// OCI annotations from the selected platform manifest.
+    pub annotations: BTreeMap<String, String>,
+}
+
+#[derive(Clone)]
+pub struct ProviderBinding {
+    pub logical_name: String,
+    pub factory: Arc<dyn LLMProviderFactory>,
+    pub static_config: Value,
+    /// Reproducible implementation identity for profile-pinned providers.
+    pub implementation_id: Option<String>,
+}
+
+#[async_trait]
+pub trait ProviderResolver: Send + Sync {
+    async fn resolve(&self, logical_name: &str) -> Result<ProviderBinding, LLMError>;
+
+    fn allows_remote_fallback(&self) -> bool {
+        true
+    }
 }
 
 #[async_trait]
@@ -53,9 +81,23 @@ pub struct PluginRegistry {
     pub oci_downloader: Arc<oci::OciDownloader>,
     pub config: config::PluginConfig,
     pub cache_path: PathBuf,
+    allow_remote_fallback: bool,
 }
 
 impl PluginRegistry {
+    fn static_config(&self, provider: &str) -> Result<Value, LLMError> {
+        Ok(self
+            .config
+            .providers
+            .iter()
+            .find(|entry| entry.name == provider)
+            .and_then(|entry| entry.config.as_ref())
+            .map(serde_json::to_value)
+            .transpose()?
+            .filter(Value::is_object)
+            .unwrap_or_else(|| Value::Object(Map::new())))
+    }
+
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, LLMError> {
         let config =
             PluginConfig::from_path(path).map_err(|e| LLMError::PluginError(e.to_string()))?;
@@ -92,6 +134,7 @@ impl PluginRegistry {
         std::fs::create_dir_all(&cache_path)
             .map_err(|e| LLMError::InvalidRequest(format!("{:#}", e)))?;
 
+        let allow_remote_fallback = !config.providers.iter().any(|provider| provider.locked);
         Ok(PluginRegistry {
             loaders: HashMap::new(),
             factories: RwLock::new(HashMap::new()),
@@ -100,6 +143,7 @@ impl PluginRegistry {
             oci_downloader: Arc::new(oci::OciDownloader::new(config.oci.clone())),
             config,
             cache_path,
+            allow_remote_fallback,
         })
     }
 
@@ -120,6 +164,7 @@ impl PluginRegistry {
                 oci: None,
             },
             cache_path: PathBuf::new(),
+            allow_remote_fallback: true,
         }
     }
 
@@ -267,6 +312,66 @@ impl PluginRegistry {
             provider_plugin = ProviderPlugin {
                 plugin_type,
                 file_path: file_path.to_path_buf(),
+                manifest_digest: None,
+                file_sha256: None,
+                annotations: BTreeMap::new(),
+            }
+        }
+
+        if provider_cfg.locked {
+            if let Some(expected_signer) = provider_cfg.signer.as_deref()
+                && self.oci_downloader.trusted_github_repository() != Some(expected_signer)
+            {
+                return Err(LLMError::PluginError(format!(
+                    "Locked provider '{}' requires signer '{}', but the host trust policy allows {:?}",
+                    provider_cfg.name,
+                    expected_signer,
+                    self.oci_downloader.trusted_github_repository()
+                )));
+            }
+            let expected_digest = provider_cfg
+                .path
+                .rsplit_once("@sha256:")
+                .map(|(_, digest)| format!("sha256:{digest}"))
+                .ok_or_else(|| {
+                    LLMError::PluginError(format!(
+                        "Locked provider '{}' must use an immutable @sha256 OCI reference",
+                        provider_cfg.name
+                    ))
+                })?;
+            if provider_plugin.manifest_digest.as_deref() != Some(expected_digest.as_str()) {
+                return Err(LLMError::PluginError(format!(
+                    "Locked provider '{}' resolved digest {:?}, expected '{}'",
+                    provider_cfg.name, provider_plugin.manifest_digest, expected_digest
+                )));
+            }
+            let expected_kind = provider_cfg.kind.as_deref().ok_or_else(|| {
+                LLMError::PluginError(format!(
+                    "Locked provider '{}' is missing an expected plugin kind",
+                    provider_cfg.name
+                ))
+            })?;
+            let actual_kind = match provider_plugin.plugin_type {
+                PluginType::Native => "native",
+                PluginType::Wasm => "wasm",
+            };
+            if expected_kind != actual_kind {
+                return Err(LLMError::PluginError(format!(
+                    "Locked provider '{}' expected kind '{}', but artifact contains '{}'",
+                    provider_cfg.name, expected_kind, actual_kind
+                )));
+            }
+            for feature in &provider_cfg.features {
+                let actual = provider_plugin
+                    .annotations
+                    .get("mt.query.plugin.feature")
+                    .map(String::as_str);
+                if actual != Some(feature.as_str()) {
+                    return Err(LLMError::PluginError(format!(
+                        "Locked provider '{}' requires feature '{}', but artifact reports {:?}",
+                        provider_cfg.name, feature, actual
+                    )));
+                }
             }
         }
 
@@ -371,6 +476,26 @@ impl PluginRegistry {
     }
 }
 
+#[async_trait]
+impl ProviderResolver for PluginRegistry {
+    async fn resolve(&self, logical_name: &str) -> Result<ProviderBinding, LLMError> {
+        let factory = self
+            .get(logical_name)
+            .await
+            .ok_or_else(|| LLMError::InvalidRequest(format!("Unknown provider: {logical_name}")))?;
+        Ok(ProviderBinding {
+            logical_name: logical_name.to_string(),
+            factory,
+            static_config: self.static_config(logical_name)?,
+            implementation_id: None,
+        })
+    }
+
+    fn allows_remote_fallback(&self) -> bool {
+        self.allow_remote_fallback
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,6 +584,12 @@ mod tests {
                 name: "local-plugin".to_string(),
                 path: "/some/local/plugin.wasm".to_string(),
                 config: None,
+                locked: false,
+                factory: None,
+                plugin_api: None,
+                kind: None,
+                features: Vec::new(),
+                signer: None,
             }],
             oci: None,
         };
@@ -480,6 +611,12 @@ mod tests {
                 name: "fake-plugin".to_string(),
                 path: "oci://localhost:9999/fake/image:latest".to_string(),
                 config: None,
+                locked: false,
+                factory: None,
+                plugin_api: None,
+                kind: None,
+                features: Vec::new(),
+                signer: None,
             }],
             oci: None,
         };

--- a/crates/querymt/src/plugin/host/native.rs
+++ b/crates/querymt/src/plugin/host/native.rs
@@ -126,17 +126,13 @@ impl PluginLoader for NativeLoader {
 }
 
 impl NativeLoader {
-    fn load_library(
-        &self,
+    fn validate_descriptor(
+        lib: &Library,
         name: &str,
         path: &Path,
         locked: bool,
         required_api: Option<u32>,
-    ) -> Result<Arc<dyn LLMProviderFactory>, LLMError> {
-        let lib = unsafe {
-            Arc::new(Library::new(path).map_err(|e| LLMError::PluginError(format!("{:#}", e)))?)
-        };
-
+    ) -> Result<(), LLMError> {
         if let Some(required_api) = required_api {
             unsafe {
                 let api = lib.get::<PluginApiFn>(b"querymt_plugin_api").map_err(|_| {
@@ -177,6 +173,21 @@ impl NativeLoader {
                 }
             }
         }
+
+        Ok(())
+    }
+
+    fn load_library(
+        &self,
+        name: &str,
+        path: &Path,
+        locked: bool,
+        required_api: Option<u32>,
+    ) -> Result<Arc<dyn LLMProviderFactory>, LLMError> {
+        let lib = unsafe {
+            Arc::new(Library::new(path).map_err(|e| LLMError::PluginError(format!("{:#}", e)))?)
+        };
+        Self::validate_descriptor(&lib, name, path, locked, required_api)?;
 
         let factory: Box<dyn LLMProviderFactory> = unsafe {
             if let Ok(async_ctor) = lib.get::<FactoryCtor>(b"plugin_factory") {
@@ -241,7 +252,111 @@ impl NativeLoader {
 
         Ok(Arc::new(NativeFactoryWrapper {
             factory_impl: factory,
-            _library: Arc::clone(&lib),
+            _library: lib,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn compile_fixture(dir: &Path, name: &str, source: &str) -> PathBuf {
+        let source_path = dir.join(format!("{name}.rs"));
+        fs::write(&source_path, source).expect("write native fixture source");
+        let library_path = dir.join(format!(
+            "{}{}{}",
+            std::env::consts::DLL_PREFIX,
+            name,
+            std::env::consts::DLL_SUFFIX
+        ));
+        let output = Command::new("rustc")
+            .args(["--crate-type", "cdylib", "--edition", "2024"])
+            .arg(&source_path)
+            .arg("-o")
+            .arg(&library_path)
+            .output()
+            .expect("compile native fixture");
+        assert!(
+            output.status.success(),
+            "fixture compilation failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        library_path
+    }
+
+    fn validate_fixture(
+        source: &str,
+        locked: bool,
+        required_api: Option<u32>,
+    ) -> Result<(), LLMError> {
+        let dir = tempfile::tempdir().expect("fixture tempdir");
+        let path = compile_fixture(dir.path(), "descriptor_fixture", source);
+        let library = unsafe { Library::new(&path).expect("load native fixture") };
+        NativeLoader::validate_descriptor(
+            &library,
+            "expected_provider",
+            &path,
+            locked,
+            required_api,
+        )
+    }
+
+    #[test]
+    fn configured_api_rejects_missing_export() {
+        let error = validate_fixture("", false, Some(NATIVE_PLUGIN_API))
+            .expect_err("missing API export must fail");
+        assert!(error.to_string().contains("querymt_plugin_api"));
+    }
+
+    #[test]
+    fn configured_api_rejects_mismatch() {
+        let error = validate_fixture(
+            "#[unsafe(no_mangle)] pub extern \"C\" fn querymt_plugin_api() -> u32 { 99 }",
+            false,
+            Some(NATIVE_PLUGIN_API),
+        )
+        .expect_err("mismatched API must fail");
+        assert!(error.to_string().contains("uses API 99"));
+    }
+
+    #[test]
+    fn configured_api_accepts_match() {
+        validate_fixture(
+            "#[unsafe(no_mangle)] pub extern \"C\" fn querymt_plugin_api() -> u32 { 1 }",
+            false,
+            Some(NATIVE_PLUGIN_API),
+        )
+        .expect("matching API must pass");
+    }
+
+    #[test]
+    fn locked_plugin_rejects_missing_name() {
+        let error = validate_fixture("", true, None).expect_err("missing name export must fail");
+        assert!(error.to_string().contains("querymt_plugin_name"));
+    }
+
+    #[test]
+    fn locked_plugin_rejects_name_mismatch() {
+        let error = validate_fixture(
+            "#[unsafe(no_mangle)] pub extern \"C\" fn querymt_plugin_name() -> *const std::ffi::c_char { c\"other_provider\".as_ptr() }",
+            true,
+            None,
+        )
+        .expect_err("mismatched name must fail");
+        assert!(error.to_string().contains("expected_provider"));
+    }
+
+    #[test]
+    fn locked_plugin_accepts_expected_name() {
+        validate_fixture(
+            "#[unsafe(no_mangle)] pub extern \"C\" fn querymt_plugin_name() -> *const std::ffi::c_char { c\"expected_provider\".as_ptr() }",
+            true,
+            None,
+        )
+        .expect("matching name must pass");
     }
 }

--- a/crates/querymt/src/plugin/host/native.rs
+++ b/crates/querymt/src/plugin/host/native.rs
@@ -141,19 +141,24 @@ impl NativeLoader {
             unsafe {
                 let api = lib.get::<PluginApiFn>(b"querymt_plugin_api").map_err(|_| {
                     LLMError::PluginError(format!(
-                        "Locked native plugin {} does not export querymt_plugin_api",
+                        "Native plugin {} does not export required querymt_plugin_api",
                         path.display()
                     ))
                 })?;
                 if required_api != NATIVE_PLUGIN_API || api() != required_api {
                     return Err(LLMError::PluginError(format!(
-                        "Locked native plugin {} uses API {}, profile requires {}, host supports {}",
+                        "Native plugin {} uses API {}, configuration requires {}, host supports {}",
                         path.display(),
                         api(),
                         required_api,
                         NATIVE_PLUGIN_API
                     )));
                 }
+            }
+        }
+
+        if locked {
+            unsafe {
                 let plugin_name =
                     lib.get::<PluginNameFn>(b"querymt_plugin_name")
                         .map_err(|_| {

--- a/crates/querymt/src/plugin/host/native.rs
+++ b/crates/querymt/src/plugin/host/native.rs
@@ -10,6 +10,7 @@ use crate::{
 use async_trait::async_trait;
 use libloading::Library;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 use std::path::Path;
 use std::sync::Arc;
 #[cfg(feature = "tracing")]
@@ -89,6 +90,10 @@ unsafe extern "C" fn host_log_callback(
     log::log!(target: target_str, log_level, "{}", message_str);
 }
 
+pub const NATIVE_PLUGIN_API: u32 = 1;
+type PluginApiFn = unsafe extern "C" fn() -> u32;
+type PluginNameFn = unsafe extern "C" fn() -> *const c_char;
+
 pub struct NativeLoader;
 
 #[async_trait]
@@ -109,7 +114,13 @@ impl PluginLoader for NativeLoader {
             plugin.file_path.display()
         );
 
-        let provider = self.load_library(&plugin_cfg.name, &plugin.file_path)?;
+        let expected_name = plugin_cfg.factory.as_deref().unwrap_or(&plugin_cfg.name);
+        let provider = self.load_library(
+            expected_name,
+            &plugin.file_path,
+            plugin_cfg.locked,
+            plugin_cfg.plugin_api,
+        )?;
         Ok(provider)
     }
 }
@@ -119,10 +130,48 @@ impl NativeLoader {
         &self,
         name: &str,
         path: &Path,
+        locked: bool,
+        required_api: Option<u32>,
     ) -> Result<Arc<dyn LLMProviderFactory>, LLMError> {
         let lib = unsafe {
             Arc::new(Library::new(path).map_err(|e| LLMError::PluginError(format!("{:#}", e)))?)
         };
+
+        if let Some(required_api) = required_api {
+            unsafe {
+                let api = lib.get::<PluginApiFn>(b"querymt_plugin_api").map_err(|_| {
+                    LLMError::PluginError(format!(
+                        "Locked native plugin {} does not export querymt_plugin_api",
+                        path.display()
+                    ))
+                })?;
+                if required_api != NATIVE_PLUGIN_API || api() != required_api {
+                    return Err(LLMError::PluginError(format!(
+                        "Locked native plugin {} uses API {}, profile requires {}, host supports {}",
+                        path.display(),
+                        api(),
+                        required_api,
+                        NATIVE_PLUGIN_API
+                    )));
+                }
+                let plugin_name =
+                    lib.get::<PluginNameFn>(b"querymt_plugin_name")
+                        .map_err(|_| {
+                            LLMError::PluginError(format!(
+                                "Locked native plugin {} does not export querymt_plugin_name",
+                                path.display()
+                            ))
+                        })?;
+                let ptr = plugin_name();
+                if ptr.is_null() || CStr::from_ptr(ptr).to_string_lossy() != name {
+                    return Err(LLMError::PluginError(format!(
+                        "Locked native plugin {} descriptor does not match expected factory '{}'",
+                        path.display(),
+                        name
+                    )));
+                }
+            }
+        }
 
         let factory: Box<dyn LLMProviderFactory> = unsafe {
             if let Ok(async_ctor) = lib.get::<FactoryCtor>(b"plugin_factory") {
@@ -155,6 +204,14 @@ impl NativeLoader {
 
         let factory_name = factory.name();
         if factory_name != name {
+            if locked {
+                return Err(LLMError::PluginError(format!(
+                    "Locked plugin name mismatch in {}: expected '{}', but plugin reports '{}'",
+                    path.display(),
+                    name,
+                    factory_name
+                )));
+            }
             log::warn!(
                 "Plugin name mismatch in {}: config name is '{}', but plugin reports '{}'. Using config name.",
                 path.display(),

--- a/crates/querymt/src/plugin/host/oci.rs
+++ b/crates/querymt/src/plugin/host/oci.rs
@@ -113,6 +113,12 @@ fn cache_metadata_has_integrity_digest(metadata: &CacheMetadata) -> bool {
     metadata.file_sha256.is_some()
 }
 
+fn eligible_cached_blob(cache_path: &Path, metadata: &CacheMetadata) -> Option<PathBuf> {
+    cache_metadata_has_integrity_digest(metadata)
+        .then(|| get_blob_path(cache_path, &metadata.manifest_digest, &metadata.filename))
+        .filter(|path| path.exists())
+}
+
 fn build_auth(reference: &Reference) -> RegistryAuth {
     let server = reference
         .resolve_registry()
@@ -1064,13 +1070,16 @@ impl OciDownloader {
                     }
                 }
 
-                if let Some(meta) = local_metadata {
-                    let blob_path =
-                        get_blob_path(cache_path, &meta.manifest_digest, &meta.filename);
-                    if blob_path.exists() {
-                        log::debug!("OFFLINE CACHE HIT: Using stale local version.");
-                        return load_from_cache(&meta, &blob_path);
-                    }
+                if let Some(meta) = local_metadata
+                    && let Some(blob_path) = eligible_cached_blob(cache_path, &meta)
+                {
+                    log::debug!("OFFLINE CACHE HIT: Using stale local version.");
+                    let cached = tokio::task::spawn_blocking(move || {
+                        load_from_cache(&meta, &blob_path).map_err(|error| error.to_string())
+                    })
+                    .await
+                    .map_err(|error| format!("OCI cache validation task failed: {error}"))?;
+                    return cached.map_err(Into::into);
                 }
                 Err("No internet connection and no cached version available for this image.".into())
             }
@@ -1201,6 +1210,28 @@ mod tests {
                 .to_string()
                 .contains("Invalid plugin type")
         );
+    }
+
+    #[test]
+    fn offline_cache_rejects_legacy_metadata_without_file_digest() {
+        let temp_dir = tempfile::tempdir().expect("cache tempdir");
+        let metadata = CacheMetadata {
+            manifest_digest: "sha256:abc".to_string(),
+            filename: "plugin.wasm".to_string(),
+            plugin_type_str: "extism".to_string(),
+            file_sha256: None,
+            annotations: BTreeMap::new(),
+            retrieved_at_unix: 1234567890,
+        };
+        let blob_path = get_blob_path(
+            temp_dir.path(),
+            &metadata.manifest_digest,
+            &metadata.filename,
+        );
+        fs::create_dir_all(blob_path.parent().expect("blob parent")).expect("create blob dir");
+        fs::write(&blob_path, b"legacy cache").expect("write cached blob");
+
+        assert_eq!(eligible_cached_blob(temp_dir.path(), &metadata), None);
     }
 
     #[test]

--- a/crates/querymt/src/plugin/host/oci.rs
+++ b/crates/querymt/src/plugin/host/oci.rs
@@ -25,6 +25,7 @@ use sigstore::trust::{ManualTrustRoot, TrustRoot};
 use std::collections::BTreeMap;
 use std::env::consts::{ARCH, OS};
 use std::fs;
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -541,8 +542,17 @@ fn persist_with_fallback(
 }
 
 fn sha256_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let bytes = fs::read(path)?;
-    Ok(hex::encode(Sha256::digest(bytes)))
+    let mut reader = BufReader::new(fs::File::open(path)?);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
 }
 
 fn load_from_cache(
@@ -720,7 +730,13 @@ impl OciDownloader {
                     bytes_total: None,
                     percent: Some(100.0),
                 });
-                return load_from_cache(meta, &blob_path);
+                let meta = meta.clone();
+                let cached = tokio::task::spawn_blocking(move || {
+                    load_from_cache(&meta, &blob_path).map_err(|error| error.to_string())
+                })
+                .await
+                .map_err(|error| format!("OCI cache validation task failed: {error}"))?;
+                return cached.map_err(Into::into);
             }
         }
 
@@ -789,7 +805,13 @@ impl OciDownloader {
                             bytes_total: None,
                             percent: Some(100.0),
                         });
-                        return load_from_cache(meta, &blob_path);
+                        let meta = meta.clone();
+                        let cached = tokio::task::spawn_blocking(move || {
+                            load_from_cache(&meta, &blob_path).map_err(|error| error.to_string())
+                        })
+                        .await
+                        .map_err(|error| format!("OCI cache validation task failed: {error}"))?;
+                        return cached.map_err(Into::into);
                     }
                 }
 

--- a/crates/querymt/src/plugin/host/oci.rs
+++ b/crates/querymt/src/plugin/host/oci.rs
@@ -109,6 +109,10 @@ struct CacheMetadata {
     retrieved_at_unix: u64,
 }
 
+fn cache_metadata_has_integrity_digest(metadata: &CacheMetadata) -> bool {
+    metadata.file_sha256.is_some()
+}
+
 fn build_auth(reference: &Reference) -> RegistryAuth {
     let server = reference
         .resolve_registry()
@@ -720,7 +724,10 @@ impl OciDownloader {
             .ok()
             .and_then(|bytes| serde_json::from_slice(&bytes).ok());
 
-        if !force_update && let Some(meta) = &local_metadata {
+        if !force_update
+            && let Some(meta) = &local_metadata
+            && cache_metadata_has_integrity_digest(meta)
+        {
             let blob_path = get_blob_path(cache_path, &meta.manifest_digest, &meta.filename);
             if blob_path.exists() {
                 log::debug!("Found cached OCI plugin. Using local version.");
@@ -794,7 +801,9 @@ impl OciDownloader {
 
         match client.pull_manifest(&reference, &auth).await {
             Ok((live_manifest, live_digest)) => {
-                if let Some(meta) = &local_metadata {
+                if let Some(meta) = &local_metadata
+                    && cache_metadata_has_integrity_digest(meta)
+                {
                     let blob_path =
                         get_blob_path(cache_path, &meta.manifest_digest, &meta.filename);
                     if meta.manifest_digest == live_digest && blob_path.exists() {
@@ -939,7 +948,13 @@ impl OciDownloader {
 
                 log::debug!("Populated OCI blob cache at: {}", blob_path.display());
 
-                let file_sha256 = sha256_file(&blob_path)?;
+                let hash_path = blob_path.clone();
+                let file_sha256 = tokio::task::spawn_blocking(move || {
+                    sha256_file(&hash_path).map_err(|error| error.to_string())
+                })
+                .await
+                .map_err(|error| format!("OCI plugin hashing task failed: {error}"))?
+                .map_err(|error| format!("Failed to hash OCI plugin: {error}"))?;
                 let new_metadata = CacheMetadata {
                     manifest_digest: live_digest.to_string(),
                     filename: filename.clone(),
@@ -1186,6 +1201,21 @@ mod tests {
                 .to_string()
                 .contains("Invalid plugin type")
         );
+    }
+
+    #[test]
+    fn cache_metadata_without_file_digest_is_not_eligible_for_cache_hit() {
+        let mut metadata = CacheMetadata {
+            manifest_digest: "sha256:abc".to_string(),
+            filename: "plugin.wasm".to_string(),
+            plugin_type_str: "extism".to_string(),
+            file_sha256: None,
+            annotations: BTreeMap::new(),
+            retrieved_at_unix: 1234567890,
+        };
+        assert!(!cache_metadata_has_integrity_digest(&metadata));
+        metadata.file_sha256 = Some("digest".to_string());
+        assert!(cache_metadata_has_integrity_digest(&metadata));
     }
 
     #[test]

--- a/crates/querymt/src/plugin/host/oci.rs
+++ b/crates/querymt/src/plugin/host/oci.rs
@@ -22,6 +22,7 @@ use sigstore::errors::SigstoreVerifyConstraintsError;
 use sigstore::registry::{Auth, OciReference};
 use sigstore::trust::sigstore::SigstoreTrustRoot;
 use sigstore::trust::{ManualTrustRoot, TrustRoot};
+use std::collections::BTreeMap;
 use std::env::consts::{ARCH, OS};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -98,6 +99,11 @@ struct CacheMetadata {
     filename: String,
     /// The discovered plugin type, e.g., "native" or "extism"
     plugin_type_str: String,
+    /// SHA-256 of the extracted plugin file.
+    #[serde(default)]
+    file_sha256: Option<String>,
+    #[serde(default)]
+    annotations: BTreeMap<String, String>,
     /// When this metadata was last updated
     retrieved_at_unix: u64,
 }
@@ -534,6 +540,11 @@ fn persist_with_fallback(
     }
 }
 
+fn sha256_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let bytes = fs::read(path)?;
+    Ok(hex::encode(Sha256::digest(bytes)))
+}
+
 fn load_from_cache(
     meta: &CacheMetadata,
     blob_path: &Path,
@@ -543,10 +554,25 @@ fn load_from_cache(
         "native" => PluginType::Native,
         _ => return Err("Invalid plugin type in cache metadata".into()),
     };
+    let file_sha256 = sha256_file(blob_path)?;
+    if let Some(expected) = &meta.file_sha256
+        && expected != &file_sha256
+    {
+        return Err(format!(
+            "cached OCI plugin integrity check failed for {}: expected {}, got {}",
+            blob_path.display(),
+            expected,
+            file_sha256
+        )
+        .into());
+    }
 
     Ok(ProviderPlugin {
         plugin_type,
         file_path: blob_path.to_path_buf(),
+        manifest_digest: Some(meta.manifest_digest.clone()),
+        file_sha256: Some(file_sha256),
+        annotations: meta.annotations.clone(),
     })
 }
 
@@ -640,6 +666,10 @@ impl OciDownloader {
             config: config.unwrap_or_default(),
             trust_root: tokio::sync::OnceCell::new(),
         }
+    }
+
+    pub fn trusted_github_repository(&self) -> Option<&str> {
+        self.config.github_workflow_repository.as_deref()
     }
 
     /// Returns a reference to the cached trust root, initializing it on first
@@ -887,6 +917,7 @@ impl OciDownloader {
 
                 log::debug!("Populated OCI blob cache at: {}", blob_path.display());
 
+                let file_sha256 = sha256_file(&blob_path)?;
                 let new_metadata = CacheMetadata {
                     manifest_digest: live_digest.to_string(),
                     filename: filename.clone(),
@@ -894,6 +925,8 @@ impl OciDownloader {
                         PluginType::Wasm => "extism".to_string(),
                         PluginType::Native => "native".to_string(),
                     },
+                    file_sha256: Some(file_sha256.clone()),
+                    annotations: image_manifest.annotations.clone().unwrap_or_default(),
                     retrieved_at_unix: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
                 };
                 fs::write(metadata_path, serde_json::to_vec(&new_metadata)?)?;
@@ -909,6 +942,9 @@ impl OciDownloader {
                 Ok(ProviderPlugin {
                     plugin_type: discovered_type,
                     file_path: blob_path,
+                    manifest_digest: Some(live_digest.to_string()),
+                    file_sha256: Some(file_sha256),
+                    annotations: image_manifest.annotations.clone().unwrap_or_default(),
                 })
             }
             Err(e) => {
@@ -1069,6 +1105,8 @@ mod tests {
             manifest_digest: "sha256:abc".to_string(),
             filename: "plugin.wasm".to_string(),
             plugin_type_str: "extism".to_string(),
+            file_sha256: None,
+            annotations: BTreeMap::new(),
             retrieved_at_unix: 1234567890,
         };
 
@@ -1088,6 +1126,8 @@ mod tests {
             manifest_digest: "sha256:def".to_string(),
             filename: "plugin.so".to_string(),
             plugin_type_str: "native".to_string(),
+            file_sha256: None,
+            annotations: BTreeMap::new(),
             retrieved_at_unix: 1234567890,
         };
 
@@ -1107,6 +1147,8 @@ mod tests {
             manifest_digest: "sha256:ghi".to_string(),
             filename: "plugin".to_string(),
             plugin_type_str: "invalid".to_string(),
+            file_sha256: None,
+            annotations: BTreeMap::new(),
             retrieved_at_unix: 1234567890,
         };
 
@@ -1130,6 +1172,8 @@ mod tests {
             manifest_digest: "sha256:test123".to_string(),
             filename: "test.wasm".to_string(),
             plugin_type_str: "extism".to_string(),
+            file_sha256: None,
+            annotations: BTreeMap::new(),
             retrieved_at_unix: 1234567890,
         };
 

--- a/crates/querymt/src/provider_config.rs
+++ b/crates/querymt/src/provider_config.rs
@@ -137,13 +137,10 @@ pub fn provider_static_config_json(
         .unwrap_or_else(|| Value::Object(Map::new())))
 }
 
-pub fn resolve_registry_provider_config(
-    registry: &PluginRegistry,
-    provider_name: &str,
+fn apply_api_key_env_fallback(
+    builder: &mut ProviderConfigBuilder,
     factory: &dyn LLMProviderFactory,
-) -> Result<ResolvedProviderConfig, LLMError> {
-    let mut builder = ProviderConfigBuilder::from_registry_provider(registry, provider_name)?;
-
+) {
     if !builder.contains_non_empty_str("api_key")
         && let Some(http_factory) = factory.as_http()
         && let Some(env_var_name) = http_factory.api_key_name()
@@ -152,7 +149,15 @@ pub fn resolve_registry_provider_config(
     {
         builder.set_if_missing("api_key", Value::String(api_key));
     }
+}
 
+pub fn resolve_registry_provider_config(
+    registry: &PluginRegistry,
+    provider_name: &str,
+    factory: &dyn LLMProviderFactory,
+) -> Result<ResolvedProviderConfig, LLMError> {
+    let mut builder = ProviderConfigBuilder::from_registry_provider(registry, provider_name)?;
+    apply_api_key_env_fallback(&mut builder, factory);
     builder.prune_for_factory(factory)
 }
 
@@ -161,14 +166,7 @@ pub fn resolve_binding_provider_config(
 ) -> Result<ResolvedProviderConfig, LLMError> {
     let mut builder = ProviderConfigBuilder::from_binding(binding);
     let factory = binding.factory.as_ref();
-    if !builder.contains_non_empty_str("api_key")
-        && let Some(http_factory) = factory.as_http()
-        && let Some(env_var_name) = http_factory.api_key_name()
-        && let Ok(api_key) = env::var(&env_var_name)
-        && !api_key.trim().is_empty()
-    {
-        builder.set_if_missing("api_key", Value::String(api_key));
-    }
+    apply_api_key_env_fallback(&mut builder, factory);
     builder.prune_for_factory(factory)
 }
 

--- a/crates/querymt/src/provider_config.rs
+++ b/crates/querymt/src/provider_config.rs
@@ -1,5 +1,8 @@
 use crate::error::LLMError;
-use crate::plugin::{LLMProviderFactory, host::PluginRegistry};
+use crate::plugin::{
+    LLMProviderFactory,
+    host::{PluginRegistry, ProviderBinding},
+};
 use serde_json::{Map, Value};
 use std::env;
 
@@ -36,6 +39,12 @@ impl ProviderConfigBuilder {
         Ok(Self {
             config: provider_static_config_json(registry, provider_name)?,
         })
+    }
+
+    pub fn from_binding(binding: &ProviderBinding) -> Self {
+        Self {
+            config: binding.static_config.clone(),
+        }
     }
 
     pub fn merge_value(&mut self, value: &Value, mode: ConfigOverrideMode) {
@@ -144,6 +153,22 @@ pub fn resolve_registry_provider_config(
         builder.set_if_missing("api_key", Value::String(api_key));
     }
 
+    builder.prune_for_factory(factory)
+}
+
+pub fn resolve_binding_provider_config(
+    binding: &ProviderBinding,
+) -> Result<ResolvedProviderConfig, LLMError> {
+    let mut builder = ProviderConfigBuilder::from_binding(binding);
+    let factory = binding.factory.as_ref();
+    if !builder.contains_non_empty_str("api_key")
+        && let Some(http_factory) = factory.as_http()
+        && let Some(env_var_name) = http_factory.api_key_name()
+        && let Ok(api_key) = env::var(&env_var_name)
+        && !api_key.trim().is_empty()
+    {
+        builder.set_if_missing("api_key", Value::String(api_key));
+    }
     builder.prune_for_factory(factory)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile provider modes and declarative, digest-pinned provider requirements.
  * Added provider-lock tracking to protect session resumption when provider configurations change.
  * Added provider metadata and integrity verification for native and OCI providers.
  * Added centralized provider resolution for catalogs, runtime construction, and remote fallback.
  * Added native plugin API and name metadata support.

* **Bug Fixes**
  * Improved detection of mismatched provider metadata and invalid cached plugin integrity data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->