### PR TITLE
fix: acp session_load

### DIFF
--- a/crates/agent/examples/qmtcode.rs
+++ b/crates/agent/examples/qmtcode.rs
@@ -37,10 +37,7 @@
 //! ./qmtcode --mesh
 //! ```
 
-use clap::ArgAction;
-#[cfg(any(feature = "api", feature = "dashboard"))]
-use clap::ArgGroup;
-use clap::Parser;
+use clap::{ArgAction, ArgGroup, Parser};
 use querymt_agent::prelude::*;
 use querymt_agent::profiles::{
     DEFAULT_EMBEDDED_PROFILE_KEY, LocalProfileCatalog, ProfileCatalog, ProfileConfigKind,

--- a/crates/agent/src/acp/client_bridge.rs
+++ b/crates/agent/src/acp/client_bridge.rs
@@ -53,7 +53,9 @@ pub enum ClientBridgeMessage {
     Notification(SessionNotification),
 
     /// Barrier acknowledged after every preceding bridge message has been forwarded.
-    Flush { response_tx: oneshot::Sender<()> },
+    Flush {
+        response_tx: oneshot::Sender<Result<(), String>>,
+    },
 
     /// Fire-and-forget ACP extension notification payload.
     ExtNotification(ExtNotification),
@@ -146,7 +148,8 @@ impl ClientBridgeSender {
             .map_err(|_| Error::from(crate::error::AgentError::ClientBridgeClosed))?;
         response_rx
             .await
-            .map_err(|_| Error::from(crate::error::AgentError::ClientBridgeClosed))
+            .map_err(|_| Error::from(crate::error::AgentError::ClientBridgeClosed))?
+            .map_err(|message| Error::internal_error().data(message))
     }
 
     pub async fn notify_ext(&self, notification: ExtNotification) -> Result<(), Error> {
@@ -248,5 +251,43 @@ impl ClientBridgeSender {
         response_rx
             .await
             .map_err(|_| Error::internal_error().data("Elicitation response channel dropped"))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::protocol::{ContentBlock, ContentChunk, SessionId, SessionUpdate, TextContent};
+
+    #[tokio::test]
+    async fn flush_is_ordered_after_preceding_notifications() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let sender = ClientBridgeSender::new(tx);
+        let notification = SessionNotification::new(
+            SessionId::from("session-1"),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new("history"),
+            ))),
+        );
+
+        sender
+            .notify(notification)
+            .await
+            .expect("enqueue notification");
+        let flush = tokio::spawn({
+            let sender = sender.clone();
+            async move { sender.flush().await }
+        });
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(ClientBridgeMessage::Notification(_))
+        ));
+        let Some(ClientBridgeMessage::Flush { response_tx }) = rx.recv().await else {
+            panic!("flush must follow the notification");
+        };
+        assert!(!flush.is_finished());
+        response_tx.send(Ok(())).expect("acknowledge flush");
+        flush.await.expect("flush task").expect("flush succeeds");
     }
 }

--- a/crates/agent/src/acp/client_bridge.rs
+++ b/crates/agent/src/acp/client_bridge.rs
@@ -93,6 +93,28 @@ pub enum ClientBridgeMessage {
     },
 }
 
