### PR TITLE
feat(agent): add multimodal ACP attachment support + test fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11212,6 +11212,7 @@ dependencies = [
 name = "qmt-openai"
 version = "0.6.0"
 dependencies = [
+ "base64 0.23.1",
  "either",
  "extism-pdk",
  "heck 0.5.0",

--- a/crates/agent/examples/replay_session.rs
+++ b/crates/agent/examples/replay_session.rs
@@ -239,7 +239,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             })
         })
         .map(|m| m.to_chat_message())
-        .collect();
+        .collect::<Result<_, _>>()?;
 
     println!("💬 Message History: {} messages", chat_messages.len());
     for (i, msg) in chat_messages.iter().enumerate() {

--- a/crates/agent/src/acp/shared.rs
+++ b/crates/agent/src/acp/shared.rs
@@ -318,11 +318,57 @@ pub fn replay_agent_events_to_session_notifications<I>(
 where
     I: IntoIterator<Item = AgentEvent>,
 {
+    replay_agent_events_with_user_prompts(session_id, events, &HashMap::new())
+}
+
+fn user_prompt_chunk(
+    message_id: &str,
+    client_prompt_id: Option<&str>,
+    block: ContentBlock,
+) -> ContentChunk {
+    let chunk = ContentChunk::new(block).message_id(MessageId::from(message_id.to_string()));
+    match client_prompt_id {
+        Some(client_prompt_id) => chunk.meta(serde_json::Map::from_iter([(
+            "querymt".to_string(),
+            serde_json::json!({"client_prompt_id": client_prompt_id}),
+        )])),
+        None => chunk,
+    }
+}
+
+pub fn replay_agent_events_with_user_prompts<I>(
+    session_id: &str,
+    events: I,
+    user_prompts: &HashMap<String, Vec<ContentBlock>>,
+) -> Vec<crate::acp::protocol::SessionNotification>
+where
+    I: IntoIterator<Item = AgentEvent>,
+{
     events
         .into_iter()
-        .filter_map(|event| {
-            let envelope = EventEnvelope::from(event);
-            translate_replay_event_to_update(&envelope).map(|update| {
+        .flat_map(|event| {
+            let structured_updates = match &event.kind {
+                AgentEventKind::PromptReceived {
+                    message_id: Some(message_id),
+                    ..
+                } => user_prompts.get(message_id).map(|blocks| {
+                    blocks
+                        .iter()
+                        .cloned()
+                        .map(|block| {
+                            SessionUpdate::UserMessageChunk(user_prompt_chunk(
+                                message_id, None, block,
+                            ))
+                        })
+                        .collect::<Vec<_>>()
+                }),
+                _ => None,
+            };
+            let updates = structured_updates.unwrap_or_else(|| {
+                let envelope = EventEnvelope::from(event);
+                translate_replay_event_to_updates(&envelope)
+            });
+            updates.into_iter().map(|update| {
                 crate::acp::protocol::SessionNotification::new(
                     crate::acp::protocol::SessionId::from(session_id.to_string()),
                     update,
@@ -340,6 +386,7 @@ enum AcpTranslateMode {
 
 pub struct AcpLiveEventTranslator {
     streamed_assistant_messages: HashSet<(String, String)>,
+    structured_user_messages: HashSet<(String, String)>,
     delegation_updates: crate::control::delegation_notifications::DelegationUpdateProjector,
 }
 
@@ -353,6 +400,7 @@ impl AcpLiveEventTranslator {
     pub fn new() -> Self {
         Self {
             streamed_assistant_messages: HashSet::new(),
+            structured_user_messages: HashSet::new(),
             delegation_updates:
                 crate::control::delegation_notifications::DelegationUpdateProjector::for_live_stream(
                 ),
@@ -408,6 +456,30 @@ impl AcpLiveEventTranslator {
 
     pub fn translate_update(&mut self, event: &EventEnvelope) -> Option<SessionUpdate> {
         match event.kind() {
+            AgentEventKind::UserPromptBlock {
+                message_id,
+                client_prompt_id,
+                block,
+            } => {
+                self.structured_user_messages
+                    .insert((event.session_id().to_owned(), message_id.clone()));
+                Some(SessionUpdate::UserMessageChunk(user_prompt_chunk(
+                    message_id,
+                    client_prompt_id.as_deref(),
+                    block.clone(),
+                )))
+            }
+            AgentEventKind::PromptReceived {
+                message_id: Some(message_id),
+                ..
+            } => {
+                let key = (event.session_id().to_owned(), message_id.clone());
+                if self.structured_user_messages.remove(&key) {
+                    None
+                } else {
+                    translate_event_to_update_for_mode(event, AcpTranslateMode::Live)
+                }
+            }
             AgentEventKind::AssistantContentDelta {
                 content,
                 message_id,
@@ -491,6 +563,12 @@ pub fn translate_replay_event_to_update(event: &EventEnvelope) -> Option<Session
     translate_event_to_update_for_mode(event, AcpTranslateMode::Replay)
 }
 
+pub fn translate_replay_event_to_updates(event: &EventEnvelope) -> Vec<SessionUpdate> {
+    translate_replay_event_to_update(event)
+        .into_iter()
+        .collect()
+}
+
 fn translate_event_to_update_for_mode(
     event: &EventEnvelope,
     mode: AcpTranslateMode,
@@ -503,6 +581,21 @@ fn translate_event_to_update_for_mode(
             ContentChunk::new(ContentBlock::Text(TextContent::new(content.clone())))
                 .message_id(message_id.clone().map(MessageId::from)),
         )),
+        AgentEventKind::UserPromptBlock {
+            message_id,
+            client_prompt_id,
+            block,
+        } => {
+            if mode == AcpTranslateMode::Replay {
+                None
+            } else {
+                Some(SessionUpdate::UserMessageChunk(user_prompt_chunk(
+                    message_id,
+                    client_prompt_id.as_deref(),
+                    block.clone(),
+                )))
+            }
+        }
         AgentEventKind::AssistantMessageStored {
             content,
             message_id,
@@ -1313,6 +1406,78 @@ mod tests {
             chunk.message_id.as_ref().map(|id| id.0.as_ref()),
             Some("u-1")
         );
+        assert!(chunk.meta.is_none());
+    }
+
+    #[test]
+    fn live_prompt_blocks_preserve_order_and_share_message_id() {
+        let blocks = vec![
+            ContentBlock::Text(TextContent::new("before")),
+            ContentBlock::Image(crate::acp::protocol::ImageContent::new("AQID", "image/png")),
+            ContentBlock::Text(TextContent::new("after")),
+        ];
+        let mut translator = AcpLiveEventTranslator::new();
+        let updates = blocks
+            .into_iter()
+            .enumerate()
+            .map(|(index, block)| {
+                translator
+                    .translate_update(&EventEnvelope::Ephemeral(crate::events::EphemeralEvent {
+                        session_id: "s-1".to_string(),
+                        timestamp: index as i64,
+                        origin: EventOrigin::Local,
+                        source_node: None,
+                        kind: AgentEventKind::UserPromptBlock {
+                            message_id: "u-1".to_string(),
+                            client_prompt_id: Some("client-1".to_string()),
+                            block,
+                        },
+                    }))
+                    .expect("prompt block should translate")
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(updates.len(), 3);
+        for update in &updates {
+            let SessionUpdate::UserMessageChunk(chunk) = update else {
+                panic!("expected user message chunk");
+            };
+            assert_eq!(
+                chunk.message_id.as_ref().map(|id| id.0.as_ref()),
+                Some("u-1")
+            );
+            assert_eq!(
+                chunk
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("querymt"))
+                    .and_then(|querymt| querymt.get("client_prompt_id"))
+                    .and_then(serde_json::Value::as_str),
+                Some("client-1")
+            );
+            let wire = serde_json::to_value(update).expect("serialize user message chunk");
+            assert_eq!(wire["sessionUpdate"], "user_message_chunk");
+            assert_eq!(wire["_meta"]["querymt"]["client_prompt_id"], "client-1");
+        }
+        assert!(matches!(
+            &updates[1],
+            SessionUpdate::UserMessageChunk(chunk)
+                if matches!(chunk.content, ContentBlock::Image(_))
+        ));
+
+        let summary = EventEnvelope::Durable(DurableEvent {
+            event_id: "evt-prompt".into(),
+            stream_seq: 4,
+            timestamp: 4,
+            session_id: "s-1".to_string(),
+            origin: EventOrigin::Local,
+            source_node: None,
+            kind: AgentEventKind::PromptReceived {
+                content: "before\n\nafter".to_string(),
+                message_id: Some("u-1".to_string()),
+            },
+        });
+        assert!(translator.translate_update(&summary).is_none());
     }
 
     #[test]
@@ -1631,6 +1796,46 @@ mod tests {
             notifications[1].update,
             SessionUpdate::AgentMessageChunk(_)
         ));
+    }
+
+    #[test]
+    fn replay_uses_persisted_structured_prompt_blocks_when_available() {
+        let event = AgentEvent {
+            seq: 1,
+            timestamp: 1,
+            session_id: "s-1".to_string(),
+            origin: EventOrigin::Local,
+            source_node: None,
+            kind: AgentEventKind::PromptReceived {
+                content: "compact summary".to_string(),
+                message_id: Some("u-1".to_string()),
+            },
+        };
+        let prompt_blocks = HashMap::from([(
+            "u-1".to_string(),
+            vec![
+                ContentBlock::Image(crate::acp::protocol::ImageContent::new("AQID", "image/png")),
+                ContentBlock::Text(TextContent::new("describe this")),
+            ],
+        )]);
+        let notifications =
+            replay_agent_events_with_user_prompts("s-1", vec![event], &prompt_blocks);
+
+        assert_eq!(notifications.len(), 2);
+        assert!(matches!(
+            notifications[0].update,
+            SessionUpdate::UserMessageChunk(ref chunk)
+                if matches!(chunk.content, ContentBlock::Image(_))
+        ));
+        for notification in notifications {
+            let SessionUpdate::UserMessageChunk(chunk) = notification.update else {
+                panic!("expected user message chunk");
+            };
+            assert_eq!(
+                chunk.message_id.as_ref().map(|id| id.0.as_ref()),
+                Some("u-1")
+            );
+        }
     }
 
     #[test]

--- a/crates/agent/src/acp/stdio.rs
+++ b/crates/agent/src/acp/stdio.rs
@@ -818,14 +818,14 @@ pub async fn serve_stdio(agent: Arc<crate::agent::LocalAgentHandle>) -> anyhow::
 mod stdio_tests {
     use super::{
         AcpLiveEventTranslator, CancelNotification, ClientBridgeMessage, PromptRequest,
-        agent_ext_request, create_elicitation_request, run_bridge_task,
-        spawn_event_bridge_forwarder,
+        agent_ext_request, create_elicitation_request, replay_agent_events_with_user_prompts,
+        run_bridge_task, spawn_event_bridge_forwarder,
     };
     use crate::acp::client_bridge::ClientBridgeSender;
     use crate::acp::protocol::{
-        AgentRequest, CreateElicitationRequest, ElicitationAcceptAction,
-        ElicitationAction as AcpElicitationAction, ElicitationContentValue, PromptResponse,
-        SessionId, SessionNotification, StopReason,
+        AgentRequest, ContentBlock, CreateElicitationRequest, ElicitationAcceptAction,
+        ElicitationAction as AcpElicitationAction, ElicitationContentValue, ImageContent,
+        PromptResponse, SessionId, SessionNotification, SessionUpdate, StopReason, TextContent,
     };
     use crate::elicitation::ElicitationAction;
     use agent_client_protocol::{Agent, ByteStreams, Client, JsonRpcMessage};
@@ -835,6 +835,58 @@ mod stdio_tests {
     use tokio::sync::{Mutex, Notify, mpsc};
     use tokio::time::{Duration, timeout};
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+    #[test]
+    fn session_load_replay_preserves_structured_prompt_order_and_message_id() {
+        let event = crate::events::AgentEvent {
+            seq: 1,
+            timestamp: 1,
+            session_id: "s-1".to_string(),
+            origin: crate::events::EventOrigin::Local,
+            source_node: None,
+            kind: crate::events::AgentEventKind::PromptReceived {
+                content: "flattened summary".to_string(),
+                message_id: Some("stored-message-id".to_string()),
+            },
+        };
+        let prompt_blocks = std::collections::HashMap::from([(
+            "stored-message-id".to_string(),
+            vec![
+                ContentBlock::Text(TextContent::new("before")),
+                ContentBlock::Image(ImageContent::new("AQID", "image/png")),
+                ContentBlock::Text(TextContent::new("after")),
+            ],
+        )]);
+
+        let notifications =
+            replay_agent_events_with_user_prompts("s-1", vec![event], &prompt_blocks);
+
+        assert_eq!(notifications.len(), 3);
+        assert!(matches!(
+            &notifications[0].update,
+            SessionUpdate::UserMessageChunk(chunk)
+                if matches!(&chunk.content, ContentBlock::Text(text) if text.text == "before")
+        ));
+        assert!(matches!(
+            &notifications[1].update,
+            SessionUpdate::UserMessageChunk(chunk)
+                if matches!(&chunk.content, ContentBlock::Image(image) if image.data == "AQID")
+        ));
+        assert!(matches!(
+            &notifications[2].update,
+            SessionUpdate::UserMessageChunk(chunk)
+                if matches!(&chunk.content, ContentBlock::Text(text) if text.text == "after")
+        ));
+        for notification in notifications {
+            let SessionUpdate::UserMessageChunk(chunk) = notification.update else {
+                panic!("expected structured user message chunk");
+            };
+            assert_eq!(
+                chunk.message_id.as_ref().map(|id| id.0.as_ref()),
+                Some("stored-message-id")
+            );
+        }
+    }
 
     #[tokio::test]
     async fn delegation_update_uses_typed_ext_notification_bridge() {

--- a/crates/agent/src/acp/stdio.rs
+++ b/crates/agent/src/acp/stdio.rs
@@ -33,13 +33,13 @@ use crate::acp::protocol::{
 };
 use crate::acp::shared::{
     AcpLiveEventTranslator, QMT_NOTIFICATION_DELEGATION_UPDATE, convert_elicitation_response,
-    create_elicitation_request, replay_agent_events_to_session_notifications,
+    create_elicitation_request, replay_agent_events_with_user_prompts,
 };
 use crate::acp::shutdown;
 use crate::event_fanout::EventFanout;
 use crate::send_agent::SendAgent;
 use agent_client_protocol::{self as acp, ByteStreams, ConnectionTo};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -86,27 +86,51 @@ async fn prepare_session_load(
         let registry = agent.registry.lock().await;
         registry.get(&session_id).cloned()
     };
-    let events = match session_ref {
+    let (events, prompt_blocks) = match session_ref {
         Some(session_ref) => match session_ref
             .get_event_stream()
             .instrument(info_span!("session.event_stream.load", session.id = %session_id))
             .await
         {
-            Ok(events) => events,
+            Ok(events) => {
+                let history = session_ref
+                    .get_history()
+                    .instrument(info_span!("session.history.load", session.id = %session_id))
+                    .await
+                    .map_err(|err| {
+                        tracing::warn!(session.id = %session_id, error = %err, "failed to load ACP replay history");
+                        acp::Error::internal_error().data(serde_json::json!({
+                            "message": format!("Failed to replay session history: {err}"),
+                            "sessionId": session_id,
+                        }))
+                    })?;
+                let prompt_blocks = history
+                    .into_iter()
+                    .filter_map(|message| {
+                        let blocks = message.parts.into_iter().find_map(|part| match part {
+                            crate::model::MessagePart::Prompt { blocks } => Some(blocks),
+                            _ => None,
+                        })?;
+                        Some((message.id, blocks))
+                    })
+                    .collect::<HashMap<_, _>>();
+                (events, prompt_blocks)
+            }
             Err(err) => {
                 tracing::warn!(session.id = %session_id, error = %err, "failed to load ACP replay events");
-                Vec::new()
+                (Vec::new(), HashMap::new())
             }
         },
         None => {
             tracing::warn!(session.id = %session_id, "loaded session has no runtime ref for ACP replay");
-            Vec::new()
+            (Vec::new(), HashMap::new())
         }
     };
     let event_count = events.len();
-    let notifications = async { replay_agent_events_to_session_notifications(&session_id, events) }
-        .instrument(info_span!("acp.replay.translate", session.id = %session_id))
-        .await;
+    let notifications =
+        async { replay_agent_events_with_user_prompts(&session_id, events, &prompt_blocks) }
+            .instrument(info_span!("acp.replay.translate", session.id = %session_id))
+            .await;
     tracing::Span::current().record("session.load.event_count", event_count as i64);
     tracing::Span::current().record(
         "session.load.replay_notification_count",

--- a/crates/agent/src/agent/execution/maintenance.rs
+++ b/crates/agent/src/agent/execution/maintenance.rs
@@ -96,6 +96,9 @@ pub(super) async fn run_ai_compaction(
                 .iter()
                 .map(|p| match p {
                     MessagePart::Text { content } => content.len() / 4,
+                    MessagePart::Prompt { blocks } | MessagePart::Steering { blocks, .. } => {
+                        crate::agent::utils::render_prompt_for_llm(blocks, None).len() / 4
+                    }
                     MessagePart::ToolResult { content, .. } => {
                         content
                             .iter()
@@ -298,8 +301,9 @@ pub(super) async fn run_ai_compaction(
         .and_then(|cfg| cfg.max_prompt_bytes);
     let chat_messages: Vec<querymt::chat::ChatMessage> = filtered_messages
         .iter()
-        .map(|m| m.to_chat_message_with_max_prompt_bytes(prompt_limit))
-        .collect();
+        .map(|message| message.to_chat_message_with_max_prompt_bytes(prompt_limit))
+        .collect::<Result<_, _>>()
+        .map_err(|error| anyhow::anyhow!("Invalid prompt content after compaction: {error}"))?;
 
     let new_context_tokens = config
         .compaction

--- a/crates/agent/src/agent/execution/maintenance.rs
+++ b/crates/agent/src/agent/execution/maintenance.rs
@@ -89,6 +89,9 @@ pub(super) async fn run_ai_compaction(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to get agent history: {}", e))?;
 
+    let prompt_limit = exec_ctx
+        .execution_config()
+        .and_then(|cfg| cfg.max_prompt_bytes);
     let token_estimate: usize = messages
         .iter()
         .map(|m| {
@@ -97,7 +100,7 @@ pub(super) async fn run_ai_compaction(
                 .map(|p| match p {
                     MessagePart::Text { content } => content.len() / 4,
                     MessagePart::Prompt { blocks } | MessagePart::Steering { blocks, .. } => {
-                        crate::agent::utils::render_prompt_for_llm(blocks, None).len() / 4
+                        crate::agent::utils::render_prompt_for_llm(blocks, prompt_limit).len() / 4
                     }
                     MessagePart::ToolResult { content, .. } => {
                         content
@@ -296,9 +299,6 @@ pub(super) async fn run_ai_compaction(
         .map_err(|e| anyhow::anyhow!("Failed to get new history: {}", e))?;
 
     // Convert AgentMessages to ChatMessages for the ConversationContext
-    let prompt_limit = exec_ctx
-        .execution_config()
-        .and_then(|cfg| cfg.max_prompt_bytes);
     let chat_messages: Vec<querymt::chat::ChatMessage> = filtered_messages
         .iter()
         .map(|message| message.to_chat_message_with_max_prompt_bytes(prompt_limit))

--- a/crates/agent/src/agent/execution/mod.rs
+++ b/crates/agent/src/agent/execution/mod.rs
@@ -93,7 +93,7 @@ fn refresh_objective_fragment(
     ))
 }
 
-async fn apply_pending_steering(
+pub(crate) async fn apply_pending_steering(
     config: &AgentConfig,
     exec_ctx: &mut ExecutionContext,
     context: &Arc<crate::middleware::ConversationContext>,
@@ -129,12 +129,11 @@ async fn apply_pending_steering(
             source_provider: None,
             source_model: None,
         };
-        exec_ctx.add_message(message.clone()).await?;
-        messages.push(
-            message
-                .to_chat_message()
-                .map_err(|error| anyhow::anyhow!("Invalid steering content: {error}"))?,
-        );
+        let chat_message = message
+            .to_chat_message()
+            .map_err(|error| anyhow::anyhow!("Invalid steering content: {error}"))?;
+        exec_ctx.add_message(message).await?;
+        messages.push(chat_message);
         if !display.trim().is_empty() {
             let summary = exec_ctx
                 .state

--- a/crates/agent/src/agent/execution/mod.rs
+++ b/crates/agent/src/agent/execution/mod.rs
@@ -130,7 +130,11 @@ async fn apply_pending_steering(
             source_model: None,
         };
         exec_ctx.add_message(message.clone()).await?;
-        messages.push(message.to_chat_message());
+        messages.push(
+            message
+                .to_chat_message()
+                .map_err(|error| anyhow::anyhow!("Invalid steering content: {error}"))?,
+        );
         if !display.trim().is_empty() {
             let summary = exec_ctx
                 .state
@@ -239,13 +243,17 @@ pub(crate) async fn execute_cycle_state_machine(
 
     let messages: Arc<[querymt::chat::ChatMessage]> = async {
         let started = std::time::Instant::now();
-        let messages: Arc<[querymt::chat::ChatMessage]> =
-            Arc::from(exec_ctx.session_handle.history().await.into_boxed_slice());
+        let history = exec_ctx
+            .session_handle
+            .history()
+            .await
+            .map_err(|error| anyhow::anyhow!("Failed to load session history: {error}"));
+        let messages: Arc<[querymt::chat::ChatMessage]> = Arc::from(history?.into_boxed_slice());
         let elapsed_ms = started.elapsed().as_millis() as u64;
         let span = tracing::Span::current();
         span.record("history_ms", elapsed_ms);
         span.record("message_count", messages.len() as u64);
-        messages
+        Ok::<_, anyhow::Error>(messages)
     }
     .instrument(info_span!(
         "agent.execution.history_load",
@@ -253,7 +261,7 @@ pub(crate) async fn execute_cycle_state_machine(
         history_ms = tracing::field::Empty,
         message_count = tracing::field::Empty
     ))
-    .await;
+    .await?;
 
     debug!(
         "Session {}: history loaded, {} messages",
@@ -528,7 +536,16 @@ pub(crate) async fn execute_cycle_state_machine(
 
             ExecutionState::Complete { context } => {
                 exec_ctx.report_phase(crate::agent::turn_control::RunPhase::Closing);
-                let history = Arc::from(exec_ctx.session_handle.history().await.into_boxed_slice());
+                let history = Arc::from(
+                    exec_ctx
+                        .session_handle
+                        .history()
+                        .await
+                        .map_err(|error| {
+                            anyhow::anyhow!("Failed to load session history: {error}")
+                        })?
+                        .into_boxed_slice(),
+                );
                 let fallback_context = Arc::new(
                     crate::middleware::ConversationContext::new(
                         context.session_id.clone(),

--- a/crates/agent/src/agent/execution/tool_calls.rs
+++ b/crates/agent/src/agent/execution/tool_calls.rs
@@ -1106,7 +1106,11 @@ pub(super) async fn store_all_tool_results(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to store tool results: {}", e))?;
 
-    messages.push(result_msg.to_chat_message());
+    messages.push(
+        result_msg
+            .to_chat_message()
+            .map_err(|error| anyhow::anyhow!("Invalid stored tool result content: {error}"))?,
+    );
 
     let new_context = Arc::new(
         crate::middleware::ConversationContext::new(

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -972,7 +972,11 @@ pub(super) async fn transition_after_llm(
     );
 
     let mut messages = (*context.messages).to_vec();
-    messages.push(assistant_msg.to_chat_message());
+    messages.push(
+        assistant_msg
+            .to_chat_message()
+            .map_err(|error| anyhow::anyhow!("Invalid stored assistant content: {error}"))?,
+    );
 
     let mut updated_stats = (*context.stats).clone();
     updated_stats.steps += 1;

--- a/crates/agent/src/agent/execution_tests.rs
+++ b/crates/agent/src/agent/execution_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
@@ -12,7 +13,7 @@ use tempfile::TempDir;
 use time::OffsetDateTime;
 use tokio::sync::{Mutex, oneshot};
 
-use crate::acp::protocol::StopReason;
+use crate::acp::protocol::{ContentBlock, ImageContent, StopReason};
 use crate::agent::agent_config::AgentConfig;
 use crate::agent::core::ToolPolicy;
 use crate::agent::execution::CycleOutcome;
@@ -38,6 +39,7 @@ struct TestHarness {
     exec_ctx: ExecutionContext,
     provider: Arc<Mutex<MockLlmProvider>>,
     stored_messages: Arc<StdMutex<Vec<crate::model::AgentMessage>>>,
+    history_writes: Arc<AtomicUsize>,
     _temp_dir: TempDir,
 }
 
@@ -109,11 +111,14 @@ impl TestHarness {
             .expect_get_session_provider_node_id()
             .returning(|_| Ok(None))
             .times(0..);
+        let history_writes = Arc::new(AtomicUsize::new(0));
         let stored_messages_for_mock = stored_messages.clone();
+        let history_writes_for_mock = history_writes.clone();
         store
             .expect_add_message()
             .returning(move |_, message| {
                 stored_messages_for_mock.lock().unwrap().push(message);
+                history_writes_for_mock.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             })
             .times(0..);
@@ -213,6 +218,7 @@ impl TestHarness {
             exec_ctx,
             provider,
             stored_messages,
+            history_writes,
             _temp_dir: temp_dir,
         }
     }
@@ -436,6 +442,42 @@ async fn completion_guard_does_not_continue_for_non_active_task() {
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn invalid_steering_conversion_does_not_persist_history() {
+    let mut harness = TestHarness::new(vec![], None).await;
+    let inbox = Arc::new(crate::agent::turn_control::SteeringInbox::new(
+        "run-1".to_string(),
+    ));
+    inbox
+        .push(
+            "input-1".to_string(),
+            None,
+            vec![ContentBlock::Image(ImageContent::new("%%%", "image/png"))],
+        )
+        .await
+        .expect("direct inbox insertion bypasses admission validation");
+    harness.exec_ctx = harness.exec_ctx.with_steering(inbox);
+    let context = Arc::new(crate::middleware::ConversationContext::new(
+        Arc::from(harness.session_id.as_str()),
+        Arc::from([]),
+        Arc::new(crate::middleware::AgentStats::default()),
+        Arc::from("mock"),
+        Arc::from("mock-model"),
+    ));
+
+    let result = crate::agent::execution::apply_pending_steering(
+        &harness.config,
+        &mut harness.exec_ctx,
+        &context,
+        "test",
+        false,
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(harness.history_writes.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -493,7 +493,10 @@ impl LocalAgentHandle {
             let mut response = LoadSessionResponse::new()
                 .modes(crate::agent::session_registry::mode_state(current_mode))
                 .config_options(config_options);
-            if let Some(meta) = profile_handle.session_load_snapshot_meta(&session_id).await {
+            if let Some(meta) = profile_handle
+                .session_load_snapshot_meta(&session_id)
+                .await?
+            {
                 response = response.meta(meta);
             }
             return Ok(response);
@@ -519,7 +522,7 @@ impl LocalAgentHandle {
             let mut response = LoadSessionResponse::new()
                 .modes(crate::agent::session_registry::mode_state(current_mode))
                 .config_options(config_options);
-            if let Some(meta) = self.session_load_snapshot_meta(&session_id).await {
+            if let Some(meta) = self.session_load_snapshot_meta(&session_id).await? {
                 response = response.meta(meta);
             }
             return Ok(response);
@@ -566,7 +569,7 @@ impl LocalAgentHandle {
         let mut response = LoadSessionResponse::new()
             .modes(crate::agent::session_registry::mode_state(current_mode))
             .config_options(config_options);
-        if let Some(meta) = self.session_load_snapshot_meta(&session_id).await {
+        if let Some(meta) = self.session_load_snapshot_meta(&session_id).await? {
             response = response.meta(meta);
         }
 
@@ -576,17 +579,27 @@ impl LocalAgentHandle {
     async fn session_load_snapshot_meta(
         &self,
         session_id: &str,
-    ) -> Option<serde_json::Map<String, serde_json::Value>> {
-        let view_store = self.config.storage.view_store()?;
+    ) -> std::result::Result<Option<serde_json::Map<String, serde_json::Value>>, Error> {
+        let Some(view_store) = self.config.storage.view_store() else {
+            return Ok(None);
+        };
         let snapshot = crate::session::load_session_snapshot(self, view_store, session_id)
             .await
-            .ok()?;
+            .map_err(|error| {
+                Error::internal_error().data(serde_json::json!({
+                    "message": format!("Failed to build session load snapshot: {error}"),
+                    "sessionId": session_id,
+                }))
+            })?;
+        let snapshot = serde_json::to_value(snapshot).map_err(|error| {
+            Error::internal_error().data(serde_json::json!({
+                "message": format!("Failed to serialize session load snapshot: {error}"),
+                "sessionId": session_id,
+            }))
+        })?;
         let mut meta = serde_json::Map::new();
-        meta.insert(
-            "querymt/sessionLoadSnapshot.v1".to_string(),
-            serde_json::to_value(snapshot).ok()?,
-        );
-        Some(meta)
+        meta.insert("querymt/sessionLoadSnapshot.v1".to_string(), snapshot);
+        Ok(Some(meta))
     }
 
     /// Gracefully shutdown the agent and all background tasks.

--- a/crates/agent/src/agent/handle/send_agent_lifecycle.rs
+++ b/crates/agent/src/agent/handle/send_agent_lifecycle.rs
@@ -31,7 +31,7 @@ impl LocalAgentHandle {
 
         let mut capabilities = AgentCapabilities::new()
             .load_session(true)
-            .prompt_capabilities(PromptCapabilities::new().embedded_context(true))
+            .prompt_capabilities(PromptCapabilities::new().image(true).embedded_context(true))
             .mcp_capabilities(McpCapabilities::new().http(true).sse(true))
             .session_capabilities(
                 SessionCapabilities::new()

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -63,6 +63,8 @@ async fn test_initialize_advertises_session_capabilities() {
     let resp = f.handle.initialize(req).await.expect("initialize");
 
     assert!(resp.agent_capabilities.load_session);
+    assert!(resp.agent_capabilities.prompt_capabilities.image);
+    assert!(resp.agent_capabilities.prompt_capabilities.embedded_context);
     assert!(resp.agent_capabilities.session_capabilities.list.is_some());
     assert!(resp.agent_capabilities.session_capabilities.fork.is_some());
     assert!(

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -1461,6 +1461,14 @@ impl Message<SubmitSessionInput> for SessionActor {
 
         match input.delivery {
             InputDelivery::Steer => {
+                let llm_config = self
+                    .config
+                    .provider
+                    .history_store()
+                    .get_session_llm_config(&self.session_id)
+                    .await
+                    .map_err(|e| AgentError::Internal(e.to_string()))?;
+                validate_model_image_support(&input.prompt, llm_config.as_ref())?;
                 let run = self
                     .active_run
                     .as_ref()
@@ -2087,13 +2095,6 @@ async fn execute_prompt_detached(
         );
         return Err(AgentError::Internal(reason));
     }
-    config.emit_event(
-        &session_id,
-        AgentEventKind::PromptReceived {
-            content: display_content.clone(),
-            message_id: Some(message_id.clone()),
-        },
-    );
 
     let mut parts = vec![MessagePart::Prompt {
         blocks: req.prompt.clone(),

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -21,7 +21,7 @@ use crate::agent::utils::{format_prompt_user_text_only, render_prompt_for_displa
 use crate::error::AgentError;
 use crate::events::{AgentEventKind, SessionLimits};
 use crate::hooks::HookNotice;
-use crate::model::{AgentMessage, MessagePart};
+use crate::model::{AgentMessage, MessagePart, prompt_contains_images, validate_prompt_blocks};
 use crate::session::runtime::RuntimeContext;
 use crate::session::store::LLMConfig;
 use kameo::Actor;
@@ -36,6 +36,15 @@ use tokio::sync::{OwnedSemaphorePermit, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info_span, instrument};
 use uuid::Uuid;
+
+fn client_prompt_id_from_meta(meta: Option<&crate::acp::protocol::Meta>) -> Option<String> {
+    meta.and_then(|meta| meta.get("querymt"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|querymt| querymt.get("client_prompt_id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+}
 
 fn parse_transport_model_id(model_id: &str, fallback_provider: &str) -> (String, String) {
     if let Some(slash_pos) = model_id.find('/') {
@@ -1444,6 +1453,7 @@ impl Message<SubmitSessionInput> for SessionActor {
                 received: input.session_id,
             }));
         }
+        validate_prompt_blocks(&input.prompt)?;
         let input_id = input
             .client_input_id
             .clone()
@@ -1553,6 +1563,9 @@ impl Message<Prompt> for SessionActor {
     type Reply = DelegatedReply<Result<PromptResponse, AgentError>>;
 
     async fn handle(&mut self, msg: Prompt, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        if let Err(error) = validate_prompt_blocks(&msg.req.prompt) {
+            return ctx.spawn(async move { Err(AgentError::from(error)) });
+        }
         let (reply, receiver) = oneshot::channel();
         if self.active_run.is_some() {
             if self.queued_prompts.len() >= MAX_QUEUED_PROMPTS {
@@ -1800,7 +1813,42 @@ async fn acquire_execution_permit_with_timeout(
 }
 
 fn normalized_run_instruction(prompt: &[crate::acp::protocol::ContentBlock]) -> String {
-    crate::agent::utils::render_prompt_for_llm(prompt, None)
+    render_prompt_for_display(prompt)
+}
+
+fn validate_model_image_support(
+    prompt: &[crate::acp::protocol::ContentBlock],
+    llm_config: Option<&LLMConfig>,
+) -> Result<(), AgentError> {
+    if !prompt_contains_images(prompt) {
+        return Ok(());
+    }
+    let Some(llm_config) = llm_config else {
+        return Ok(());
+    };
+    if !model_supports_images(
+        crate::model_info::get_model_info(&llm_config.provider, &llm_config.model).as_ref(),
+    ) {
+        return Err(AgentError::InvalidPromptContent {
+            message: format!(
+                "selected model {}/{} does not support image attachments",
+                llm_config.provider, llm_config.model
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn model_supports_images(model_info: Option<&querymt::providers::ModelInfo>) -> bool {
+    model_info.is_none_or(|info| {
+        info.capabilities.attachment
+            || info
+                .capabilities
+                .modalities
+                .input
+                .iter()
+                .any(|modality| modality == "image")
+    })
 }
 
 async fn validate_execution_task(
@@ -1873,6 +1921,8 @@ async fn execute_prompt_detached(
         session_id,
         req.prompt.len()
     );
+    let client_prompt_id = client_prompt_id_from_meta(req.meta.as_ref());
+    validate_prompt_blocks(&req.prompt)?;
 
     // Acquire execution permit (blocking with timeout)
     let _permit = match acquire_execution_permit_with_timeout(
@@ -1945,6 +1995,9 @@ async fn execute_prompt_detached(
         .with_session(&session_id)
         .await
         .map_err(|e| AgentError::Internal(e.to_string()))?;
+
+    // Slash-command expansion can alter text, but never attachment capability.
+    validate_model_image_support(&req.prompt, session_handle.llm_config())?;
 
     // Create and load RuntimeContext
     let mut runtime_context =
@@ -2077,6 +2130,26 @@ async fn execute_prompt_detached(
         return Err(AgentError::Internal(e.to_string()));
     }
 
+    for block in &req.prompt {
+        config.emit_event(
+            &session_id,
+            AgentEventKind::UserPromptBlock {
+                message_id: message_id.clone(),
+                client_prompt_id: client_prompt_id.clone(),
+                block: block.clone(),
+            },
+        );
+    }
+    config
+        .emit_event_persisted(
+            &session_id,
+            AgentEventKind::PromptReceived {
+                content: display_content.clone(),
+                message_id: Some(message_id.clone()),
+            },
+        )
+        .await
+        .map_err(|error| AgentError::Internal(error.to_string()))?;
     config.emit_event(
         &session_id,
         AgentEventKind::UserMessageStored {
@@ -2620,6 +2693,31 @@ mod tests {
         let instruction = normalized_run_instruction(&prompt);
 
         assert!(instruction.contains(required_sentence));
+    }
+
+    #[test]
+    fn model_image_capability_allows_unknown_and_rejects_known_text_only() {
+        let text_only = querymt::providers::ModelInfo {
+            id: "text-only".to_string(),
+            name: "Text only".to_string(),
+            ..Default::default()
+        };
+        let multimodal = querymt::providers::ModelInfo {
+            id: "vision".to_string(),
+            name: "Vision".to_string(),
+            capabilities: querymt::providers::ModelCapabilities {
+                modalities: querymt::providers::Modalities {
+                    input: vec!["text".to_string(), "image".to_string()],
+                    output: vec!["text".to_string()],
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(model_supports_images(None));
+        assert!(!model_supports_images(Some(&text_only)));
+        assert!(model_supports_images(Some(&multimodal)));
     }
 
     #[tokio::test]
@@ -3216,6 +3314,19 @@ mod tests {
     }
 
     // ── Token state machine tests ─────────────────────────────────────────────
+
+    #[test]
+    fn client_prompt_id_uses_querymt_metadata_namespace() {
+        let meta = serde_json::Map::from_iter([(
+            "querymt".to_string(),
+            serde_json::json!({"client_prompt_id": "client-123"}),
+        )]);
+        assert_eq!(
+            client_prompt_id_from_meta(Some(&meta)).as_deref(),
+            Some("client-123")
+        );
+        assert!(client_prompt_id_from_meta(None).is_none());
+    }
 
     #[test]
     fn parse_transport_model_id_splits_on_first_slash() {

--- a/crates/agent/src/agent/turn_control.rs
+++ b/crates/agent/src/agent/turn_control.rs
@@ -7,8 +7,8 @@ use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
 pub const MAX_STEERING_MESSAGES: usize = 32;
-pub const MAX_STEERING_BYTES: usize = 256 * 1024;
-pub const MAX_STEERING_INPUT_BYTES: usize = 64 * 1024;
+pub const MAX_STEERING_BYTES: usize = 256 * 1024 * 1024;
+pub const MAX_STEERING_INPUT_BYTES: usize = 32 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/agent/src/agent/utils.rs
+++ b/crates/agent/src/agent/utils.rs
@@ -4,17 +4,18 @@ use crate::acp::protocol::{ContentBlock, EmbeddedResourceResource, ToolCallLocat
 use log::warn;
 
 const ATTACHMENTS_DISPLAY_FALLBACK: &str = "(attachments included)";
+const IMAGE_DISPLAY_FALLBACK: &str = "(image attached)";
 
-/// Format only user text from prompt blocks (first Text block only).
-/// This excludes attachment content which is in subsequent blocks.
+/// Collect user-authored text without incorporating attachment payloads.
 pub fn format_prompt_user_text_only(blocks: &[ContentBlock]) -> String {
     blocks
-        .first()
-        .and_then(|block| match block {
-            ContentBlock::Text(text) => Some(text.text.clone()),
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text(text) => Some(text.text.as_str()),
             _ => None,
         })
-        .unwrap_or_default()
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 /// Render prompt blocks for user-facing displays/events.
@@ -26,7 +27,9 @@ pub fn render_prompt_for_display(blocks: &[ContentBlock]) -> String {
         return user_text;
     }
 
-    if blocks.get(1).is_some() {
+    if crate::model::prompt_contains_images(blocks) {
+        IMAGE_DISPLAY_FALLBACK.to_string()
+    } else if !blocks.is_empty() {
         ATTACHMENTS_DISPLAY_FALLBACK.to_string()
     } else {
         String::new()
@@ -58,9 +61,9 @@ pub fn render_prompt_for_llm(blocks: &[ContentBlock], max_prompt_bytes: Option<u
                 }
                 EmbeddedResourceResource::BlobResourceContents(blob) => {
                     content.push_str(&format!(
-                        "[Embedded Resource: {}] (blob, {} bytes)",
+                        "[Embedded Resource: {}] ({})",
                         blob.uri,
-                        blob.blob.len()
+                        blob.mime_type.as_deref().unwrap_or("binary")
                     ));
                 }
                 _ => {
@@ -68,18 +71,10 @@ pub fn render_prompt_for_llm(blocks: &[ContentBlock], max_prompt_bytes: Option<u
                 }
             },
             ContentBlock::Image(image) => {
-                content.push_str(&format!(
-                    "[Image] mime={}, bytes={}",
-                    image.mime_type,
-                    image.data.len()
-                ));
+                content.push_str(&format!("[Image: {}]", image.mime_type));
             }
             ContentBlock::Audio(audio) => {
-                content.push_str(&format!(
-                    "[Audio] mime={}, bytes={}",
-                    audio.mime_type,
-                    audio.data.len()
-                ));
+                content.push_str(&format!("[Audio: {}]", audio.mime_type));
             }
             _ => {
                 content.push_str("[Unsupported content block]");
@@ -189,8 +184,8 @@ mod tests {
             ContentBlock::Text(TextContent::new("[file: x]".to_string())),
         ];
 
-        assert_eq!(render_prompt_for_display(&blocks), "hello");
-        assert_eq!(format_prompt_user_text_only(&blocks), "hello");
+        assert_eq!(render_prompt_for_display(&blocks), "hello\n\n[file: x]");
+        assert_eq!(format_prompt_user_text_only(&blocks), "hello\n\n[file: x]");
     }
 
     #[test]
@@ -200,6 +195,6 @@ mod tests {
             ContentBlock::Text(TextContent::new("[file: x]".to_string())),
         ];
 
-        assert_eq!(render_prompt_for_display(&blocks), "(attachments included)");
+        assert_eq!(render_prompt_for_display(&blocks), "[file: x]");
     }
 }

--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -94,6 +94,9 @@ pub enum AgentError {
     #[error("turn control error: {message}")]
     TurnControl { kind: String, message: String },
 
+    #[error("invalid prompt content: {message}")]
+    InvalidPromptContent { message: String },
+
     // --- Serialization ---
     #[error("serialization error: {0}")]
     Serialization(String),
@@ -135,6 +138,12 @@ impl From<AgentError> for AcpError {
             return AcpError::new(-32602, message.clone()).data(serde_json::json!({
                 "category": "turn_control",
                 "kind": kind,
+                "message": message,
+            }));
+        }
+        if let AgentError::InvalidPromptContent { message } = &e {
+            return AcpError::new(-32602, message.clone()).data(serde_json::json!({
+                "category": "prompt_content",
                 "message": message,
             }));
         }
@@ -181,6 +190,14 @@ impl From<crate::agent::turn_control::TurnControlError> for AgentError {
     }
 }
 
+impl From<crate::model::PromptContentError> for AgentError {
+    fn from(error: crate::model::PromptContentError) -> Self {
+        Self::InvalidPromptContent {
+            message: error.to_string(),
+        }
+    }
+}
+
 impl From<anyhow::Error> for AgentError {
     fn from(e: anyhow::Error) -> Self {
         AgentError::Internal(e.to_string())
@@ -215,6 +232,15 @@ mod tests {
     use agent_client_protocol::ErrorCode;
 
     // ── From<AgentError> for AcpError ──────────────────────────────────────
+
+    #[test]
+    fn invalid_prompt_content_maps_to_invalid_params() {
+        let error: AcpError = AgentError::InvalidPromptContent {
+            message: "invalid base64 attachment data".to_string(),
+        }
+        .into();
+        assert_eq!(error.code, ErrorCode::InvalidParams);
+    }
 
     #[test]
     fn provider_required_maps_to_internal_error() {

--- a/crates/agent/src/event_sink.rs
+++ b/crates/agent/src/event_sink.rs
@@ -503,4 +503,67 @@ mod tests {
 
         assert!(env.is_ephemeral());
     }
+
+    #[tokio::test]
+    async fn structured_prompt_blocks_precede_awaited_summary_and_stay_out_of_journal() {
+        let sink = make_sink().await;
+        let mut rx = sink.fanout().subscribe();
+        let blocks = [
+            crate::acp::protocol::ContentBlock::Text(crate::acp::protocol::TextContent::new(
+                "before",
+            )),
+            crate::acp::protocol::ContentBlock::Image(crate::acp::protocol::ImageContent::new(
+                "AQID",
+                "image/png",
+            )),
+        ];
+
+        for block in blocks {
+            sink.emit_ephemeral(
+                "s1",
+                AgentEventKind::UserPromptBlock {
+                    message_id: "m1".into(),
+                    client_prompt_id: Some("client-1".into()),
+                    block,
+                },
+            );
+        }
+        sink.emit_durable(
+            "s1",
+            AgentEventKind::PromptReceived {
+                content: "before\n\n[Image: image/png]".into(),
+                message_id: Some("m1".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let first = rx.recv().await.unwrap();
+        let second = rx.recv().await.unwrap();
+        let third = rx.recv().await.unwrap();
+        assert!(matches!(
+            first.kind(),
+            AgentEventKind::UserPromptBlock { .. }
+        ));
+        assert!(matches!(
+            second.kind(),
+            AgentEventKind::UserPromptBlock { .. }
+        ));
+        assert!(matches!(
+            third.kind(),
+            AgentEventKind::PromptReceived { .. }
+        ));
+
+        let journal = sink
+            .journal()
+            .load_session_stream("s1", None, None)
+            .await
+            .unwrap();
+        assert_eq!(journal.len(), 1);
+        assert!(matches!(
+            journal[0].kind,
+            AgentEventKind::PromptReceived { .. }
+        ));
+        assert!(!serde_json::to_string(&journal).unwrap().contains("AQID"));
+    }
 }

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -1,4 +1,4 @@
-use crate::acp::protocol::StopReason;
+use crate::acp::protocol::{ContentBlock, StopReason};
 use querymt::Usage;
 use querymt::chat::FinishReason;
 use serde::{Deserialize, Serialize};
@@ -138,8 +138,17 @@ pub enum AgentEventKind {
     SessionCreated,
     PromptReceived {
         content: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         message_id: Option<String>,
+    },
+    /// Transient structured prompt block for live ACP delivery. Durable prompt
+    /// content remains in MessagePart::Prompt rather than the event journal.
+    UserPromptBlock {
+        message_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client_prompt_id: Option<String>,
+        #[typeshare(serialized_as = "any")]
+        block: ContentBlock,
     },
     UserMessageStored {
         content: String,
@@ -779,6 +788,7 @@ pub fn classify_durability(kind: &AgentEventKind) -> Durability {
         // ── Ephemeral: high-frequency streaming deltas ──────────────
         // Rationale: per-token chunks; the full content is captured by
         // AssistantMessageStored which IS durable.
+        AgentEventKind::UserPromptBlock { .. } => Durability::Ephemeral,
         AgentEventKind::AssistantContentDelta { .. } => Durability::Ephemeral,
         AgentEventKind::AssistantThinkingDelta { .. } => Durability::Ephemeral,
         AgentEventKind::RemoteStreamDisconnected { .. } => Durability::Ephemeral,
@@ -902,6 +912,25 @@ mod tests {
         // adjacently tagged: payload is under "data"
         assert_eq!(json["data"]["content"], "test prompt");
         assert_eq!(json["data"]["message_id"], "msg-1");
+    }
+
+    #[test]
+    fn user_prompt_block_client_id_is_optional_for_compatibility() {
+        let value = serde_json::json!({
+            "type": "user_prompt_block",
+            "data": {
+                "message_id": "msg-1",
+                "block": {"type": "text", "text": "hello"}
+            }
+        });
+        let kind: AgentEventKind = serde_json::from_value(value).unwrap();
+        assert!(matches!(
+            kind,
+            AgentEventKind::UserPromptBlock {
+                client_prompt_id: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/agent/src/hooks/runner.rs
+++ b/crates/agent/src/hooks/runner.rs
@@ -41,8 +41,17 @@ pub async fn run_command_hook(
     let mut child = command.spawn()?;
     if let Some(mut stdin) = child.stdin.take() {
         use tokio::io::AsyncWriteExt;
-        stdin.write_all(stdin_json.as_bytes()).await?;
-        stdin.shutdown().await?;
+        let result = async {
+            stdin.write_all(stdin_json.as_bytes()).await?;
+            stdin.shutdown().await
+        }
+        .await;
+        // Hooks may produce a valid response without consuming their input.
+        if let Err(err) = result
+            && err.kind() != std::io::ErrorKind::BrokenPipe
+        {
+            return Err(err.into());
+        }
     }
 
     let output = tokio::time::timeout(spec.timeout, child.wait_with_output())
@@ -54,4 +63,50 @@ pub async fn run_command_hook(
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
     })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn early_stdin_close_preserves_output_and_exit_status() {
+        // Exceed the pipe capacity so the write cannot finish before stdin closes.
+        let input = "x".repeat(4 * 1024 * 1024);
+        let cwd = tempfile::tempdir().unwrap();
+        for exit_code in [0, 2] {
+            let spec = CommandHookSpec {
+                command: format!(
+                    "exec 0<&-; printf '%s' 'response'; printf '%s' 'diagnostic' >&2; exit {exit_code}"
+                ),
+                timeout: Duration::from_secs(5),
+                env: BTreeMap::new(),
+            };
+            let output = tokio::time::timeout(
+                Duration::from_secs(10),
+                run_command_hook(&spec, cwd.path(), &input),
+            )
+            .await
+            .expect("hook should finish after closing stdin")
+            .unwrap();
+            assert_eq!(output.exit_code, Some(exit_code));
+            assert_eq!(output.stdout, "response");
+            assert_eq!(output.stderr, "diagnostic");
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_receives_complete_input_and_eof() {
+        let spec = CommandHookSpec {
+            command: "cat".into(),
+            timeout: Duration::from_secs(5),
+            env: BTreeMap::new(),
+        };
+        let cwd = tempfile::tempdir().unwrap();
+        let input = r#"{"session_id":"test"}"#;
+        let output = run_command_hook(&spec, cwd.path(), input).await.unwrap();
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, input);
+        assert!(output.stderr.is_empty());
+    }
 }

--- a/crates/agent/src/model.rs
+++ b/crates/agent/src/model.rs
@@ -7,6 +7,7 @@ use querymt::{
     chat::{ChatMessage, ChatRole, Content},
 };
 use serde::{Deserialize, Serialize};
+use std::io::{Cursor, Read};
 
 pub const MAX_IMAGES_PER_PROMPT: usize = 8;
 pub const MAX_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
@@ -53,7 +54,45 @@ pub fn prompt_contains_images(blocks: &[ContentBlock]) -> bool {
 }
 
 pub fn validate_prompt_blocks(blocks: &[ContentBlock]) -> Result<(), PromptContentError> {
-    convert_prompt_blocks(blocks, None).map(|_| ())
+    if blocks.is_empty() {
+        return Err(PromptContentError::EmptyPrompt);
+    }
+
+    let mut image_count = 0usize;
+    let mut total_attachment_bytes = 0usize;
+    for (index, block) in blocks.iter().enumerate() {
+        match block {
+            ContentBlock::Text(_) | ContentBlock::ResourceLink(_) | ContentBlock::Audio(_) => {}
+            ContentBlock::Image(image) => {
+                let bytes = validate_encoded_attachment(index, &image.data, false)?;
+                validate_attachment_size(index, bytes, &mut total_attachment_bytes)?;
+                validate_image(index, &image.mime_type, &mut image_count)?;
+            }
+            ContentBlock::Resource(resource) => match &resource.resource {
+                EmbeddedResourceResource::TextResourceContents(text) => {
+                    validate_attachment_size(index, text.text.len(), &mut total_attachment_bytes)?;
+                }
+                EmbeddedResourceResource::BlobResourceContents(blob) => {
+                    let mime_type = blob
+                        .mime_type
+                        .as_deref()
+                        .unwrap_or("application/octet-stream");
+                    let bytes = validate_encoded_attachment(
+                        index,
+                        &blob.blob,
+                        mime_type.starts_with("text/"),
+                    )?;
+                    validate_attachment_size(index, bytes, &mut total_attachment_bytes)?;
+                    if mime_type.starts_with("image/") {
+                        validate_image(index, mime_type, &mut image_count)?;
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 pub fn convert_prompt_blocks(
@@ -141,7 +180,54 @@ pub fn convert_prompt_blocks(
     Ok(converted)
 }
 
-fn decode_attachment(index: usize, encoded: &str) -> Result<Vec<u8>, PromptContentError> {
+fn validate_encoded_attachment(
+    index: usize,
+    encoded: &str,
+    require_utf8: bool,
+) -> Result<usize, PromptContentError> {
+    validate_encoded_attachment_bound(index, encoded)?;
+    let mut decoder = base64::read::DecoderReader::new(
+        Cursor::new(encoded.as_bytes()),
+        &base64::engine::general_purpose::STANDARD,
+    );
+    let mut buffer = [0u8; 8192];
+    let mut utf8_tail = Vec::new();
+    let mut decoded_bytes = 0usize;
+    loop {
+        let read =
+            decoder
+                .read(&mut buffer)
+                .map_err(|error| PromptContentError::InvalidBase64 {
+                    index,
+                    reason: error.to_string(),
+                })?;
+        if read == 0 {
+            break;
+        }
+        decoded_bytes = decoded_bytes.saturating_add(read);
+        if require_utf8 {
+            utf8_tail.extend_from_slice(&buffer[..read]);
+            match std::str::from_utf8(&utf8_tail) {
+                Ok(_) => utf8_tail.clear(),
+                Err(error) if error.error_len().is_some() => {
+                    return Err(PromptContentError::InvalidTextResource { index });
+                }
+                Err(error) => {
+                    utf8_tail.drain(..error.valid_up_to());
+                }
+            }
+        }
+    }
+    if require_utf8 && !utf8_tail.is_empty() {
+        return Err(PromptContentError::InvalidTextResource { index });
+    }
+    Ok(decoded_bytes)
+}
+
+fn validate_encoded_attachment_bound(
+    index: usize,
+    encoded: &str,
+) -> Result<(), PromptContentError> {
     // Standard base64 has no ignored whitespace, so this bounds allocation before decoding.
     let max_encoded_bytes = MAX_ATTACHMENT_BYTES.div_ceil(3).saturating_mul(4);
     if encoded.len() > max_encoded_bytes {
@@ -150,7 +236,11 @@ fn decode_attachment(index: usize, encoded: &str) -> Result<Vec<u8>, PromptConte
             max_bytes: MAX_ATTACHMENT_BYTES,
         });
     }
+    Ok(())
+}
 
+fn decode_attachment(index: usize, encoded: &str) -> Result<Vec<u8>, PromptContentError> {
+    validate_encoded_attachment_bound(index, encoded)?;
     base64::engine::general_purpose::STANDARD
         .decode(encoded)
         .map_err(|error| PromptContentError::InvalidBase64 {
@@ -640,6 +730,13 @@ mod tests {
         ))]);
         assert!(matches!(
             invalid_base64.to_chat_message(),
+            Err(PromptContentError::InvalidBase64 { index: 0, .. })
+        ));
+        assert!(matches!(
+            super::validate_prompt_blocks(&[ContentBlock::Image(ImageContent::new(
+                "%%%",
+                "image/png",
+            ))]),
             Err(PromptContentError::InvalidBase64 { index: 0, .. })
         ));
 

--- a/crates/agent/src/model.rs
+++ b/crates/agent/src/model.rs
@@ -1,11 +1,216 @@
-use crate::acp::protocol::ContentBlock;
-use crate::agent::utils::render_prompt_for_llm;
+use crate::acp::protocol::{ContentBlock, EmbeddedResourceResource};
+use crate::agent::utils::truncate_to_bytes;
 use crate::index::merkle::DiffPaths;
+use base64::Engine as _;
 use querymt::{
     ToolCall,
     chat::{ChatMessage, ChatRole, Content},
 };
 use serde::{Deserialize, Serialize};
+
+pub const MAX_IMAGES_PER_PROMPT: usize = 8;
+pub const MAX_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
+pub const MAX_TOTAL_ATTACHMENT_BYTES: usize = 20 * 1024 * 1024;
+
+const SUPPORTED_IMAGE_MIME_TYPES: &[&str] = &["image/png", "image/jpeg", "image/webp", "image/gif"];
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum PromptContentError {
+    #[error("prompt must contain at least one content block")]
+    EmptyPrompt,
+    #[error("unsupported image MIME type at block {index}: {mime_type}")]
+    UnsupportedImageMime { index: usize, mime_type: String },
+    #[error("invalid base64 attachment data at block {index}: {reason}")]
+    InvalidBase64 { index: usize, reason: String },
+    #[error("attachment at block {index} is {bytes} bytes; maximum is {max_bytes} bytes")]
+    AttachmentTooLarge {
+        index: usize,
+        bytes: usize,
+        max_bytes: usize,
+    },
+    #[error("attachment data at block {index} exceeds the maximum of {max_bytes} decoded bytes")]
+    EncodedAttachmentTooLarge { index: usize, max_bytes: usize },
+    #[error("prompt contains {count} images; maximum is {max_count}")]
+    TooManyImages { count: usize, max_count: usize },
+    #[error("prompt attachment data totals {bytes} bytes; maximum is {max_bytes} bytes")]
+    AttachmentsTooLarge { bytes: usize, max_bytes: usize },
+    #[error("text attachment at block {index} is not valid UTF-8")]
+    InvalidTextResource { index: usize },
+}
+
+pub fn prompt_contains_images(blocks: &[ContentBlock]) -> bool {
+    blocks.iter().any(|block| match block {
+        ContentBlock::Image(_) => true,
+        ContentBlock::Resource(resource) => match &resource.resource {
+            EmbeddedResourceResource::BlobResourceContents(blob) => blob
+                .mime_type
+                .as_deref()
+                .is_some_and(|mime| mime.starts_with("image/")),
+            _ => false,
+        },
+        _ => false,
+    })
+}
+
+pub fn validate_prompt_blocks(blocks: &[ContentBlock]) -> Result<(), PromptContentError> {
+    convert_prompt_blocks(blocks, None).map(|_| ())
+}
+
+pub fn convert_prompt_blocks(
+    blocks: &[ContentBlock],
+    max_text_bytes: Option<usize>,
+) -> Result<Vec<Content>, PromptContentError> {
+    if blocks.is_empty() {
+        return Err(PromptContentError::EmptyPrompt);
+    }
+
+    let mut converted = Vec::with_capacity(blocks.len());
+    let mut remaining_text_bytes = max_text_bytes;
+    let mut image_count = 0usize;
+    let mut total_attachment_bytes = 0usize;
+
+    for (index, block) in blocks.iter().enumerate() {
+        match block {
+            ContentBlock::Text(text) => converted.push(Content::text(limit_text(
+                &text.text,
+                &mut remaining_text_bytes,
+            ))),
+            ContentBlock::Image(image) => {
+                let data = decode_attachment(index, &image.data)?;
+                validate_attachment_size(index, data.len(), &mut total_attachment_bytes)?;
+                validate_image(index, &image.mime_type, &mut image_count)?;
+                converted.push(Content::image(image.mime_type.clone(), data));
+            }
+            ContentBlock::Resource(resource) => match &resource.resource {
+                EmbeddedResourceResource::TextResourceContents(text) => {
+                    validate_attachment_size(index, text.text.len(), &mut total_attachment_bytes)?;
+                    let contextual = format!("[Embedded Resource: {}]\n{}", text.uri, text.text);
+                    converted.push(Content::text(limit_text(
+                        &contextual,
+                        &mut remaining_text_bytes,
+                    )));
+                }
+                EmbeddedResourceResource::BlobResourceContents(blob) => {
+                    let data = decode_attachment(index, &blob.blob)?;
+                    validate_attachment_size(index, data.len(), &mut total_attachment_bytes)?;
+                    let mime_type = blob
+                        .mime_type
+                        .as_deref()
+                        .unwrap_or("application/octet-stream");
+                    if mime_type.starts_with("image/") {
+                        validate_image(index, mime_type, &mut image_count)?;
+                        converted.push(Content::image(mime_type.to_string(), data));
+                    } else if mime_type == "application/pdf" {
+                        converted.push(Content::pdf(data));
+                    } else if mime_type.starts_with("text/") {
+                        let text = String::from_utf8(data)
+                            .map_err(|_| PromptContentError::InvalidTextResource { index })?;
+                        let contextual = format!("[Embedded Resource: {}]\n{}", blob.uri, text);
+                        converted.push(Content::text(limit_text(
+                            &contextual,
+                            &mut remaining_text_bytes,
+                        )));
+                    } else {
+                        let marker = format!(
+                            "[Attached resource: {} ({mime_type}, {} bytes)]",
+                            blob.uri,
+                            data.len()
+                        );
+                        converted.push(Content::text(limit_text(
+                            &marker,
+                            &mut remaining_text_bytes,
+                        )));
+                    }
+                }
+                _ => converted.push(Content::text("[Unsupported embedded resource]")),
+            },
+            ContentBlock::ResourceLink(link) => {
+                converted.push(Content::resource_link(link.uri.clone()));
+            }
+            ContentBlock::Audio(audio) => {
+                let marker = format!("[Audio attachment: {}]", audio.mime_type);
+                converted.push(Content::text(limit_text(
+                    &marker,
+                    &mut remaining_text_bytes,
+                )));
+            }
+            _ => converted.push(Content::text("[Unsupported content block]")),
+        }
+    }
+
+    Ok(converted)
+}
+
+fn decode_attachment(index: usize, encoded: &str) -> Result<Vec<u8>, PromptContentError> {
+    // Standard base64 has no ignored whitespace, so this bounds allocation before decoding.
+    let max_encoded_bytes = MAX_ATTACHMENT_BYTES.div_ceil(3).saturating_mul(4);
+    if encoded.len() > max_encoded_bytes {
+        return Err(PromptContentError::EncodedAttachmentTooLarge {
+            index,
+            max_bytes: MAX_ATTACHMENT_BYTES,
+        });
+    }
+
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| PromptContentError::InvalidBase64 {
+            index,
+            reason: error.to_string(),
+        })
+}
+
+fn validate_attachment_size(
+    index: usize,
+    bytes: usize,
+    total_attachment_bytes: &mut usize,
+) -> Result<(), PromptContentError> {
+    if bytes > MAX_ATTACHMENT_BYTES {
+        return Err(PromptContentError::AttachmentTooLarge {
+            index,
+            bytes,
+            max_bytes: MAX_ATTACHMENT_BYTES,
+        });
+    }
+
+    *total_attachment_bytes = total_attachment_bytes.saturating_add(bytes);
+    if *total_attachment_bytes > MAX_TOTAL_ATTACHMENT_BYTES {
+        return Err(PromptContentError::AttachmentsTooLarge {
+            bytes: *total_attachment_bytes,
+            max_bytes: MAX_TOTAL_ATTACHMENT_BYTES,
+        });
+    }
+    Ok(())
+}
+
+fn validate_image(
+    index: usize,
+    mime_type: &str,
+    image_count: &mut usize,
+) -> Result<(), PromptContentError> {
+    if !SUPPORTED_IMAGE_MIME_TYPES.contains(&mime_type) {
+        return Err(PromptContentError::UnsupportedImageMime {
+            index,
+            mime_type: mime_type.to_string(),
+        });
+    }
+    *image_count += 1;
+    if *image_count > MAX_IMAGES_PER_PROMPT {
+        return Err(PromptContentError::TooManyImages {
+            count: *image_count,
+            max_count: MAX_IMAGES_PER_PROMPT,
+        });
+    }
+    Ok(())
+}
+
+fn limit_text(text: &str, remaining: &mut Option<usize>) -> String {
+    let Some(remaining_bytes) = remaining.as_mut() else {
+        return text.to_string();
+    };
+    let limited = truncate_to_bytes(text, *remaining_bytes);
+    *remaining_bytes = remaining_bytes.saturating_sub(limited.len());
+    limited
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "data")]
@@ -155,14 +360,14 @@ impl AgentMessage {
         }
     }
 
-    pub fn to_chat_message(&self) -> ChatMessage {
+    pub fn to_chat_message(&self) -> Result<ChatMessage, PromptContentError> {
         self.to_chat_message_with_target(None, None, None)
     }
 
     pub fn to_chat_message_with_max_prompt_bytes(
         &self,
         max_prompt_bytes: Option<usize>,
-    ) -> ChatMessage {
+    ) -> Result<ChatMessage, PromptContentError> {
         self.to_chat_message_with_target(None, None, max_prompt_bytes)
     }
 
@@ -171,7 +376,7 @@ impl AgentMessage {
         target_provider: Option<&str>,
         target_model: Option<&str>,
         max_prompt_bytes: Option<usize>,
-    ) -> ChatMessage {
+    ) -> Result<ChatMessage, PromptContentError> {
         let mut blocks = Vec::new();
 
         let preserve_provider_metadata = match (
@@ -196,10 +401,7 @@ impl AgentMessage {
                     blocks: prompt_blocks,
                     ..
                 } => {
-                    blocks.push(Content::text(render_prompt_for_llm(
-                        prompt_blocks,
-                        max_prompt_bytes,
-                    )));
+                    blocks.extend(convert_prompt_blocks(prompt_blocks, max_prompt_bytes)?);
                 }
                 MessagePart::Reasoning {
                     content, signature, ..
@@ -272,27 +474,65 @@ impl AgentMessage {
             }
         }
 
-        // For User messages with tool results, ensure all ToolResult blocks
-        // appear before any Text blocks.  The Anthropic API fails to match
-        // tool_result blocks to their tool_use counterparts when non-tool_result
-        // content blocks (e.g. Snapshot-derived Text) are interleaved between them.
-        if self.role == ChatRole::User && blocks.iter().any(|b| b.is_tool_result()) {
-            blocks.sort_by_key(|b| if b.is_tool_result() { 0 } else { 1 });
+        if self.role == ChatRole::User && blocks.iter().any(|block| block.is_tool_result()) {
+            blocks.sort_by_key(|block| if block.is_tool_result() { 0 } else { 1 });
         }
 
-        ChatMessage {
+        Ok(ChatMessage {
             role: self.role.clone(),
             content: blocks,
             cache: None,
-        }
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentMessage, MessagePart};
-    use crate::acp::protocol::{ContentBlock, TextContent};
+    use super::{AgentMessage, MessagePart, PromptContentError};
+    use crate::acp::protocol::{
+        BlobResourceContents, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
+        ImageContent, TextContent, TextResourceContents,
+    };
+    use base64::Engine as _;
     use querymt::chat::{ChatRole, Content};
+
+    fn prompt_message(blocks: Vec<ContentBlock>) -> AgentMessage {
+        AgentMessage {
+            id: "m1".to_string(),
+            session_id: "s1".to_string(),
+            role: ChatRole::User,
+            parts: vec![MessagePart::Prompt { blocks }],
+            created_at: 0,
+            parent_message_id: None,
+            source_provider: None,
+            source_model: None,
+        }
+    }
+
+    fn image(data: &[u8], mime_type: &str) -> ContentBlock {
+        ContentBlock::Image(ImageContent::new(
+            base64::engine::general_purpose::STANDARD.encode(data),
+            mime_type,
+        ))
+    }
+
+    fn blob(data: &[u8], mime_type: &str, uri: &str) -> ContentBlock {
+        ContentBlock::Resource(EmbeddedResource::new(
+            EmbeddedResourceResource::BlobResourceContents(
+                BlobResourceContents::new(
+                    base64::engine::general_purpose::STANDARD.encode(data),
+                    uri,
+                )
+                .mime_type(mime_type.to_string()),
+            ),
+        ))
+    }
+
+    fn text_resource(text: impl Into<String>, uri: &str) -> ContentBlock {
+        ContentBlock::Resource(EmbeddedResource::new(
+            EmbeddedResourceResource::TextResourceContents(TextResourceContents::new(text, uri)),
+        ))
+    }
 
     #[test]
     fn to_chat_message_renders_prompt_blocks() {
@@ -309,8 +549,230 @@ mod tests {
             source_model: None,
         };
 
-        let chat = msg.to_chat_message();
+        let chat = msg.to_chat_message().unwrap();
         assert_eq!(chat.text(), "display");
+    }
+
+    #[test]
+    fn to_chat_message_preserves_mixed_native_images_and_text() {
+        let chat = prompt_message(vec![
+            ContentBlock::Text(TextContent::new("before")),
+            image(&[1, 2, 3], "image/png"),
+            ContentBlock::Text(TextContent::new("after")),
+            image(&[4, 5], "image/jpeg"),
+        ])
+        .to_chat_message()
+        .unwrap();
+
+        assert_eq!(chat.content.len(), 4);
+        assert_eq!(chat.content[0].as_text(), Some("before"));
+        assert!(matches!(
+            &chat.content[1],
+            Content::Image { mime_type, data }
+                if mime_type == "image/png" && data == &[1, 2, 3]
+        ));
+        assert_eq!(chat.content[2].as_text(), Some("after"));
+        assert!(matches!(
+            &chat.content[3],
+            Content::Image { mime_type, data }
+                if mime_type == "image/jpeg" && data == &[4, 5]
+        ));
+    }
+
+    #[test]
+    fn to_chat_message_promotes_legacy_image_resource_and_preserves_other_resources() {
+        let text_resource = ContentBlock::Resource(EmbeddedResource::new(
+            EmbeddedResourceResource::TextResourceContents(
+                TextResourceContents::new("notes", "attachment:///notes.txt")
+                    .mime_type("text/plain".to_string()),
+            ),
+        ));
+        let chat = prompt_message(vec![
+            blob(&[9, 8, 7], "image/webp", "attachment:///image.webp"),
+            text_resource,
+            blob(&[0x25, 0x50], "application/pdf", "attachment:///doc.pdf"),
+            blob(
+                &[6, 6],
+                "application/octet-stream",
+                "attachment:///data.bin",
+            ),
+        ])
+        .to_chat_message()
+        .unwrap();
+
+        assert!(matches!(
+            &chat.content[0],
+            Content::Image { mime_type, data }
+                if mime_type == "image/webp" && data == &[9, 8, 7]
+        ));
+        assert_eq!(
+            chat.content[1].as_text(),
+            Some("[Embedded Resource: attachment:///notes.txt]\nnotes")
+        );
+        assert!(matches!(&chat.content[2], Content::Pdf { data } if data == &[0x25, 0x50]));
+        assert_eq!(
+            chat.content[3].as_text(),
+            Some("[Attached resource: attachment:///data.bin (application/octet-stream, 2 bytes)]")
+        );
+    }
+
+    #[test]
+    fn steering_uses_the_same_image_conversion() {
+        let mut message = prompt_message(Vec::new());
+        message.parts = vec![MessagePart::Steering {
+            run_id: "run-1".to_string(),
+            client_input_id: None,
+            blocks: vec![image(&[3, 1, 4], "image/gif")],
+        }];
+        let chat = message.to_chat_message().unwrap();
+        assert!(matches!(
+            &chat.content[0],
+            Content::Image { mime_type, data }
+                if mime_type == "image/gif" && data == &[3, 1, 4]
+        ));
+    }
+
+    #[test]
+    fn invalid_base64_and_mime_are_explicit_errors() {
+        let invalid_base64 = prompt_message(vec![ContentBlock::Image(ImageContent::new(
+            "%%%",
+            "image/png",
+        ))]);
+        assert!(matches!(
+            invalid_base64.to_chat_message(),
+            Err(PromptContentError::InvalidBase64 { index: 0, .. })
+        ));
+
+        let invalid_mime = prompt_message(vec![image(&[1], "image/svg+xml")]);
+        assert_eq!(
+            invalid_mime.to_chat_message().unwrap_err(),
+            PromptContentError::UnsupportedImageMime {
+                index: 0,
+                mime_type: "image/svg+xml".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn image_count_limit_is_enforced() {
+        let message = prompt_message(
+            (0..=super::MAX_IMAGES_PER_PROMPT)
+                .map(|_| image(&[1], "image/png"))
+                .collect(),
+        );
+        assert!(matches!(
+            message.to_chat_message(),
+            Err(PromptContentError::TooManyImages { .. })
+        ));
+    }
+
+    #[test]
+    fn oversized_pdf_and_other_resources_are_rejected() {
+        let oversized = vec![0; super::MAX_ATTACHMENT_BYTES + 1];
+        for mime_type in ["application/pdf", "application/octet-stream"] {
+            let message = prompt_message(vec![blob(
+                &oversized,
+                mime_type,
+                "attachment:///oversized.bin",
+            )]);
+            assert_eq!(
+                message.to_chat_message().unwrap_err(),
+                PromptContentError::AttachmentTooLarge {
+                    index: 0,
+                    bytes: super::MAX_ATTACHMENT_BYTES + 1,
+                    max_bytes: super::MAX_ATTACHMENT_BYTES,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_text_resource_is_rejected() {
+        let message = prompt_message(vec![text_resource(
+            "x".repeat(super::MAX_ATTACHMENT_BYTES + 1),
+            "attachment:///oversized.txt",
+        )]);
+
+        assert_eq!(
+            message.to_chat_message().unwrap_err(),
+            PromptContentError::AttachmentTooLarge {
+                index: 0,
+                bytes: super::MAX_ATTACHMENT_BYTES + 1,
+                max_bytes: super::MAX_ATTACHMENT_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn mixed_attachment_aggregate_limit_counts_text_resources_and_blobs() {
+        let message = prompt_message(vec![
+            blob(
+                &vec![1; super::MAX_ATTACHMENT_BYTES],
+                "application/pdf",
+                "attachment:///document.pdf",
+            ),
+            text_resource(
+                "x".repeat(super::MAX_ATTACHMENT_BYTES),
+                "attachment:///notes.txt",
+            ),
+            blob(
+                &[2],
+                "application/octet-stream",
+                "attachment:///payload.bin",
+            ),
+        ]);
+
+        assert_eq!(
+            message.to_chat_message().unwrap_err(),
+            PromptContentError::AttachmentsTooLarge {
+                bytes: super::MAX_TOTAL_ATTACHMENT_BYTES + 1,
+                max_bytes: super::MAX_TOTAL_ATTACHMENT_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn mixed_attachment_aggregate_limit_counts_images_and_all_blobs() {
+        let message = prompt_message(vec![
+            image(&vec![1; super::MAX_ATTACHMENT_BYTES], "image/png"),
+            blob(
+                &vec![2; super::MAX_ATTACHMENT_BYTES],
+                "application/pdf",
+                "attachment:///document.pdf",
+            ),
+            blob(
+                &[3],
+                "application/octet-stream",
+                "attachment:///payload.bin",
+            ),
+        ]);
+
+        assert_eq!(
+            message.to_chat_message().unwrap_err(),
+            PromptContentError::AttachmentsTooLarge {
+                bytes: super::MAX_TOTAL_ATTACHMENT_BYTES + 1,
+                max_bytes: super::MAX_TOTAL_ATTACHMENT_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn empty_prompt_is_rejected() {
+        assert_eq!(
+            prompt_message(Vec::new()).to_chat_message().unwrap_err(),
+            PromptContentError::EmptyPrompt
+        );
+    }
+
+    #[test]
+    fn text_limit_does_not_truncate_image_bytes() {
+        let chat = prompt_message(vec![
+            ContentBlock::Text(TextContent::new("long text")),
+            image(&[1, 2, 3, 4], "image/png"),
+        ])
+        .to_chat_message_with_max_prompt_bytes(Some(4))
+        .unwrap();
+        assert!(matches!(&chat.content[1], Content::Image { data, .. } if data == &[1, 2, 3, 4]));
     }
 
     #[test]
@@ -329,7 +791,7 @@ mod tests {
             source_model: None,
         };
 
-        let chat = msg.to_chat_message();
+        let chat = msg.to_chat_message().unwrap();
         assert_eq!(chat.text(), "Summary of previous conversation");
         assert_eq!(chat.role, ChatRole::Assistant);
     }
@@ -349,7 +811,7 @@ mod tests {
             source_model: None,
         };
 
-        let chat = msg.to_chat_message();
+        let chat = msg.to_chat_message().unwrap();
         assert_eq!(chat.text(), "Summarize our conversation so far.");
         assert_eq!(chat.role, ChatRole::User);
     }
@@ -382,8 +844,8 @@ mod tests {
             source_model: None,
         };
 
-        let req_chat = req.to_chat_message();
-        let sum_chat = sum.to_chat_message();
+        let req_chat = req.to_chat_message().unwrap();
+        let sum_chat = sum.to_chat_message().unwrap();
 
         // User message followed by assistant message — valid API exchange
         assert_eq!(req_chat.role, ChatRole::User);
@@ -414,7 +876,7 @@ mod tests {
             source_model: None,
         };
 
-        let chat = msg.to_chat_message();
+        let chat = msg.to_chat_message().unwrap();
         assert!(chat.has_tool_result());
         // The tool result block should contain the text
         let tr = chat.content.iter().find(|b| b.is_tool_result()).unwrap();
@@ -454,7 +916,7 @@ mod tests {
             source_model: None,
         };
 
-        let chat = msg.to_chat_message();
+        let chat = msg.to_chat_message().unwrap();
         let tr = chat.content.iter().find(|b| b.is_tool_result()).unwrap();
         match tr {
             Content::ToolResult { content, .. } => {
@@ -484,8 +946,9 @@ mod tests {
             source_model: Some("claude-sonnet-4-5".to_string()),
         };
 
-        let chat =
-            msg.to_chat_message_with_target(Some("anthropic"), Some("claude-sonnet-4-5"), None);
+        let chat = msg
+            .to_chat_message_with_target(Some("anthropic"), Some("claude-sonnet-4-5"), None)
+            .unwrap();
 
         match &chat.content[0] {
             Content::Thinking {
@@ -513,8 +976,9 @@ mod tests {
             source_model: Some("claude-sonnet-4-5".to_string()),
         };
 
-        let chat =
-            msg.to_chat_message_with_target(Some("anthropic"), Some("claude-opus-4-1"), None);
+        let chat = msg
+            .to_chat_message_with_target(Some("anthropic"), Some("claude-opus-4-1"), None)
+            .unwrap();
 
         match &chat.content[0] {
             Content::Thinking {
@@ -581,7 +1045,7 @@ mod tests {
             source_model: None,
         };
 
-        let chat = msg.to_chat_message();
+        let chat = msg.to_chat_message().unwrap();
 
         // Must have 2 ToolResult + at least 1 Text (from snapshots).
         let tool_result_count = chat.content.iter().filter(|b| b.is_tool_result()).count();

--- a/crates/agent/src/session/compaction.rs
+++ b/crates/agent/src/session/compaction.rs
@@ -917,6 +917,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_process_invalid_attachment_does_not_call_provider() {
+        let service = SessionCompaction::new();
+        let message = AgentMessage {
+            id: "invalid-image".into(),
+            session_id: "s1".into(),
+            role: ChatRole::User,
+            parts: vec![MessagePart::Prompt {
+                blocks: vec![crate::acp::protocol::ContentBlock::Image(
+                    crate::acp::protocol::ImageContent::new("%%%", "image/png"),
+                )],
+            }],
+            created_at: 0,
+            parent_message_id: None,
+            source_provider: None,
+            source_model: None,
+        };
+        let provider = Arc::new(MockCompactionProvider::with_summary("must not be called"));
+
+        let result = service
+            .process(
+                &[message],
+                provider.clone(),
+                "model",
+                &RetryConfig::default(),
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(provider.call_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_process_success_simple() {
         let fixture = CompactionFixture::new();
         let messages = MessageFixture::simple_conversation("s1");

--- a/crates/agent/src/session/compaction.rs
+++ b/crates/agent/src/session/compaction.rs
@@ -103,7 +103,7 @@ impl SessionCompaction {
         let original_token_count = self.estimate_messages_tokens(messages, max_prompt_bytes);
 
         // Build the compaction request
-        let chat_messages = self.build_compaction_messages(messages, max_prompt_bytes);
+        let chat_messages = self.build_compaction_messages(messages, max_prompt_bytes)?;
 
         // Call LLM with retry logic
         let summary = self
@@ -124,11 +124,11 @@ impl SessionCompaction {
         &self,
         messages: &[AgentMessage],
         max_prompt_bytes: Option<usize>,
-    ) -> Vec<querymt::chat::ChatMessage> {
+    ) -> Result<Vec<querymt::chat::ChatMessage>> {
         let mut chat_messages: Vec<querymt::chat::ChatMessage> = messages
             .iter()
-            .map(|m| m.to_chat_message_with_max_prompt_bytes(max_prompt_bytes))
-            .collect();
+            .map(|message| message.to_chat_message_with_max_prompt_bytes(max_prompt_bytes))
+            .collect::<std::result::Result<_, _>>()?;
 
         // Add the compaction prompt as a user message
         chat_messages.push(querymt::chat::ChatMessage {
@@ -137,7 +137,7 @@ impl SessionCompaction {
             cache: None,
         });
 
-        chat_messages
+        Ok(chat_messages)
     }
 
     /// Call LLM with exponential backoff retry.
@@ -838,7 +838,10 @@ mod tests {
         let fixture = CompactionFixture::new();
         let messages = MessageFixture::simple_conversation("s1");
 
-        let chat_messages = fixture.service.build_compaction_messages(&messages, None);
+        let chat_messages = fixture
+            .service
+            .build_compaction_messages(&messages, None)
+            .unwrap();
 
         // Should have all original messages + compaction prompt
         assert_eq!(
@@ -863,13 +866,54 @@ mod tests {
         let fixture = CompactionFixture::new();
         let messages = MessageFixture::simple_conversation("s1");
 
-        let chat_messages = fixture.service.build_compaction_messages(&messages, None);
+        let chat_messages = fixture
+            .service
+            .build_compaction_messages(&messages, None)
+            .unwrap();
 
         // Check that roles are preserved (excluding the appended prompt)
         assert_eq!(chat_messages[0].role, ChatRole::User);
         assert_eq!(chat_messages[1].role, ChatRole::Assistant);
         assert_eq!(chat_messages[2].role, ChatRole::User);
         assert_eq!(chat_messages[3].role, ChatRole::Assistant);
+    }
+
+    #[test]
+    fn test_build_compaction_messages_preserves_pdf_content() {
+        use base64::Engine as _;
+
+        let fixture = CompactionFixture::new();
+        let message = AgentMessage {
+            id: "pdf-message".into(),
+            session_id: "s1".into(),
+            role: ChatRole::User,
+            parts: vec![MessagePart::Prompt {
+                blocks: vec![crate::acp::protocol::ContentBlock::Resource(
+                    crate::acp::protocol::EmbeddedResource::new(
+                        crate::acp::protocol::EmbeddedResourceResource::BlobResourceContents(
+                            crate::acp::protocol::BlobResourceContents::new(
+                                base64::engine::general_purpose::STANDARD.encode(b"%PDF"),
+                                "attachment:///document.pdf",
+                            )
+                            .mime_type("application/pdf".to_string()),
+                        ),
+                    ),
+                )],
+            }],
+            created_at: 0,
+            parent_message_id: None,
+            source_provider: None,
+            source_model: None,
+        };
+
+        let chat_messages = fixture
+            .service
+            .build_compaction_messages(&[message], None)
+            .unwrap();
+        assert!(matches!(
+            &chat_messages[0].content[0],
+            querymt::chat::Content::Pdf { data } if data == b"%PDF"
+        ));
     }
 
     #[tokio::test]
@@ -1063,7 +1107,10 @@ mod tests {
         let fixture = CompactionFixture::new();
         let messages = MessageFixture::simple_conversation("s1");
 
-        let chat_messages = fixture.service.build_compaction_messages(&messages, None);
+        let chat_messages = fixture
+            .service
+            .build_compaction_messages(&messages, None)
+            .unwrap();
 
         // Verify first message is the user message from conversation
         if let MessagePart::Text { content } = &messages[0].parts[0] {
@@ -1074,7 +1121,7 @@ mod tests {
     #[test]
     fn test_compaction_message_to_chat_has_no_trailing_whitespace() {
         let (_, sum) = SessionCompaction::create_compaction_messages("s1", "Test summary", 5000);
-        let chat = sum.to_chat_message();
+        let chat = sum.to_chat_message().unwrap();
 
         let text = chat.text();
         assert!(

--- a/crates/agent/src/session/load_snapshot.rs
+++ b/crates/agent/src/session/load_snapshot.rs
@@ -75,7 +75,7 @@ pub fn cursor_from_events(events: &[AgentEvent]) -> StreamCursor {
     cursor
 }
 
-pub fn user_prompt_records(messages: &[crate::model::AgentMessage]) -> Vec<UserPromptRecord> {
+fn user_prompt_records(messages: &[crate::model::AgentMessage]) -> Vec<UserPromptRecord> {
     messages
         .iter()
         .enumerate()

--- a/crates/agent/src/session/load_snapshot.rs
+++ b/crates/agent/src/session/load_snapshot.rs
@@ -2,7 +2,7 @@ use crate::acp::protocol::ContentBlock;
 use crate::agent::LocalAgentHandle;
 use crate::events::AgentEvent;
 use crate::model::MessagePart;
-use crate::session::error::SessionResult;
+use crate::session::error::{SessionError, SessionResult};
 use crate::session::projection::{AuditView, ViewStore};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -144,12 +144,26 @@ pub async fn load_session_snapshot(
     let cursor = cursor_from_events(&audit.events);
     let delegation_updates =
         crate::control::delegation_notifications::delegation_updates_from_events(&audit.events);
-    let messages = agent
+    // Remote attached sessions live on their peer and have no local history
+    // rows, so `get_history` reports `SessionNotFound`. Treat that as an empty
+    // history (no user prompt records) instead of failing the whole snapshot.
+    let messages = match agent
         .config
         .provider
         .history_store()
         .get_history(session_id)
-        .await?;
+        .await
+    {
+        Ok(messages) => messages,
+        Err(SessionError::SessionNotFound(_)) if is_remote_attached => {
+            tracing::debug!(
+                session_id,
+                "remote session missing local history rows; using empty history for snapshot"
+            );
+            Vec::new()
+        }
+        Err(e) => return Err(e),
+    };
     let user_prompts = Some(user_prompt_records(&messages));
     Ok(SessionLoadSnapshot {
         audit,

--- a/crates/agent/src/session/load_snapshot.rs
+++ b/crates/agent/src/session/load_snapshot.rs
@@ -1,5 +1,7 @@
+use crate::acp::protocol::ContentBlock;
 use crate::agent::LocalAgentHandle;
 use crate::events::AgentEvent;
+use crate::model::MessagePart;
 use crate::session::error::SessionResult;
 use crate::session::projection::{AuditView, ViewStore};
 use serde::{Deserialize, Serialize};
@@ -18,6 +20,20 @@ pub struct StreamCursor {
 }
 
 #[typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UserPromptRecord {
+    pub message_id: String,
+    /// Zero-based position in persisted message history; this is not an event sequence.
+    #[typeshare(serialized_as = "number")]
+    pub message_order: u64,
+    #[typeshare(serialized_as = "number")]
+    pub timestamp: i64,
+    #[typeshare(serialized_as = "any")]
+    pub blocks: Vec<ContentBlock>,
+}
+
+#[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionLoadSnapshot {
     pub audit: AuditView,
@@ -25,6 +41,12 @@ pub struct SessionLoadSnapshot {
     #[serde(rename = "delegationUpdates")]
     pub delegation_updates:
         Vec<crate::control::delegation_notifications::DelegationUpdateNotification>,
+    #[serde(
+        default,
+        rename = "userPrompts",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub user_prompts: Option<Vec<UserPromptRecord>>,
 }
 
 pub fn cursor_from_events(events: &[AgentEvent]) -> StreamCursor {
@@ -51,6 +73,25 @@ pub fn cursor_from_events(events: &[AgentEvent]) -> StreamCursor {
     }
 
     cursor
+}
+
+pub fn user_prompt_records(messages: &[crate::model::AgentMessage]) -> Vec<UserPromptRecord> {
+    messages
+        .iter()
+        .enumerate()
+        .filter_map(|(message_order, message)| {
+            let blocks = message.parts.iter().find_map(|part| match part {
+                MessagePart::Prompt { blocks } => Some(blocks.clone()),
+                _ => None,
+            })?;
+            Some(UserPromptRecord {
+                message_id: message.id.clone(),
+                message_order: message_order as u64,
+                timestamp: message.created_at,
+                blocks,
+            })
+        })
+        .collect()
 }
 
 pub async fn load_session_snapshot(
@@ -103,9 +144,138 @@ pub async fn load_session_snapshot(
     let cursor = cursor_from_events(&audit.events);
     let delegation_updates =
         crate::control::delegation_notifications::delegation_updates_from_events(&audit.events);
+    let messages = agent
+        .config
+        .provider
+        .history_store()
+        .get_history(session_id)
+        .await?;
+    let user_prompts = Some(user_prompt_records(&messages));
     Ok(SessionLoadSnapshot {
         audit,
         cursor,
         delegation_updates,
+        user_prompts,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SessionLoadSnapshot, load_session_snapshot, user_prompt_records};
+    use crate::acp::protocol::{ContentBlock, ImageContent, TextContent};
+    use crate::agent::agent_config_builder::AgentConfigBuilder;
+    use crate::model::{AgentMessage, MessagePart};
+    use crate::session::backend::StorageBackend;
+    use crate::session::error::SessionError;
+    use crate::session::provider::SessionProvider;
+    use crate::session::store::SessionStore;
+    use crate::test_utils::{MockSessionStore, empty_plugin_registry};
+    use querymt::{LLMParams, chat::ChatRole};
+    use std::sync::Arc;
+
+    #[test]
+    fn user_prompt_projection_preserves_message_identity_order_and_blocks() {
+        let messages = vec![
+            AgentMessage {
+                id: "assistant".to_string(),
+                session_id: "s1".to_string(),
+                role: ChatRole::Assistant,
+                parts: vec![MessagePart::Text {
+                    content: "response".to_string(),
+                }],
+                created_at: 10,
+                parent_message_id: None,
+                source_provider: None,
+                source_model: None,
+            },
+            AgentMessage {
+                id: "user-1".to_string(),
+                session_id: "s1".to_string(),
+                role: ChatRole::User,
+                parts: vec![MessagePart::Prompt {
+                    blocks: vec![
+                        ContentBlock::Text(TextContent::new("look")),
+                        ContentBlock::Image(ImageContent::new("AQID", "image/png")),
+                    ],
+                }],
+                created_at: 11,
+                parent_message_id: None,
+                source_provider: None,
+                source_model: None,
+            },
+        ];
+
+        let records = user_prompt_records(&messages);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].message_id, "user-1");
+        // messageOrder is the zero-based persisted history position, not the
+        // PromptReceived event's stream sequence.
+        assert_eq!(records[0].message_order, 1);
+        assert_eq!(records[0].timestamp, 11);
+        assert!(matches!(records[0].blocks[1], ContentBlock::Image(_)));
+        let value = serde_json::to_value(&records[0]).unwrap();
+        assert_eq!(value["messageId"], "user-1");
+        assert_eq!(value["messageOrder"], 1);
+        assert_eq!(value["blocks"][1]["type"], "image");
+    }
+
+    #[tokio::test]
+    async fn snapshot_history_failure_is_propagated() {
+        let storage = Arc::new(
+            crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into())
+                .await
+                .unwrap(),
+        );
+        let session = storage
+            .create_session(None, None, None, None)
+            .await
+            .unwrap();
+        let mut store = MockSessionStore::new();
+        store
+            .expect_get_history()
+            .withf({
+                let session_id = session.public_id.clone();
+                move |actual| actual == session_id
+            })
+            .returning(|_| Err(SessionError::DatabaseError("history unavailable".into())))
+            .times(1);
+        let (plugin_registry, _temp_dir) = empty_plugin_registry().unwrap();
+        let provider = Arc::new(SessionProvider::new(
+            Arc::new(plugin_registry),
+            Arc::new(store),
+            LLMParams::new().provider("mock").model("mock-model"),
+        ));
+        let config = Arc::new(
+            AgentConfigBuilder::from_provider(storage.clone(), provider, storage.event_journal())
+                .build(),
+        );
+        let agent = crate::agent::LocalAgentHandle::from_config(config);
+
+        let error =
+            load_session_snapshot(&agent, storage.view_store().unwrap(), &session.public_id)
+                .await
+                .unwrap_err();
+        assert!(error.to_string().contains("history unavailable"));
+    }
+
+    #[test]
+    fn old_snapshot_without_user_prompts_deserializes() {
+        let value = serde_json::json!({
+            "audit": {
+                "session_id": "s1",
+                "events": [],
+                "tasks": [],
+                "intent_snapshots": [],
+                "decisions": [],
+                "progress_entries": [],
+                "artifacts": [],
+                "delegations": [],
+                "generated_at": "1970-01-01T00:00:00Z"
+            },
+            "cursor": {"local_seq": 0, "remote_seq_by_source": {}},
+            "delegationUpdates": []
+        });
+        let snapshot: SessionLoadSnapshot = serde_json::from_value(value).unwrap();
+        assert!(snapshot.user_prompts.is_none());
+    }
 }

--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -1160,11 +1160,12 @@ pub mod tests {
     use std::collections::HashMap;
     use std::pin::Pin;
 
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
     use crate::agent::core::AgentMode;
     use crate::agent::session_control::{SessionControlState, SessionModelBinding};
     use crate::test_utils::{MockSessionStore, empty_plugin_registry, mock_session};
-    use tokio::sync::mpsc;
-    use tokio_stream::wrappers::ReceiverStream;
 
     #[tokio::test]
     async fn handle_construction_uses_atomic_control_snapshot_during_model_transition() {
@@ -1347,6 +1348,48 @@ pub mod tests {
         ) -> querymt::plugin::Fut<'a, Result<Vec<String>, LLMError>> {
             Box::pin(async { Ok(Vec::new()) })
         }
+    }
+
+    #[tokio::test]
+    async fn chat_skips_provider_when_history_conversion_fails() {
+        use crate::acp::protocol::{ContentBlock, ImageContent};
+        use crate::model::MessagePart;
+        use crate::test_utils::{MockSessionStore, mock_llm_config, mock_session};
+
+        let invalid_message = AgentMessage {
+            id: "invalid".to_string(),
+            session_id: "session".to_string(),
+            role: ChatRole::User,
+            parts: vec![MessagePart::Prompt {
+                blocks: vec![ContentBlock::Image(ImageContent::new("%%%", "image/png"))],
+            }],
+            created_at: 0,
+            parent_message_id: None,
+            source_provider: None,
+            source_model: None,
+        };
+        let mut store = MockSessionStore::new();
+        store
+            .expect_get_effective_history()
+            .return_once(move |_| Ok(vec![invalid_message]));
+        let (registry, _temp_dir) = empty_plugin_registry().expect("plugin registry");
+        let provider = Arc::new(SessionProvider::new(
+            Arc::new(registry),
+            Arc::new(store),
+            LLMParams::new().provider("mock").model("model"),
+        ));
+        let handle = SessionHandle {
+            provider,
+            session: mock_session("session"),
+            llm_config: Some(mock_llm_config()),
+            provider_node_id: None,
+            execution_config: None,
+            cached_llm_provider: tokio::sync::OnceCell::new(),
+        };
+
+        let error = handle.chat(&[]).await.unwrap_err();
+
+        assert!(matches!(error, SessionError::InvalidOperation(_)));
     }
 
     #[tokio::test]

--- a/crates/agent/src/session/provider.rs
+++ b/crates/agent/src/session/provider.rs
@@ -779,26 +779,23 @@ impl SessionHandle {
             .await
     }
 
-    /// Get the session history converted to standard ChatMessages for the LLM
-    pub async fn history(&self) -> Vec<ChatMessage> {
-        match self.get_effective_agent_history().await {
-            Ok(agent_msgs) => agent_msgs
-                .iter()
-                .map(|m| {
-                    m.to_chat_message_with_target(
+    /// Get the session history converted to standard ChatMessages for the LLM.
+    pub async fn history(&self) -> SessionResult<Vec<ChatMessage>> {
+        let agent_msgs = self.get_effective_agent_history().await?;
+        agent_msgs
+            .iter()
+            .map(|message| {
+                message
+                    .to_chat_message_with_target(
                         self.llm_config.as_ref().map(|cfg| cfg.provider.as_str()),
                         self.llm_config.as_ref().map(|cfg| cfg.model.as_str()),
                         self.execution_config
                             .as_ref()
                             .and_then(|cfg| cfg.max_prompt_bytes),
                     )
-                })
-                .collect(),
-            Err(err) => {
-                log::warn!("Failed to load session history: {}", err);
-                Vec::new()
-            }
-        }
+                    .map_err(|error| SessionError::InvalidOperation(error.to_string()))
+            })
+            .collect()
     }
 
     /// Persist an AgentMessage to the store
@@ -837,7 +834,7 @@ impl SessionHandle {
         }
 
         // 2. Fetch full history for context
-        let llm_messages = self.history().await;
+        let llm_messages = self.history().await?;
 
         // 3. Call LLM
         let response = self.submit_request(&llm_messages).await?;

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use querymt::LLMParams;
+use querymt::chat::ChatRole;
 use rusqlite::Connection;
 
 use crate::acp::protocol::{ContentBlock, ImageContent, TextContent};
@@ -13,7 +14,6 @@ use crate::session::projection::{
     EventJournal, NewDurableEvent, RecentModelEntry, SessionScope, ViewStore,
 };
 use crate::session::store::SessionStore;
-use querymt::chat::ChatRole;
 
 use super::SqliteStorage;
 use super::migrations::{MIGRATIONS, apply_migrations};

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -3,17 +3,60 @@ use std::collections::HashMap;
 use querymt::LLMParams;
 use rusqlite::Connection;
 
+use crate::acp::protocol::{ContentBlock, ImageContent, TextContent};
 use crate::agent::core::AgentMode;
 use crate::agent::session_control::{SessionControlState, SessionModelBinding};
 use crate::events::{AgentEventKind, EventOrigin};
+use crate::model::{AgentMessage, MessagePart};
 use crate::session::domain::ForkOrigin;
 use crate::session::projection::{
     EventJournal, NewDurableEvent, RecentModelEntry, SessionScope, ViewStore,
 };
 use crate::session::store::SessionStore;
+use querymt::chat::ChatRole;
 
 use super::SqliteStorage;
 use super::migrations::{MIGRATIONS, apply_migrations};
+
+#[tokio::test]
+async fn prompt_blocks_round_trip_through_persistence_and_fork() {
+    let storage = SqliteStorage::connect(":memory:".into()).await.unwrap();
+    let session = storage
+        .create_session(Some("source".to_string()), None, None, None)
+        .await
+        .unwrap();
+    let message = AgentMessage {
+        id: "message-1".to_string(),
+        session_id: session.public_id.clone(),
+        role: ChatRole::User,
+        parts: vec![MessagePart::Prompt {
+            blocks: vec![
+                ContentBlock::Text(TextContent::new("before")),
+                ContentBlock::Image(ImageContent::new("AQID", "image/png")),
+                ContentBlock::Text(TextContent::new("after")),
+            ],
+        }],
+        created_at: 1,
+        parent_message_id: None,
+        source_provider: None,
+        source_model: None,
+    };
+    storage
+        .add_message(&session.public_id, message.clone())
+        .await
+        .unwrap();
+
+    let history = storage.get_history(&session.public_id).await.unwrap();
+    assert_eq!(history[0].parts, message.parts);
+
+    let fork_id = storage
+        .fork_session(&session.public_id, "message-1", ForkOrigin::User)
+        .await
+        .unwrap();
+    let fork_history = storage.get_history(&fork_id).await.unwrap();
+    assert_eq!(fork_history.len(), 1);
+    assert_eq!(fork_history[0].parts, message.parts);
+}
 
 #[test]
 fn migration_0001_is_recorded() {

--- a/crates/agent/src/ui/connection.rs
+++ b/crates/agent/src/ui/connection.rs
@@ -546,7 +546,7 @@ async fn forward_event_to_ui(
             agent_id,
             profile_id,
             session_id: event.session_id().to_owned(),
-            event: event.clone(),
+            event: Box::new(event.clone()),
         },
     )
     .await

--- a/crates/agent/src/ui/messages.rs
+++ b/crates/agent/src/ui/messages.rs
@@ -770,7 +770,7 @@ pub enum UiServerMessage {
         agent_id: String,
         profile_id: Option<String>,
         session_id: String,
-        event: EventEnvelope,
+        event: Box<EventEnvelope>,
     },
     InputSubmitted {
         session_id: String,

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -13,6 +13,15 @@ export type AgentEventKind =
 	content: string;
 	message_id?: string;
 }}
+	/**
+	 * Transient structured prompt block for live ACP delivery. Durable prompt
+	 * content remains in MessagePart::Prompt rather than the event journal.
+	 */
+	| { type: "user_prompt_block", data: {
+	message_id: string;
+	client_prompt_id?: string;
+	block: any;
+}}
 	| { type: "user_message_stored", data: {
 	content: string;
 }}
@@ -1126,10 +1135,19 @@ export interface StreamCursor {
 	remote_seq_by_source: Record<string, number>;
 }
 
+export interface UserPromptRecord {
+	messageId: string;
+	/** Zero-based position in persisted message history; this is not an event sequence. */
+	messageOrder: number;
+	timestamp: number;
+	blocks: any;
+}
+
 export interface SessionLoadSnapshot {
 	audit: AuditView;
 	cursor: StreamCursor;
 	delegationUpdates: DelegationUpdateNotification[];
+	userPrompts?: UserPromptRecord[];
 }
 
 export enum SessionRuntimePhase {

--- a/crates/providers/openai/Cargo.toml
+++ b/crates/providers/openai/Cargo.toml
@@ -26,4 +26,5 @@ url.workspace = true
 schemars.workspace = true
 http.workspace = true
 heck.workspace = true
+base64.workspace = true
 extism-pdk = { workspace = true, optional = true }

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -1,3 +1,4 @@
+use base64::Engine as _;
 use either::*;
 use http::{
     Method, Request, Response,
@@ -913,6 +914,28 @@ fn extract_reasoning_content<'a>(msg: &'a ChatMessage, include: bool) -> Option<
     msg.thinking().map(Cow::Borrowed)
 }
 
+fn content_text_with_fallbacks<'a>(content: impl IntoIterator<Item = &'a Content>) -> String {
+    content
+        .into_iter()
+        .filter_map(|block| match block {
+            Content::Text { text } => Some(text.clone()),
+            Content::Image { mime_type, data } => Some(format!(
+                "[Image attachment: {mime_type}, {} bytes]",
+                data.len()
+            )),
+            Content::ImageUrl { .. } => Some("[Image URL attachment]".to_string()),
+            Content::Pdf { data } => Some(format!("[PDF attachment: {} bytes]", data.len())),
+            Content::Audio { mime_type, data } => Some(format!(
+                "[Audio attachment: {mime_type}, {} bytes]",
+                data.len()
+            )),
+            Content::ResourceLink { uri, .. } => Some(format!("[Attached resource: {uri}]")),
+            Content::Thinking { .. } | Content::ToolUse { .. } | Content::ToolResult { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Convert a ChatMessage with Vec<Content> blocks into one or more OpenAI API messages.
 ///
 /// Most messages map 1:1, but ToolResult blocks each become a separate `role: "tool"` message.
@@ -937,22 +960,17 @@ fn convert_chat_message_to_openai<'a>(
     // it inside the final tool response: some OpenAI-compatible APIs reject a
     // user message interleaved between an assistant tool call and its responses.
     if has_tool_results {
-        let supplemental_text = chat_msg
-            .content
-            .iter()
-            .filter(|block| !block.is_tool_result())
-            .filter_map(Content::as_text)
-            .collect::<Vec<_>>()
-            .join("\n");
+        let supplemental_text = content_text_with_fallbacks(
+            chat_msg
+                .content
+                .iter()
+                .filter(|block| !block.is_tool_result()),
+        );
         let last_tool_result_index = chat_msg.content.iter().rposition(Content::is_tool_result);
 
         for (index, block) in chat_msg.content.iter().enumerate() {
             if let Content::ToolResult { id, content, .. } = block {
-                let mut text = content
-                    .iter()
-                    .filter_map(Content::as_text)
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                let mut text = content_text_with_fallbacks(content);
                 if Some(index) == last_tool_result_index && !supplemental_text.is_empty() {
                     if !text.is_empty() {
                         text.push_str("\n\n");
@@ -973,8 +991,8 @@ fn convert_chat_message_to_openai<'a>(
 
     // Emit tool use blocks as tool_calls on an assistant message
     if has_tool_use {
-        // Collect any text blocks as the message content
-        let text: String = chat_msg.text();
+        // Preserve non-tool blocks as text or bounded attachment markers.
+        let text = content_text_with_fallbacks(&chat_msg.content);
         let content_val = if text.is_empty() {
             None
         } else {
@@ -1020,14 +1038,20 @@ fn convert_chat_message_to_openai<'a>(
         return;
     }
 
-    // Normal message: text, images, etc.
-    // Check for image URLs — use content array format
-    let has_images = chat_msg
-        .content
-        .iter()
-        .any(|b| matches!(b, Content::ImageUrl { .. } | Content::Image { .. }));
+    // Use content-array format whenever the message contains non-text input so
+    // ordering is retained and unsupported binary kinds receive explicit markers.
+    let has_structured_content = chat_msg.content.iter().any(|block| {
+        matches!(
+            block,
+            Content::ImageUrl { .. }
+                | Content::Image { .. }
+                | Content::Pdf { .. }
+                | Content::Audio { .. }
+                | Content::ResourceLink { .. }
+        )
+    });
 
-    if has_images {
+    if has_structured_content {
         let content_blocks: Vec<MessageContent<'a>> = chat_msg
             .content
             .iter()
@@ -1048,7 +1072,48 @@ fn convert_chat_message_to_openai<'a>(
                     tool_call_id: None,
                     tool_output: None,
                 }),
-                _ => None,
+                Content::Image { mime_type, data } => {
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+                    Some(MessageContent {
+                        message_type: Some(Cow::Borrowed("image_url")),
+                        text: None,
+                        image_url: Some(ImageUrlContent {
+                            url: Cow::Owned(format!("data:{mime_type};base64,{encoded}")),
+                        }),
+                        tool_call_id: None,
+                        tool_output: None,
+                    })
+                }
+                Content::Pdf { data } => Some(MessageContent {
+                    message_type: Some(Cow::Borrowed("text")),
+                    text: Some(Cow::Owned(format!(
+                        "[PDF attachment: {} bytes]",
+                        data.len()
+                    ))),
+                    image_url: None,
+                    tool_call_id: None,
+                    tool_output: None,
+                }),
+                Content::Audio { mime_type, data } => Some(MessageContent {
+                    message_type: Some(Cow::Borrowed("text")),
+                    text: Some(Cow::Owned(format!(
+                        "[Audio attachment: {mime_type}, {} bytes]",
+                        data.len()
+                    ))),
+                    image_url: None,
+                    tool_call_id: None,
+                    tool_output: None,
+                }),
+                Content::ResourceLink { uri, .. } => Some(MessageContent {
+                    message_type: Some(Cow::Borrowed("text")),
+                    text: Some(Cow::Owned(format!("[Attached resource: {uri}]"))),
+                    image_url: None,
+                    tool_call_id: None,
+                    tool_output: None,
+                }),
+                Content::Thinking { .. } | Content::ToolUse { .. } | Content::ToolResult { .. } => {
+                    None
+                }
             })
             .collect();
 
@@ -1537,9 +1602,117 @@ mod tests {
 
     use super::{
         MultipartForm, OpenAIChatResponse, OpenAIToolUseState, classify_openai_http_error,
-        openai_parse_chat, openai_parse_list_models, parse_openai_sse_chunk,
+        convert_chat_message_to_openai, openai_parse_chat, openai_parse_list_models,
+        parse_openai_sse_chunk,
     };
     use crate::OpenAI;
+
+    #[test]
+    fn raw_images_serialize_as_ordered_data_urls() {
+        use querymt::chat::{ChatMessage, ChatRole, Content};
+
+        let message = ChatMessage {
+            role: ChatRole::User,
+            content: vec![
+                Content::text("before"),
+                Content::image("image/png", vec![1, 2, 3]),
+                Content::text("after"),
+            ],
+            cache: None,
+        };
+        let mut converted = Vec::new();
+        convert_chat_message_to_openai(&message, &mut converted, true);
+        let value = serde_json::to_value(&converted[0]).unwrap();
+        let content = value["content"].as_array().unwrap();
+
+        assert_eq!(content.len(), 3);
+        assert_eq!(content[0]["text"], "before");
+        assert_eq!(content[1]["image_url"]["url"], "data:image/png;base64,AQID");
+        assert_eq!(content[2]["text"], "after");
+    }
+
+    #[test]
+    fn image_only_message_is_not_dropped() {
+        use querymt::chat::{ChatMessage, ChatRole, Content};
+
+        let message = ChatMessage {
+            role: ChatRole::User,
+            content: vec![Content::image("image/jpeg", vec![0xff, 0xd8])],
+            cache: None,
+        };
+        let mut converted = Vec::new();
+        convert_chat_message_to_openai(&message, &mut converted, true);
+        let value = serde_json::to_value(&converted[0]).unwrap();
+
+        assert_eq!(
+            value["content"][0]["image_url"]["url"],
+            "data:image/jpeg;base64,/9g="
+        );
+    }
+
+    #[test]
+    fn pdf_only_message_uses_explicit_size_marker() {
+        use querymt::chat::{ChatMessage, ChatRole, Content};
+
+        let message = ChatMessage {
+            role: ChatRole::User,
+            content: vec![Content::pdf(vec![0x25, 0x50, 0x44, 0x46])],
+            cache: None,
+        };
+        let mut converted = Vec::new();
+        convert_chat_message_to_openai(&message, &mut converted, true);
+        let value = serde_json::to_value(&converted[0]).unwrap();
+
+        assert_eq!(value["content"].as_array().unwrap().len(), 1);
+        assert_eq!(value["content"][0]["type"], "text");
+        assert_eq!(value["content"][0]["text"], "[PDF attachment: 4 bytes]");
+    }
+
+    #[test]
+    fn mixed_image_pdf_and_text_preserve_order_without_filtering() {
+        use querymt::chat::{ChatMessage, ChatRole, Content};
+
+        let message = ChatMessage {
+            role: ChatRole::User,
+            content: vec![
+                Content::text("before"),
+                Content::image("image/png", vec![1, 2, 3]),
+                Content::pdf(vec![0x25, 0x50]),
+                Content::text("after"),
+            ],
+            cache: None,
+        };
+        let mut converted = Vec::new();
+        convert_chat_message_to_openai(&message, &mut converted, true);
+        let value = serde_json::to_value(&converted[0]).unwrap();
+        let content = value["content"].as_array().unwrap();
+
+        assert_eq!(content.len(), 4);
+        assert_eq!(content[0]["text"], "before");
+        assert_eq!(content[1]["image_url"]["url"], "data:image/png;base64,AQID");
+        assert_eq!(content[2]["text"], "[PDF attachment: 2 bytes]");
+        assert_eq!(content[3]["text"], "after");
+    }
+
+    #[test]
+    fn tool_result_pdf_uses_explicit_marker() {
+        use querymt::chat::{ChatMessage, ChatRole, Content};
+
+        let message = ChatMessage {
+            role: ChatRole::User,
+            content: vec![Content::tool_result(
+                "call-1",
+                vec![Content::pdf(vec![0x25, 0x50, 0x44, 0x46])],
+            )],
+            cache: None,
+        };
+        let mut converted = Vec::new();
+        convert_chat_message_to_openai(&message, &mut converted, true);
+        let value = serde_json::to_value(&converted[0]).unwrap();
+
+        assert_eq!(value["role"], "tool");
+        assert_eq!(value["content"], "[PDF attachment: 4 bytes]");
+    }
 
     #[test]
     fn multipart_form_encodes_text_and_file_parts() {


### PR DESCRIPTION
Preserve native images and embedded resources throughout the ACP prompt pipeline instead of reducing them to textual placeholders.

Convert image resources into provider-native image content, retain mixed content ordering, validate attachment sizes and MIME types, and support text, PDF, and generic file resources.

Extend sessionLoadSnapshot.v1 with structured user prompts, replay attachment content across session loads, and correlate live prompt updates with optimistic desktop messages.

Advertise image and embedded-context capabilities, preserve legacy resource-backed sessions, and serialize images and PDFs through OpenAI-compatible providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured prompt support for text, images, PDFs, audio, links, and embedded resources.
  * Preserved prompt order, IDs, metadata, and attachments across live sessions, replay, history, and session forking.
  * Image prompt support is now advertised during initialization.
  * Increased steering input limits substantially.
  * Added session-end notifications and expanded tool execution hook support.
* **Bug Fixes**
  * Invalid prompt content and session-history failures now return clear errors.
  * Improved attachment rendering and provider compatibility.
  * Improved tool execution, permissions, and completion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #824