### PR TITLE
feat: add delegation slash command

### DIFF
--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -59,6 +59,7 @@ impl LocalAgentHandle {
             oauth_service,
             profiles: ArcSwap::from_pointee(None),
             scheduler_handle: Arc::new(parking_lot::Mutex::new(None)),
+            slash_delegation_orchestrator: OnceCell::new(),
             shutdown_done: AtomicBool::new(false),
         }
     }
@@ -74,6 +75,282 @@ impl LocalAgentHandle {
 
     pub fn profiles(&self) -> Option<ProfileRuntime> {
         self.profiles.load_full().as_ref().clone()
+    }
+
+    async fn slash_delegation_orchestrator(
+        &self,
+    ) -> Arc<crate::delegation::DelegationOrchestrator> {
+        self.slash_delegation_orchestrator
+            .get_or_init(|| async {
+                let orchestrator = Arc::new(crate::delegation::DelegationOrchestrator::new(
+                    Arc::new(Self::from_config(self.config.clone())),
+                    self.config.event_sink.clone(),
+                    self.config.storage.session_store(),
+                    self.config.agent_registry.clone(),
+                    Arc::new(self.config.tool_registry.clone()),
+                    self.config.hooks.clone(),
+                    None,
+                ));
+                orchestrator.start_listening(self.config.event_sink.fanout());
+                orchestrator
+            })
+            .await
+            .clone()
+    }
+
+    pub(super) async fn submit_slash_delegation(
+        &self,
+        parent_session_id: String,
+        command: crate::slash_commands::DelegateSlashCommand,
+        delegation: crate::session::domain::Delegation,
+    ) -> Result<(), Error> {
+        use crate::slash_commands::DelegateTarget;
+
+        let (target, binding) = match &command.target {
+            DelegateTarget::Agent(id) => {
+                let handle = self.config.agent_registry.get_handle(id).ok_or_else(|| {
+                    let available = self
+                        .config
+                        .agent_registry
+                        .list_agents()
+                        .into_iter()
+                        .map(|agent| agent.id)
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    Error::invalid_params().data(serde_json::json!({
+                        "message": format!("Agent '{id}' is not registered"),
+                        "availableAgents": available,
+                    }))
+                })?;
+                (handle, None)
+            }
+            DelegateTarget::Profile(id) => {
+                let profiles = self.profiles().ok_or_else(|| {
+                    Error::invalid_params().data(serde_json::json!({
+                        "message": "Profile delegation requires an attached profile catalog",
+                    }))
+                })?;
+                let runtime = profiles.runtime_for_profile(id).await.map_err(|err| {
+                    Error::invalid_params().data(serde_json::json!({
+                        "message": format!("Failed to load profile '{id}': {err}"),
+                    }))
+                })?;
+                let mut binding = runtime.session_binding();
+                binding.agent_id = None;
+                (
+                    runtime.agent().handle() as Arc<dyn AgentHandle>,
+                    Some(binding),
+                )
+            }
+        };
+
+        self.slash_delegation_orchestrator()
+            .await
+            .submit_resolved(parent_session_id, delegation, target, binding, false)
+            .await
+            .map_err(|err| Error::internal_error().data(err))
+    }
+
+    pub(super) async fn execute_delegate_slash_command(
+        &self,
+        req: PromptRequest,
+        session_ref: crate::agent::remote::SessionActorRef,
+        command: crate::slash_commands::DelegateSlashCommand,
+    ) -> Result<PromptResponse, Error> {
+        use crate::acp::protocol::{ContentBlock, StopReason, TextContent};
+        use crate::events::AgentEventKind;
+        use crate::model::{AgentMessage, MessagePart};
+        use querymt::chat::ChatRole;
+
+        let session_id = req.session_id.to_string();
+        let display_content = crate::agent::utils::render_prompt_for_display(&req.prompt);
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let user_message = AgentMessage {
+            id: message_id.clone(),
+            session_id: session_id.clone(),
+            role: ChatRole::User,
+            parts: vec![MessagePart::Prompt {
+                blocks: req.prompt.clone(),
+            }],
+            created_at: time::OffsetDateTime::now_utc().unix_timestamp(),
+            parent_message_id: None,
+            source_provider: None,
+            source_model: None,
+        };
+        self.config
+            .provider
+            .history_store()
+            .add_message(&session_id, user_message)
+            .await
+            .map_err(|err| Error::internal_error().data(err.to_string()))?;
+        self.config.emit_event(
+            &session_id,
+            AgentEventKind::PromptReceived {
+                content: display_content.clone(),
+                message_id: Some(message_id),
+            },
+        );
+        self.config.emit_event(
+            &session_id,
+            AgentEventKind::UserMessageStored {
+                content: display_content,
+            },
+        );
+
+        let runtime = crate::session::runtime::RuntimeContext::new(
+            self.config.provider.history_store(),
+            session_id.clone(),
+        )
+        .await
+        .map_err(|err| Error::internal_error().data(err.to_string()))?;
+        let delegation = runtime
+            .record_delegation(
+                command.target.id().to_string(),
+                command.objective.clone(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .map_err(|err| Error::internal_error().data(err.to_string()))?;
+        let delegation_id = delegation.public_id.clone();
+        let mut events = self.config.event_sink.fanout().subscribe();
+        self.submit_slash_delegation(session_id.clone(), command.clone(), delegation.clone())
+            .await?;
+        self.config.emit_event(
+            &session_id,
+            AgentEventKind::DelegationRequested {
+                delegation,
+                tool_call_id: None,
+            },
+        );
+        if command.mode == crate::slash_commands::DelegateMode::Async {
+            let acknowledgement = format!(
+                "Delegation queued.\n\nTarget: {}\nDelegation ID: {}",
+                command.target, delegation_id
+            );
+            self.store_slash_command_reply(&session_id, acknowledgement)
+                .await?;
+            let child_prompt = session_ref.clone();
+            tokio::spawn(async move {
+                while let Ok(event) = events.recv().await {
+                    if event.session_id() != session_id {
+                        continue;
+                    }
+                    let content = match event.kind() {
+                        AgentEventKind::DelegationCompleted {
+                            delegation_id: completed_id,
+                            result,
+                        } if completed_id == &delegation_id => {
+                            Some(crate::delegation::format_delegation_completion_message(
+                                completed_id,
+                                result.as_deref().unwrap_or("No summary provided."),
+                            ))
+                        }
+                        AgentEventKind::DelegationFailed {
+                            delegation_id: failed_id,
+                            error,
+                        } if failed_id == &delegation_id => Some(
+                            crate::delegation::format_delegation_failure_message(failed_id, error),
+                        ),
+                        AgentEventKind::DelegationCancelled {
+                            delegation_id: cancelled_id,
+                        } if cancelled_id == &delegation_id => Some(format!(
+                            "Delegation cancelled.\n\nDelegation ID: {cancelled_id}"
+                        )),
+                        _ => None,
+                    };
+                    if let Some(content) = content {
+                        let _ = child_prompt
+                            .prompt(PromptRequest::new(
+                                session_id.clone(),
+                                vec![ContentBlock::Text(TextContent::new(content))],
+                            ))
+                            .await;
+                        break;
+                    }
+                }
+            });
+            return Ok(PromptResponse::new(StopReason::EndTurn));
+        }
+
+        loop {
+            let event = events
+                .recv()
+                .await
+                .map_err(|err| Error::internal_error().data(err.to_string()))?;
+            if event.session_id() != session_id {
+                continue;
+            }
+            let content = match event.kind() {
+                AgentEventKind::DelegationCompleted {
+                    delegation_id: completed_id,
+                    result,
+                } if completed_id == &delegation_id => {
+                    Some(crate::delegation::format_delegation_completion_message(
+                        completed_id,
+                        result.as_deref().unwrap_or("No summary provided."),
+                    ))
+                }
+                AgentEventKind::DelegationFailed {
+                    delegation_id: failed_id,
+                    error,
+                } if failed_id == &delegation_id => Some(
+                    crate::delegation::format_delegation_failure_message(failed_id, error),
+                ),
+                AgentEventKind::DelegationCancelled {
+                    delegation_id: cancelled_id,
+                } if cancelled_id == &delegation_id => Some(format!(
+                    "Delegation cancelled.\n\nDelegation ID: {cancelled_id}"
+                )),
+                _ => None,
+            };
+            if let Some(content) = content {
+                return session_ref
+                    .prompt(PromptRequest::new(
+                        session_id,
+                        vec![ContentBlock::Text(TextContent::new(content))],
+                    ))
+                    .await;
+            }
+        }
+    }
+
+    async fn store_slash_command_reply(
+        &self,
+        session_id: &str,
+        content: String,
+    ) -> Result<(), Error> {
+        let message_id = uuid::Uuid::new_v4().to_string();
+        self.config
+            .provider
+            .history_store()
+            .add_message(
+                session_id,
+                crate::model::AgentMessage {
+                    id: message_id.clone(),
+                    session_id: session_id.to_string(),
+                    role: querymt::chat::ChatRole::Assistant,
+                    parts: vec![crate::model::MessagePart::Text {
+                        content: content.clone(),
+                    }],
+                    created_at: time::OffsetDateTime::now_utc().unix_timestamp(),
+                    parent_message_id: None,
+                    source_provider: None,
+                    source_model: None,
+                },
+            )
+            .await
+            .map_err(|err| Error::internal_error().data(err.to_string()))?;
+        self.config.emit_event(
+            session_id,
+            crate::events::AgentEventKind::AssistantMessageStored {
+                content,
+                thinking: None,
+                message_id: Some(message_id),
+            },
+        );
+        Ok(())
     }
 
     pub(super) async fn session_config_options(
@@ -601,6 +878,10 @@ impl LocalAgentHandle {
             scheduler.request_shutdown();
         }
         self.clear_scheduler_handle();
+
+        if let Some(orchestrator) = self.slash_delegation_orchestrator.get() {
+            orchestrator.cancel_active_delegations().await;
+        }
 
         #[cfg(feature = "remote")]
         self.clear_mesh();

--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -82,15 +82,18 @@ impl LocalAgentHandle {
     ) -> Arc<crate::delegation::DelegationOrchestrator> {
         self.slash_delegation_orchestrator
             .get_or_init(|| async {
-                let orchestrator = Arc::new(crate::delegation::DelegationOrchestrator::new(
-                    Arc::new(Self::from_config(self.config.clone())),
-                    self.config.event_sink.clone(),
-                    self.config.storage.session_store(),
-                    self.config.agent_registry.clone(),
-                    Arc::new(self.config.tool_registry.clone()),
-                    self.config.hooks.clone(),
-                    None,
-                ));
+                let orchestrator = Arc::new(
+                    crate::delegation::DelegationOrchestrator::new(
+                        Arc::new(Self::from_config(self.config.clone())),
+                        self.config.event_sink.clone(),
+                        self.config.storage.session_store(),
+                        self.config.agent_registry.clone(),
+                        Arc::new(self.config.tool_registry.clone()),
+                        self.config.hooks.clone(),
+                        None,
+                    )
+                    .with_wait_timeout_secs(self.config.delegation_wait_timeout_secs),
+                );
                 orchestrator.start_listening(self.config.event_sink.fanout());
                 orchestrator
             })
@@ -103,7 +106,7 @@ impl LocalAgentHandle {
         parent_session_id: String,
         command: crate::slash_commands::DelegateSlashCommand,
         delegation: crate::session::domain::Delegation,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         use crate::slash_commands::DelegateTarget;
 
         let (target, binding) = match &command.target {
@@ -144,11 +147,12 @@ impl LocalAgentHandle {
             }
         };
 
-        self.slash_delegation_orchestrator()
-            .await
+        let orchestrator = self.slash_delegation_orchestrator().await;
+        orchestrator
             .submit_resolved(parent_session_id, delegation, target, binding, false)
             .await
-            .map_err(|err| Error::internal_error().data(err))
+            .map_err(|err| Error::internal_error().data(err))?;
+        Ok(orchestrator.wait_timeout_secs())
     }
 
     pub(super) async fn execute_delegate_slash_command(
@@ -215,7 +219,8 @@ impl LocalAgentHandle {
             .map_err(|err| Error::internal_error().data(err.to_string()))?;
         let delegation_id = delegation.public_id.clone();
         let mut events = self.config.event_sink.fanout().subscribe();
-        self.submit_slash_delegation(session_id.clone(), command.clone(), delegation.clone())
+        let wait_timeout_secs = self
+            .submit_slash_delegation(session_id.clone(), command.clone(), delegation.clone())
             .await?;
         self.config.emit_event(
             &session_id,
@@ -232,88 +237,42 @@ impl LocalAgentHandle {
             self.store_slash_command_reply(&session_id, acknowledgement)
                 .await?;
             let child_prompt = session_ref.clone();
+            let config = self.config.clone();
             tokio::spawn(async move {
-                while let Ok(event) = events.recv().await {
-                    if event.session_id() != session_id {
-                        continue;
-                    }
-                    let content = match event.kind() {
-                        AgentEventKind::DelegationCompleted {
-                            delegation_id: completed_id,
-                            result,
-                        } if completed_id == &delegation_id => {
-                            Some(crate::delegation::format_delegation_completion_message(
-                                completed_id,
-                                result.as_deref().unwrap_or("No summary provided."),
-                            ))
-                        }
-                        AgentEventKind::DelegationFailed {
-                            delegation_id: failed_id,
-                            error,
-                        } if failed_id == &delegation_id => Some(
-                            crate::delegation::format_delegation_failure_message(failed_id, error),
-                        ),
-                        AgentEventKind::DelegationCancelled {
-                            delegation_id: cancelled_id,
-                        } if cancelled_id == &delegation_id => Some(format!(
-                            "Delegation cancelled.\n\nDelegation ID: {cancelled_id}"
-                        )),
-                        _ => None,
-                    };
-                    if let Some(content) = content {
-                        let _ = child_prompt
-                            .prompt(PromptRequest::new(
-                                session_id.clone(),
-                                vec![ContentBlock::Text(TextContent::new(content))],
-                            ))
-                            .await;
-                        break;
-                    }
+                if let Ok(content) = wait_for_slash_delegation_result(
+                    &config,
+                    wait_timeout_secs,
+                    &mut events,
+                    &session_id,
+                    &delegation_id,
+                )
+                .await
+                {
+                    let _ = child_prompt
+                        .prompt(PromptRequest::new(
+                            session_id,
+                            vec![ContentBlock::Text(TextContent::new(content))],
+                        ))
+                        .await;
                 }
             });
             return Ok(PromptResponse::new(StopReason::EndTurn));
         }
 
-        loop {
-            let event = events
-                .recv()
-                .await
-                .map_err(|err| Error::internal_error().data(err.to_string()))?;
-            if event.session_id() != session_id {
-                continue;
-            }
-            let content = match event.kind() {
-                AgentEventKind::DelegationCompleted {
-                    delegation_id: completed_id,
-                    result,
-                } if completed_id == &delegation_id => {
-                    Some(crate::delegation::format_delegation_completion_message(
-                        completed_id,
-                        result.as_deref().unwrap_or("No summary provided."),
-                    ))
-                }
-                AgentEventKind::DelegationFailed {
-                    delegation_id: failed_id,
-                    error,
-                } if failed_id == &delegation_id => Some(
-                    crate::delegation::format_delegation_failure_message(failed_id, error),
-                ),
-                AgentEventKind::DelegationCancelled {
-                    delegation_id: cancelled_id,
-                } if cancelled_id == &delegation_id => Some(format!(
-                    "Delegation cancelled.\n\nDelegation ID: {cancelled_id}"
-                )),
-                _ => None,
-            };
-            if let Some(content) = content {
-                return session_ref
-                    .prompt(PromptRequest::new(
-                        session_id,
-                        vec![ContentBlock::Text(TextContent::new(content))],
-                    ))
-                    .await;
-            }
-        }
+        let content = wait_for_slash_delegation_result(
+            &self.config,
+            wait_timeout_secs,
+            &mut events,
+            &session_id,
+            &delegation_id,
+        )
+        .await?;
+        session_ref
+            .prompt(PromptRequest::new(
+                session_id,
+                vec![ContentBlock::Text(TextContent::new(content))],
+            ))
+            .await
     }
 
     async fn store_slash_command_reply(
@@ -889,6 +848,82 @@ impl LocalAgentHandle {
         self.config.shutdown().await;
 
         log::info!("LocalAgentHandle: Shutdown requested");
+    }
+}
+
+async fn wait_for_slash_delegation_result(
+    config: &Arc<AgentConfig>,
+    timeout_secs: u64,
+    events: &mut tokio::sync::broadcast::Receiver<crate::events::EventEnvelope>,
+    session_id: &str,
+    delegation_id: &str,
+) -> Result<String, Error> {
+    use crate::events::AgentEventKind;
+    use tokio::sync::broadcast::error::RecvError;
+
+    let deadline = (timeout_secs > 0)
+        .then(|| tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs));
+
+    loop {
+        let received = if let Some(deadline) = deadline {
+            match tokio::time::timeout_at(deadline, events.recv()).await {
+                Ok(received) => received,
+                Err(_) => {
+                    config.emit_event(
+                        session_id,
+                        AgentEventKind::DelegationCancelRequested {
+                            delegation_id: delegation_id.to_string(),
+                        },
+                    );
+                    return Ok(crate::delegation::format_delegation_failure_message(
+                        delegation_id,
+                        &format!("Timed out after {timeout_secs}s while waiting for delegation"),
+                    ));
+                }
+            }
+        } else {
+            events.recv().await
+        };
+
+        let event = match received {
+            Ok(event) => event,
+            Err(RecvError::Lagged(_)) => continue,
+            Err(RecvError::Closed) => {
+                return Err(Error::internal_error()
+                    .data("Event stream closed while waiting for delegation"));
+            }
+        };
+        if event.session_id() != session_id {
+            continue;
+        }
+
+        match event.kind() {
+            AgentEventKind::DelegationCompleted {
+                delegation_id: completed_id,
+                result,
+            } if completed_id == delegation_id => {
+                return Ok(crate::delegation::format_delegation_completion_message(
+                    completed_id,
+                    result.as_deref().unwrap_or("No summary provided."),
+                ));
+            }
+            AgentEventKind::DelegationFailed {
+                delegation_id: failed_id,
+                error,
+            } if failed_id == delegation_id => {
+                return Ok(crate::delegation::format_delegation_failure_message(
+                    failed_id, error,
+                ));
+            }
+            AgentEventKind::DelegationCancelled {
+                delegation_id: cancelled_id,
+            } if cancelled_id == delegation_id => {
+                return Ok(format!(
+                    "Delegation cancelled.\n\nDelegation ID: {cancelled_id}"
+                ));
+            }
+            _ => {}
+        }
     }
 }
 

--- a/crates/agent/src/agent/handle/mod.rs
+++ b/crates/agent/src/agent/handle/mod.rs
@@ -66,10 +66,8 @@ use std::any::Any;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 #[cfg(feature = "remote")]
-use tokio::sync::OnceCell;
-#[cfg(feature = "remote")]
 use tokio::sync::Semaphore;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, OnceCell, broadcast};
 
 /// Trait capturing the interface consumers actually use for agent interaction.
 ///
@@ -226,6 +224,9 @@ pub struct LocalAgentHandle {
     /// Handle to the scheduler actor, set after `start_scheduler()` succeeds.
     /// `None` if scheduling is not enabled or lease was not acquired.
     pub(crate) scheduler_handle: SchedulerHandleSlot,
+
+    /// Lazily-created orchestrator for direct slash-command delegations.
+    slash_delegation_orchestrator: OnceCell<Arc<crate::delegation::DelegationOrchestrator>>,
 
     /// Guard to ensure `shutdown()` only runs its body once.
     shutdown_done: AtomicBool,

--- a/crates/agent/src/agent/handle/send_agent_impl.rs
+++ b/crates/agent/src/agent/handle/send_agent_impl.rs
@@ -21,6 +21,14 @@ impl SendAgent for LocalAgentHandle {
     async fn prompt(&self, req: PromptRequest) -> Result<PromptResponse, Error> {
         let session_id = req.session_id.to_string();
         let session_ref = self.session_ref_for_agent_session(&session_id).await?;
+        if let Some(command) = crate::slash_commands::parse_builtin_invocation(&req) {
+            let command = command.map_err(|message| {
+                Error::invalid_params().data(serde_json::json!({ "message": message }))
+            })?;
+            return self
+                .execute_delegate_slash_command(req, session_ref, command)
+                .await;
+        }
         session_ref.prompt(req).await
     }
 

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -235,6 +235,88 @@ impl DelegationOrchestrator {
         .expect("delegation was not registered");
     }
 
+    /// Submit a delegation to an already resolved handle.
+    ///
+    /// Slash commands use this entry point so profile targets and remote handles
+    /// share the same execution, persistence, hook, and completion pipeline as
+    /// tool-originated delegations.
+    pub async fn submit_resolved(
+        &self,
+        parent_session_id: String,
+        delegation: Delegation,
+        target_handle: Arc<dyn crate::agent::handle::AgentHandle>,
+        child_profile_binding: Option<crate::profiles::SessionProfileBinding>,
+        inject_results: bool,
+    ) -> Result<(), String> {
+        match self.claim_delegation(&delegation.public_id).await? {
+            DelegationClaim::Claimed => {}
+            DelegationClaim::AlreadyClaimed => return Err("delegation was already claimed".into()),
+            DelegationClaim::NotFound => return Err("delegation record was not found".into()),
+            DelegationClaim::InvalidState(status) => {
+                return Err(format!("delegation is in invalid state {status:?}"));
+            }
+        }
+
+        let delegator = self.delegator.clone();
+        let event_sink = self.event_sink.clone();
+        let store = self.store.clone();
+        let tool_registry = self.tool_registry.clone();
+        let mut config = self.config.clone();
+        config.inject_results = inject_results;
+        let max_parallel = self.max_parallel.clone();
+        let delegation_summarizer = self.delegation_summarizer.clone();
+        let delegate_model_overrides = self.delegate_model_overrides.clone();
+        let routing_snapshot = self.routing_snapshot.clone();
+        let profile_id = self.profile_id.clone();
+        let parent_for_active = parent_session_id.clone();
+        let active_delegations = self.active_delegations.clone();
+        let active_for_task = active_delegations.clone();
+        let hooks = self.hooks.clone();
+        let delegation_id = delegation.public_id.clone();
+        let cancel_token = CancellationToken::new();
+        let cancel_for_active = cancel_token.clone();
+        let (start_tx, start_rx) = oneshot::channel();
+
+        let handle = tokio::spawn(async move {
+            if start_rx.await.is_err() {
+                return;
+            }
+            let _permit = match max_parallel.acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => return,
+            };
+            execute_delegation(
+                DelegationContext {
+                    delegator,
+                    event_sink,
+                    store,
+                    tool_registry,
+                    hooks,
+                    config,
+                    active_delegations: active_for_task,
+                    delegation_summarizer,
+                    delegate_model_overrides,
+                    profile_id,
+                    child_profile_binding,
+                    inject_results: Some(inject_results),
+                    routing_snapshot,
+                },
+                target_handle,
+                parent_session_id,
+                delegation,
+                cancel_token,
+            )
+            .await;
+        });
+
+        self.active_delegations.lock().await.insert(
+            delegation_id,
+            (parent_for_active, cancel_for_active, handle),
+        );
+        let _ = start_tx.send(());
+        Ok(())
+    }
+
     pub async fn cancel_active_delegations(&self) {
         self.begin_shutdown();
         let active = std::mem::take(&mut *self.active_delegations.lock().await);
@@ -522,6 +604,8 @@ impl DelegationOrchestrator {
                         delegation_summarizer,
                         delegate_model_overrides,
                         profile_id,
+                        child_profile_binding: None,
+                        inject_results: None,
                         routing_snapshot,
                     };
                     execute_delegation(
@@ -636,6 +720,8 @@ struct DelegationContext {
     delegation_summarizer: Option<Arc<super::summarizer::DelegationSummarizer>>,
     delegate_model_overrides: super::DelegateModelOverrideStore,
     profile_id: Option<String>,
+    child_profile_binding: Option<crate::profiles::SessionProfileBinding>,
+    inject_results: Option<bool>,
     routing_snapshot: Option<crate::agent::remote::RoutingSnapshotHandle>,
 }
 
@@ -849,8 +935,19 @@ async fn execute_delegation(
         }
     };
 
-    if let Some(profile_id) = ctx.profile_id.as_deref()
-        && let Err(err) = persist_delegate_runtime_binding(
+    let runtime_binding_result = if let Some(binding) = ctx.child_profile_binding.as_ref() {
+        ctx.store
+            .set_session_runtime_binding(
+                &child_session_id,
+                &binding.profile_id,
+                binding.agent_id.as_deref(),
+                binding.profile_fingerprint.as_deref(),
+                binding.provider_lock_digest.as_deref(),
+                binding.provider_locks_json.as_deref(),
+            )
+            .await
+    } else if let Some(profile_id) = ctx.profile_id.as_deref() {
+        persist_delegate_runtime_binding(
             ctx.store.as_ref(),
             &parent_session_id,
             &child_session_id,
@@ -858,7 +955,10 @@ async fn execute_delegation(
             &delegation.target_agent_id,
         )
         .await
-    {
+    } else {
+        Ok(())
+    };
+    if let Err(err) = runtime_binding_result {
         if let Err(shutdown_err) = session_ref.shutdown().await {
             tracing::warn!(
                 delegation_id = %delegation.public_id,
@@ -1358,7 +1458,7 @@ async fn execute_delegation(
                 },
             );
 
-            if ctx.config.inject_results {
+            if ctx.inject_results.unwrap_or(ctx.config.inject_results) {
                 inject_results(
                     &ctx.delegator,
                     &parent_session_id,

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -216,6 +216,10 @@ impl DelegationOrchestrator {
         self.shutting_down.store(true, Ordering::Release);
     }
 
+    pub fn wait_timeout_secs(&self) -> u64 {
+        self.config.wait_timeout_secs
+    }
+
     #[cfg(test)]
     async fn wait_until_registered(&self, delegation_id: &str) {
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -248,6 +252,16 @@ impl DelegationOrchestrator {
         child_profile_binding: Option<crate::profiles::SessionProfileBinding>,
         inject_results: bool,
     ) -> Result<(), String> {
+        if self.shutting_down.load(Ordering::Acquire) {
+            self.fail_unclaimed_delegation(
+                &delegation,
+                &parent_session_id,
+                "Delegation cancelled because the orchestrator is shutting down",
+            )
+            .await;
+            return Err("delegation orchestrator is shutting down".into());
+        }
+
         match self.claim_delegation(&delegation.public_id).await? {
             DelegationClaim::Claimed => {}
             DelegationClaim::AlreadyClaimed => return Err("delegation was already claimed".into()),
@@ -283,7 +297,24 @@ impl DelegationOrchestrator {
             }
             let _permit = match max_parallel.acquire_owned().await {
                 Ok(permit) => permit,
-                Err(_) => return,
+                Err(_) => {
+                    fail_delegation(
+                        DelegationFailureContext {
+                            event_sink: &event_sink,
+                            delegator: &delegator,
+                            store: &store,
+                            hooks: Some(&hooks),
+                            config: &config,
+                            parent_session_id: &parent_session_id,
+                            delegation_id: &delegation.public_id,
+                            target_agent_id: Some(&delegation.target_agent_id),
+                            objective: Some(&delegation.objective),
+                        },
+                        "Delegation queue closed before execution could start",
+                    )
+                    .await;
+                    return;
+                }
             };
             execute_delegation(
                 DelegationContext {
@@ -309,10 +340,32 @@ impl DelegationOrchestrator {
             .await;
         });
 
-        self.active_delegations.lock().await.insert(
+        let mut active = self.active_delegations.lock().await;
+        if self.shutting_down.load(Ordering::Acquire) {
+            handle.abort();
+            drop(active);
+            fail_delegation(
+                DelegationFailureContext {
+                    event_sink: &self.event_sink,
+                    delegator: &self.delegator,
+                    store: &self.store,
+                    hooks: None,
+                    config: &self.config,
+                    parent_session_id: &parent_for_active,
+                    delegation_id: &delegation_id,
+                    target_agent_id: None,
+                    objective: None,
+                },
+                "Delegation cancelled because the orchestrator is shutting down",
+            )
+            .await;
+            return Err("delegation orchestrator is shutting down".into());
+        }
+        active.insert(
             delegation_id,
             (parent_for_active, cancel_for_active, handle),
         );
+        drop(active);
         let _ = start_tx.send(());
         Ok(())
     }

--- a/crates/agent/src/slash_commands/acp.rs
+++ b/crates/agent/src/slash_commands/acp.rs
@@ -9,6 +9,7 @@ use crate::slash_commands::registry::SlashCommandRegistry;
 pub fn registry_to_acp_update(registry: &SlashCommandRegistry) -> AvailableCommandsUpdate {
     let mut commands: Vec<AvailableCommand> = registry
         .all()
+        .filter(|cmd| cmd.name != delegate::NAME)
         .map(|cmd| {
             let mut acp_cmd = AvailableCommand::new(format!("/{}", cmd.name), &cmd.description);
 
@@ -109,6 +110,30 @@ mod tests {
             .unwrap();
         // No argument hint and no $ARGUMENTS in template
         assert!(command.input.is_none());
+    }
+
+    #[test]
+    fn test_discovered_delegate_is_replaced_by_builtin() {
+        let mut registry = SlashCommandRegistry::new();
+        registry.register(make_command("delegate", "Discovered delegate", None));
+        registry.register(make_command("review", "Review changes", None));
+
+        let update = registry_to_acp_update(&registry);
+        assert_eq!(
+            update
+                .available_commands
+                .iter()
+                .filter(|command| command.name == "/delegate")
+                .count(),
+            1
+        );
+        assert_eq!(update.available_commands.len(), 2);
+        let delegate = update
+            .available_commands
+            .iter()
+            .find(|command| command.name == "/delegate")
+            .unwrap();
+        assert_eq!(delegate.description, super::delegate::DESCRIPTION);
     }
 
     #[test]

--- a/crates/agent/src/slash_commands/acp.rs
+++ b/crates/agent/src/slash_commands/acp.rs
@@ -2,11 +2,12 @@ use crate::acp::protocol::{
     AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, SessionId,
     SessionNotification, SessionUpdate, UnstructuredCommandInput,
 };
+use crate::slash_commands::builtin_commands::delegate;
 use crate::slash_commands::registry::SlashCommandRegistry;
 
 /// Convert the registry into an ACP `AvailableCommandsUpdate`.
 pub fn registry_to_acp_update(registry: &SlashCommandRegistry) -> AvailableCommandsUpdate {
-    let commands: Vec<AvailableCommand> = registry
+    let mut commands: Vec<AvailableCommand> = registry
         .all()
         .map(|cmd| {
             let mut acp_cmd = AvailableCommand::new(format!("/{}", cmd.name), &cmd.description);
@@ -20,6 +21,14 @@ pub fn registry_to_acp_update(registry: &SlashCommandRegistry) -> AvailableComma
             acp_cmd
         })
         .collect();
+    commands.push(
+        AvailableCommand::new(format!("/{}", delegate::NAME), delegate::DESCRIPTION).input(
+            AvailableCommandInput::Unstructured(UnstructuredCommandInput::new(
+                delegate::ARGUMENT_HINT,
+            )),
+        ),
+    );
+    commands.sort_by(|left, right| left.name.cmp(&right.name));
 
     AvailableCommandsUpdate::new(commands)
 }
@@ -61,10 +70,12 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_registry() {
+    fn test_empty_registry_still_advertises_builtins() {
         let registry = SlashCommandRegistry::new();
         let update = registry_to_acp_update(&registry);
-        assert!(update.available_commands.is_empty());
+        assert_eq!(update.available_commands.len(), 1);
+        assert_eq!(update.available_commands[0].name, "/delegate");
+        assert!(update.available_commands[0].input.is_some());
     }
 
     #[test]
@@ -73,10 +84,13 @@ mod tests {
         registry.register(make_command("review", "Review changes", Some("[scope]")));
 
         let update = registry_to_acp_update(&registry);
-        assert_eq!(update.available_commands.len(), 1);
+        assert_eq!(update.available_commands.len(), 2);
 
-        let cmd = &update.available_commands[0];
-        assert_eq!(cmd.name, "/review");
+        let cmd = update
+            .available_commands
+            .iter()
+            .find(|command| command.name == "/review")
+            .unwrap();
         assert_eq!(cmd.description, "Review changes");
         assert!(cmd.input.is_some());
     }
@@ -87,10 +101,14 @@ mod tests {
         registry.register(make_command("help", "Show help", None));
 
         let update = registry_to_acp_update(&registry);
-        assert_eq!(update.available_commands.len(), 1);
-        assert_eq!(update.available_commands[0].name, "/help");
+        assert_eq!(update.available_commands.len(), 2);
+        let command = update
+            .available_commands
+            .iter()
+            .find(|command| command.name == "/help")
+            .unwrap();
         // No argument hint and no $ARGUMENTS in template
-        assert!(update.available_commands[0].input.is_none());
+        assert!(command.input.is_none());
     }
 
     #[test]

--- a/crates/agent/src/slash_commands/builtin_commands/delegate.rs
+++ b/crates/agent/src/slash_commands/builtin_commands/delegate.rs
@@ -1,0 +1,151 @@
+use std::fmt;
+
+pub const NAME: &str = "delegate";
+pub const DESCRIPTION: &str = "Delegate a task to a profile or registered agent";
+pub const ARGUMENT_HINT: &str = "[--wait|--async] <profile:id|agent:id> <task>";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelegateMode {
+    Wait,
+    Async,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DelegateTarget {
+    Profile(String),
+    Agent(String),
+}
+
+impl DelegateTarget {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Profile(id) | Self::Agent(id) => id,
+        }
+    }
+}
+
+impl fmt::Display for DelegateTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Profile(id) => write!(f, "profile:{id}"),
+            Self::Agent(id) => write!(f, "agent:{id}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegateSlashCommand {
+    pub mode: DelegateMode,
+    pub target: DelegateTarget,
+    pub objective: String,
+}
+
+pub fn parse_delegate_command(arguments: &str) -> Result<DelegateSlashCommand, String> {
+    let trimmed = arguments.trim();
+    if trimmed.is_empty() {
+        return Err(usage("missing target and task"));
+    }
+
+    let mut mode = None;
+    let mut offset = 0;
+    let mut target_token = None;
+
+    for token in trimmed.split_whitespace() {
+        let token_start = trimmed[offset..]
+            .find(token)
+            .map(|index| offset + index)
+            .unwrap_or(offset);
+        offset = token_start + token.len();
+
+        match token {
+            "--wait" => set_mode(&mut mode, DelegateMode::Wait)?,
+            "--async" => set_mode(&mut mode, DelegateMode::Async)?,
+            value if value.starts_with("--") => {
+                return Err(usage(&format!("unknown option '{value}'")));
+            }
+            value => {
+                target_token = Some((value, offset));
+                break;
+            }
+        }
+    }
+
+    let Some((target_token, target_end)) = target_token else {
+        return Err(usage("missing target"));
+    };
+    let target = parse_target(target_token)?;
+    let objective = trimmed[target_end..].trim().to_string();
+    if objective.is_empty() {
+        return Err(usage("missing task"));
+    }
+
+    Ok(DelegateSlashCommand {
+        mode: mode.unwrap_or(DelegateMode::Wait),
+        target,
+        objective,
+    })
+}
+
+fn set_mode(mode: &mut Option<DelegateMode>, requested: DelegateMode) -> Result<(), String> {
+    if let Some(existing) = mode {
+        if *existing == requested {
+            return Err(usage("delegation mode was specified more than once"));
+        }
+        return Err(usage("--wait and --async cannot be used together"));
+    }
+    *mode = Some(requested);
+    Ok(())
+}
+
+fn parse_target(value: &str) -> Result<DelegateTarget, String> {
+    let (kind, id) = value
+        .split_once(':')
+        .ok_or_else(|| usage("target must use the profile: or agent: prefix"))?;
+    if id.trim().is_empty() {
+        return Err(usage("target id cannot be empty"));
+    }
+    match kind {
+        "profile" => Ok(DelegateTarget::Profile(id.to_string())),
+        "agent" => Ok(DelegateTarget::Agent(id.to_string())),
+        _ => Err(usage("target must use the profile: or agent: prefix")),
+    }
+}
+
+fn usage(message: &str) -> String {
+    format!("{message}. Usage: /{NAME} {ARGUMENT_HINT}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_profile_wait_by_default() {
+        let command = parse_delegate_command("profile:reviewer Review this branch").unwrap();
+        assert_eq!(command.mode, DelegateMode::Wait);
+        assert_eq!(command.target, DelegateTarget::Profile("reviewer".into()));
+        assert_eq!(command.objective, "Review this branch");
+    }
+
+    #[test]
+    fn parses_async_remote_agent_and_multiline_task() {
+        let command = parse_delegate_command(
+            "--async agent:gpu-coder Implement the fix\nand run the test suite",
+        )
+        .unwrap();
+        assert_eq!(command.mode, DelegateMode::Async);
+        assert_eq!(command.target, DelegateTarget::Agent("gpu-coder".into()));
+        assert_eq!(
+            command.objective,
+            "Implement the fix\nand run the test suite"
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_and_conflicting_inputs() {
+        assert!(parse_delegate_command("reviewer Review").is_err());
+        assert!(parse_delegate_command("--wait --async profile:reviewer Review").is_err());
+        assert!(parse_delegate_command("profile:reviewer").is_err());
+        assert!(parse_delegate_command("peer:reviewer Review").is_err());
+    }
+}

--- a/crates/agent/src/slash_commands/builtin_commands/mod.rs
+++ b/crates/agent/src/slash_commands/builtin_commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod delegate;
+
+pub use delegate::{DelegateMode, DelegateSlashCommand, DelegateTarget, parse_delegate_command};

--- a/crates/agent/src/slash_commands/expander.rs
+++ b/crates/agent/src/slash_commands/expander.rs
@@ -39,8 +39,10 @@ pub fn try_parse_invocation(
         return None;
     }
 
-    // Must exist in registry
-    registry.get(name)?;
+    // Must exist as a built-in or discovered command.
+    if !registry.contains(name) {
+        return None;
+    }
 
     let arguments = after_slash[name_end..].trim().to_string();
     let original_text = trimmed.to_string();

--- a/crates/agent/src/slash_commands/mod.rs
+++ b/crates/agent/src/slash_commands/mod.rs
@@ -31,6 +31,7 @@
 //! - [`acp`] — convert registry entries to ACP `AvailableCommandsUpdate`
 
 pub mod acp;
+pub mod builtin_commands;
 pub mod discovery;
 pub mod expander;
 pub mod parser;
@@ -38,6 +39,9 @@ pub mod registry;
 pub mod script;
 pub mod types;
 
+pub use builtin_commands::{
+    DelegateMode, DelegateSlashCommand, DelegateTarget, parse_delegate_command,
+};
 pub use discovery::{default_search_paths, discover_all, discover_from_source};
 pub use expander::{expand_invocation, try_expand, try_parse_invocation};
 pub use parser::parse_command_file;
@@ -46,3 +50,51 @@ pub use types::{
     CommandFrontmatter, SlashCommand, SlashCommandDiagnostic, SlashCommandExpansion,
     SlashCommandInvocation, SlashCommandScriptsConfig, SlashCommandSource, is_valid_command_name,
 };
+
+/// Parse the built-in command when the first prompt block is `/delegate`.
+pub fn parse_builtin_invocation(
+    req: &crate::acp::protocol::PromptRequest,
+) -> Option<Result<DelegateSlashCommand, String>> {
+    let crate::acp::protocol::ContentBlock::Text(text) = req.prompt.first()? else {
+        return None;
+    };
+    let trimmed = text.text.trim_start();
+    let rest = trimmed.strip_prefix("/delegate")?;
+    if rest
+        .chars()
+        .next()
+        .is_some_and(|character| !character.is_whitespace())
+    {
+        return None;
+    }
+    Some(parse_delegate_command(rest))
+}
+
+#[cfg(test)]
+mod builtin_tests {
+    use super::*;
+    use crate::acp::protocol::{ContentBlock, PromptRequest, TextContent};
+
+    fn request(text: &str) -> PromptRequest {
+        PromptRequest::new(
+            "session".to_string(),
+            vec![ContentBlock::Text(TextContent::new(text))],
+        )
+    }
+
+    #[test]
+    fn detects_delegate_prompt() {
+        let parsed =
+            parse_builtin_invocation(&request("/delegate --async agent:remote-coder run tests"))
+                .unwrap()
+                .unwrap();
+        assert_eq!(parsed.mode, DelegateMode::Async);
+        assert_eq!(parsed.target, DelegateTarget::Agent("remote-coder".into()));
+    }
+
+    #[test]
+    fn does_not_match_similar_command_name() {
+        assert!(parse_builtin_invocation(&request("/delegate-more task")).is_none());
+        assert!(parse_builtin_invocation(&request("ordinary prompt")).is_none());
+    }
+}

--- a/crates/agent/src/slash_commands/registry.rs
+++ b/crates/agent/src/slash_commands/registry.rs
@@ -1,3 +1,4 @@
+use crate::slash_commands::builtin_commands::delegate;
 use crate::slash_commands::discovery;
 use crate::slash_commands::types::{
     SlashCommand, SlashCommandDiagnostic, SlashCommandScriptsConfig, SlashCommandSource,
@@ -66,7 +67,12 @@ impl SlashCommandRegistry {
         })
     }
 
-    /// List all visible command names (sorted).
+    /// Return whether a built-in or discovered command exists.
+    pub fn contains(&self, name: &str) -> bool {
+        name == delegate::NAME || self.get(name).is_some()
+    }
+
+    /// List all visible discovered command names (sorted).
     pub fn names(&self) -> Vec<&str> {
         let mut names: Vec<&str> = self
             .by_name
@@ -91,7 +97,7 @@ impl SlashCommandRegistry {
         self.names().len()
     }
 
-    /// Whether the registry has no visible commands.
+    /// Whether the registry has no visible discovered commands.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/docs/docs/agent/delegation.md
+++ b/docs/docs/agent/delegation.md
@@ -11,6 +11,31 @@ Delegation allows agents to:
 - **Run in parallel** multiple delegations
 - **Route to remote agents** via mesh networking
 
+## Delegate from the prompt
+
+Use the built-in `/delegate` command to send a task directly to a configured profile or agent:
+
+```text
+/delegate [--wait|--async] <profile:id|agent:id> <task>
+```
+
+Examples:
+
+```text
+/delegate --wait profile:reviewer Review the current branch
+/delegate --async profile:multi-agent Investigate the failing integration tests
+/delegate --wait agent:gpu-coder Implement and benchmark the fix
+```
+
+`profile:<id>` loads a QueryMT profile. A multi-agent profile starts at its planner. `agent:<id>` targets an entry in the current agent registry, including configured remote agents. `--wait` waits for the result and lets the parent agent process it; `--async` completes the command turn immediately and injects the result in a later turn. The default is `--wait`.
+
+Remote execution supports both existing modes:
+
+- A remote `agent:<id>` runs the child session, model, and tools on the remote node.
+- A peer-routed delegate in a `profile:<id>` keeps the session and tools local while routing model calls to its configured peer.
+
+Both forms use the delegation orchestrator, including concurrency limits, hooks, persistence, cancellation, summaries, and result events.
+
 ## Architecture
 
 ```mermaid

--- a/docs/docs/agent/profiles.md
+++ b/docs/docs/agent/profiles.md
@@ -208,6 +208,18 @@ Profile names are resolved as:
 
 ## Using Profiles
 
+### Profiles as Subagents
+
+Profiles can be selected as subagents with the built-in slash command:
+
+```text
+/delegate --wait profile:reviewer Review the current changes
+/delegate --async profile:coder Implement the authentication tests
+/delegate --wait profile:multi-agent Investigate and fix the integration suite
+```
+
+Single-agent profiles run their configured agent. Multi-agent profiles run their planner, which can delegate further using its own local or remote delegate configuration. Use `agent:<id>` instead when targeting a registered agent directly, including a fully remote agent.
+
 ### CLI Usage
 
 #### List All Profiles


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `/delegate` command for assigning tasks to agents or profiles.
  - Supports synchronous waiting or asynchronous execution with completion updates.
  - Delegation supports remote agents, multi-agent profiles, and peer-routed profiles.
  - Added validation and clear usage errors for invalid commands, targets, and objectives.
  - The command appears in discovery with consistent metadata and no duplicate entries.

- **Bug Fixes**
  - Improved delegation timeout, cancellation, shutdown, and failure handling to prevent tasks from remaining active indefinitely.

- **Documentation**
  - Added guidance and examples for delegating tasks to agents and profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->