+#[derive(Default)]
+pub(crate) struct NotificationForwardingState {
+    pending_error: Option<String>,
+}
+
+impl NotificationForwardingState {
+    pub(crate) fn record_result<E: std::fmt::Debug>(&mut self, result: Result<(), E>) {
+        if let Err(error) = result
+            && self.pending_error.is_none()
+        {
+            self.pending_error = Some(format!("session notification forwarding failed: {error:?}"));
+        }
+    }
+
+    pub(crate) fn take_flush_result(&mut self) -> Result<(), String> {
+        match self.pending_error.take() {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+}
+
 /// Send-side handle for the client bridge.
 ///
 /// This type is `Send + Sync` and can be cloned and used from multi-threaded contexts.
@@ -289,5 +311,38 @@ mod tests {
         assert!(!flush.is_finished());
         response_tx.send(Ok(())).expect("acknowledge flush");
         flush.await.expect("flush task").expect("flush succeeds");
+    }
+
+    #[tokio::test]
+    async fn forwarding_failure_is_returned_by_next_flush() {
+        let (tx, mut rx) = mpsc::channel(2);
+        let sender = ClientBridgeSender::new(tx);
+        let flush = tokio::spawn({
+            let sender = sender.clone();
+            async move { sender.flush().await }
+        });
+        let Some(ClientBridgeMessage::Flush { response_tx }) = rx.recv().await else {
+            panic!("expected flush message");
+        };
+        let mut forwarding = NotificationForwardingState::default();
+        forwarding.record_result::<&str>(Err("connection closed"));
+        response_tx
+            .send(forwarding.take_flush_result())
+            .expect("acknowledge failed flush");
+
+        let error = flush
+            .await
+            .expect("flush task")
+            .expect_err("flush must report forwarding failure");
+        assert!(error.to_string().contains("connection closed"));
+        assert!(forwarding.take_flush_result().is_ok());
+    }
+
+    #[test]
+    fn fully_forwarded_notifications_keep_flush_successful() {
+        let mut forwarding = NotificationForwardingState::default();
+        forwarding.record_result::<&str>(Ok(()));
+        forwarding.record_result::<&str>(Ok(()));
+        assert!(forwarding.take_flush_result().is_ok());
     }
 }

--- a/crates/agent/src/acp/stdio.rs
+++ b/crates/agent/src/acp/stdio.rs
@@ -196,7 +196,7 @@ async fn run_bridge_task(
                 }
             }
             ClientBridgeMessage::Flush { response_tx } => {
-                let _ = response_tx.send(());
+                let _ = response_tx.send(Ok(()));
             }
             ClientBridgeMessage::ExtNotification(notif) => {
                 let _span = info_span!("acp.ext_notification").entered();

--- a/crates/agent/src/acp/stdio.rs
+++ b/crates/agent/src/acp/stdio.rs
@@ -21,7 +21,9 @@
 //!                                        └───────────────────────────┘
 //! ```
 
-use crate::acp::client_bridge::{ClientBridgeMessage, ClientBridgeSender};
+use crate::acp::client_bridge::{
+    ClientBridgeMessage, ClientBridgeSender, NotificationForwardingState,
+};
 use crate::acp::protocol::{
     AgentRequest, AuthenticateRequest, CancelNotification, ClientNotification, ClientRequest,
     CloseSessionRequest, DeleteSessionRequest, ExtRequest, ForkSessionRequest, InitializeRequest,
@@ -185,18 +187,21 @@ async fn run_bridge_task(
     connection: ConnectionTo<acp::Client>,
 ) {
     log::info!("Client bridge task started");
+    let mut notification_forwarding = NotificationForwardingState::default();
 
     while let Some(msg) = rx.recv().await {
         match msg {
             ClientBridgeMessage::Notification(notif) => {
                 let _span = info_span!("acp.notification").entered();
                 log::debug!("Bridge: forwarding session notification");
-                if let Err(e) = connection.send_notification(notif) {
+                let result = connection.send_notification(notif);
+                if let Err(e) = &result {
                     log::error!("Bridge: session_notification failed: {:?}", e);
                 }
+                notification_forwarding.record_result(result);
             }
             ClientBridgeMessage::Flush { response_tx } => {
-                let _ = response_tx.send(Ok(()));
+                let _ = response_tx.send(notification_forwarding.take_flush_result());
             }
             ClientBridgeMessage::ExtNotification(notif) => {
                 let _span = info_span!("acp.ext_notification").entered();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flush acknowledgments now report notification-delivery failures instead of indicating success.
  * Communication errors are retained and surfaced during the next flush confirmation.
  * Successful notification delivery continues to produce successful flush results.
  * Improved reliability and error handling for standard input/output communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->