### PR TITLE
refactor: hooks

### DIFF
--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -50,6 +50,7 @@ tracing = { version = "0.1", features = ["attributes", "release_max_level_debug"
 serde.workspace = true
 serde_json.workspace = true
 schemars.workspace = true
+jsonschema = "0.52"
 tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream", "gzip", "brotli", "deflate"] }
 rusqlite = { version = "0.40", features = ["bundled", "uuid", "time"] }

--- a/crates/agent/src/agent/core.rs
+++ b/crates/agent/src/agent/core.rs
@@ -179,6 +179,7 @@ pub struct SessionRuntime {
     /// `tools/list_changed`.
     pub mcp_tool_state: Arc<McpToolState>,
     pub permission_cache: ParkingMutex<HashMap<String, bool>>,
+    pub tool_validator_cache: ParkingMutex<HashMap<String, Arc<jsonschema::Validator>>>,
     /// Workspace handle for duplicate code detection (built asynchronously on session start)
     pub workspace_handle: Arc<OnceCell<crate::index::WorkspaceHandle>>,
     /// Turn snapshot: (turn_id, snapshot_id) taken at the start of the turn for undo/redo
@@ -215,6 +216,7 @@ impl SessionRuntime {
             _mcp_services: mcp_services,
             mcp_tool_state,
             permission_cache: ParkingMutex::new(HashMap::new()),
+            tool_validator_cache: ParkingMutex::new(HashMap::new()),
             workspace_handle: Arc::new(OnceCell::new()),
             turn_snapshot: ParkingMutex::new(None),
             pre_turn_snapshot_task: ParkingMutex::new(None),

--- a/crates/agent/src/agent/execution/maintenance.rs
+++ b/crates/agent/src/agent/execution/maintenance.rs
@@ -129,6 +129,10 @@ pub(super) async fn run_ai_compaction(
             trigger: "context_threshold".to_string(),
             token_estimate: token_estimate_u32,
             message_count,
+            messages: messages
+                .iter()
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()?,
         })
         .await?;
     for notice in pre_hook.notices {
@@ -166,12 +170,6 @@ pub(super) async fn run_ai_compaction(
         },
     );
 
-    let llm_provider = exec_ctx
-        .session_handle
-        .provider()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get LLM provider: {}", e))?;
-
     let llm_config = exec_ctx
         .llm_config()
         .ok_or_else(|| anyhow::anyhow!("No LLM config for session"))?;
@@ -183,25 +181,37 @@ pub(super) async fn run_ai_compaction(
         .as_ref()
         .unwrap_or(&llm_config.model);
 
-    let retry_config = crate::session::compaction::RetryConfig {
-        max_retries: config.execution_policy.compaction.retry.max_retries,
-        initial_backoff_ms: config.execution_policy.compaction.retry.initial_backoff_ms,
-        backoff_multiplier: config.execution_policy.compaction.retry.backoff_multiplier,
+    let mut result = if let Some(summary) = pre_hook.custom_summary {
+        crate::session::compaction::CompactionResult {
+            summary_token_count: summary.len() / 4,
+            summary,
+            original_token_count: token_estimate,
+        }
+    } else {
+        let llm_provider = exec_ctx
+            .session_handle
+            .provider()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get LLM provider: {}", e))?;
+        let retry_config = crate::session::compaction::RetryConfig {
+            max_retries: config.execution_policy.compaction.retry.max_retries,
+            initial_backoff_ms: config.execution_policy.compaction.retry.initial_backoff_ms,
+            backoff_multiplier: config.execution_policy.compaction.retry.backoff_multiplier,
+        };
+        config
+            .compaction
+            .process(
+                &messages,
+                llm_provider,
+                model,
+                &retry_config,
+                exec_ctx
+                    .execution_config()
+                    .and_then(|cfg| cfg.max_prompt_bytes),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Compaction failed: {}", e))?
     };
-
-    let mut result = config
-        .compaction
-        .process(
-            &messages,
-            llm_provider,
-            model,
-            &retry_config,
-            exec_ctx
-                .execution_config()
-                .and_then(|cfg| cfg.max_prompt_bytes),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("Compaction failed: {}", e))?;
 
     let post_hook = config
         .hooks

--- a/crates/agent/src/agent/execution/mod.rs
+++ b/crates/agent/src/agent/execution/mod.rs
@@ -411,14 +411,14 @@ pub(crate) async fn execute_cycle_state_machine(
 
             ExecutionState::CallLlm {
                 ref context,
-                ref tools,
+                ref request,
             } => {
                 llm_request_count = llm_request_count.saturating_add(1);
-                task_completion_tool_available = has_effective_task_completion_tool(tools);
+                task_completion_tool_available = has_effective_task_completion_tool(&request.tools);
                 let span = tracing::Span::current();
                 span.record("llm_request_count", llm_request_count as u64);
                 span.record("completion_guard_available", task_completion_tool_available);
-                transitions::transition_call_llm(config, context, tools, exec_ctx).await?
+                transitions::transition_call_llm(config, context, request, exec_ctx).await?
             }
 
             ExecutionState::AfterLlm { .. } => {

--- a/crates/agent/src/agent/execution/tool_calls.rs
+++ b/crates/agent/src/agent/execution/tool_calls.rs
@@ -63,6 +63,7 @@ pub(super) async fn execute_tool_call(
         .hooks
         .run_pre_tool_use(PreToolUseRequest {
             session_id: exec_ctx.session_id.clone(),
+            mcp_tool_state: Some(exec_ctx.runtime.mcp_tool_state.clone()),
             turn_id: exec_ctx.turn_id().unwrap_or_default().to_string(),
             cwd: exec_ctx.cwd().map(|path| path.to_path_buf()),
             model: exec_ctx
@@ -88,13 +89,10 @@ pub(super) async fn execute_tool_call(
     if let Some(updated_input) = hook_result.updated_input {
         args = updated_input;
     }
-    if !hook_result.additional_contexts.is_empty() {
-        log::debug!(
-            "Session {}: ignoring {} pre-tool-use hook additional_context item(s) for MVP",
-            exec_ctx.session_id,
-            hook_result.additional_contexts.len()
-        );
-    }
+    let hook_allows_interactive = matches!(
+        hook_result.permission_decision,
+        Some(crate::hooks::engine::PreToolPermissionDecision::Allow)
+    );
     if hook_result.should_block {
         let reason = hook_result
             .block_reason
@@ -105,7 +103,25 @@ pub(super) async fn execute_tool_call(
             true,
             Some(call.function.name.clone()),
             Some(serde_json::to_string(&args).unwrap_or_else(|_| call.function.arguments.clone())),
-        ));
+        )
+        .with_execution(true, "blocked")
+        .with_hook_contexts(hook_result.context_contributions));
+    }
+
+    if let Err(error) = validate_tool_arguments(config, exec_ctx, &call.function.name, &args).await
+    {
+        return Ok(ToolResult::new(
+            call.id.clone(),
+            vec![Content::text(format!(
+                "Error: invalid tool arguments: {}",
+                error
+            ))],
+            true,
+            Some(call.function.name.clone()),
+            Some(serde_json::to_string(&args).unwrap_or_else(|_| call.function.arguments.clone())),
+        )
+        .with_execution(true, "validation")
+        .with_hook_contexts(hook_result.context_contributions));
     }
 
     let arguments_json =
@@ -288,23 +304,24 @@ pub(super) async fn execute_tool_call(
                 Ok(res) => (res, false, "mcp"),
                 Err(e) => (vec![Content::text(format!("Error: {}", e))], true, "mcp"),
             }
-        } else if !ensure_tool_permission(
-            config,
-            exec_ctx,
-            &call.id,
-            &call.function.name,
-            &args,
-            bridge,
-            exec_ctx.turn_id().unwrap_or_default(),
-        )
-        .instrument(info_span!(
-            "agent.tool.permission_wait",
-            tool_name = %call.function.name,
-            tool_call_id = %call.id,
-            session_id = %exec_ctx.session_id,
-        ))
-        .await
-        .map_err(|e| anyhow::anyhow!("Permission check failed: {}", e))?
+        } else if !hook_allows_interactive
+            && !ensure_tool_permission(
+                config,
+                exec_ctx,
+                &call.id,
+                &call.function.name,
+                &args,
+                bridge,
+                exec_ctx.turn_id().unwrap_or_default(),
+            )
+            .instrument(info_span!(
+                "agent.tool.permission_wait",
+                tool_name = %call.function.name,
+                tool_call_id = %call.id,
+                session_id = %exec_ctx.session_id,
+            ))
+            .await
+            .map_err(|e| anyhow::anyhow!("Permission check failed: {}", e))?
         {
             (
                 vec![Content::text("Error: permission denied")],
@@ -336,70 +353,16 @@ pub(super) async fn execute_tool_call(
     span.record("tool_source", tool_source);
     span.record("is_error", is_error);
 
-    // Apply Layer 1 truncation to text content blocks.
-    let result_blocks = if !is_error {
-        use crate::tools::builtins::helpers::{
-            TruncationDirection, format_truncation_message_with_overflow, save_overflow_output,
-            truncate_output,
-        };
-        let tc = &config.execution_policy.tool_output;
-
-        let raw_text: String = raw_result_blocks
-            .iter()
-            .filter_map(|b| b.as_text())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let truncation = truncate_output(
-            &raw_text,
-            tc.max_lines,
-            tc.max_bytes,
-            TruncationDirection::Head,
-        );
-
-        if truncation.was_truncated {
-            let overflow = save_overflow_output(
-                &raw_text,
-                &tc.overflow_storage,
-                &exec_ctx.session_id,
-                &call.id,
-                None,
-            );
-
-            let tool_hint = config
-                .tool_registry
-                .find(&call.function.name)
-                .and_then(|t| t.truncation_hint());
-
-            let suffix = format_truncation_message_with_overflow(
-                &truncation,
-                TruncationDirection::Head,
-                Some(&overflow),
-                tool_hint,
-            );
-
-            let mut blocks: Vec<Content> = raw_result_blocks
-                .into_iter()
-                .filter(|b| b.as_text().is_none())
-                .collect();
-            blocks.insert(
-                0,
-                Content::text(format!("{}{}", truncation.content, suffix)),
-            );
-            blocks
-        } else {
-            raw_result_blocks
-        }
-    } else {
-        raw_result_blocks
-    };
-
-    let mut result_blocks = result_blocks;
+    // Post hooks inspect the complete canonical output; truncation is applied once
+    // after the transformation pipeline.
+    let execution_is_error = is_error;
+    let mut result_blocks = raw_result_blocks;
     let mut is_error = is_error;
     let post_hook = config
         .hooks
         .run_post_tool_use(PostToolUseRequest {
             session_id: exec_ctx.session_id.clone(),
+            mcp_tool_state: Some(exec_ctx.runtime.mcp_tool_state.clone()),
             turn_id: exec_ctx.turn_id().unwrap_or_default().to_string(),
             cwd: exec_ctx.cwd().map(|path| path.to_path_buf()),
             model: exec_ctx
@@ -409,13 +372,10 @@ pub(super) async fn execute_tool_call(
             permission_mode: exec_ctx.permission_mode().to_string(),
             tool_name: call.function.name.clone(),
             tool_input: args.clone(),
-            tool_response: serde_json::Value::String(
-                result_blocks
-                    .iter()
-                    .filter_map(|b| b.as_text())
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-            ),
+            content: result_blocks.clone(),
+            is_error,
+            execution_is_error,
+            tool_source: tool_source.to_string(),
             tool_use_id: call.id.clone(),
         })
         .await?;
@@ -429,22 +389,20 @@ pub(super) async fn execute_tool_call(
             },
         );
     }
-    if !post_hook.additional_contexts.is_empty() {
-        log::debug!(
-            "Session {}: ignoring {} post-tool-use hook additional_context item(s) for MVP",
-            exec_ctx.session_id,
-            post_hook.additional_contexts.len()
-        );
+    if let Some(content) = post_hook.content {
+        result_blocks = content;
     }
-    if post_hook.should_block {
-        is_error = true;
-        result_blocks = vec![Content::text(format!(
-            "Error: {}",
-            post_hook
-                .block_reason
-                .unwrap_or_else(|| "tool result blocked by hook".to_string())
-        ))];
+    if let Some(model_is_error) = post_hook.is_error {
+        is_error = model_is_error;
     }
+    result_blocks = truncate_model_tool_output(
+        config,
+        exec_ctx,
+        &call.id,
+        &call.function.name,
+        result_blocks,
+        is_error,
+    );
 
     // Extract text summary for event (display purposes)
     let result_text: String = result_blocks
@@ -507,13 +465,17 @@ pub(super) async fn execute_tool_call(
         SnapshotState::None => None,
     };
 
+    let mut hook_contexts = hook_result.context_contributions;
+    hook_contexts.extend(post_hook.context_contributions);
     let mut tool_result = ToolResult::new(
         call.id.clone(),
         result_blocks,
         is_error,
         Some(call.function.name.clone()),
         Some(arguments_json.clone()),
-    );
+    )
+    .with_execution(execution_is_error, tool_source)
+    .with_hook_contexts(hook_contexts);
     if let Some(part) = snapshot_part {
         tool_result = tool_result.with_snapshot(part);
     }
@@ -521,6 +483,110 @@ pub(super) async fn execute_tool_call(
     Span::current().record("has_snapshot", tool_result.snapshot_part.is_some());
 
     Ok(tool_result)
+}
+
+async fn validate_tool_arguments(
+    config: &AgentConfig,
+    exec_ctx: &ExecutionContext,
+    tool_name: &str,
+    arguments: &serde_json::Value,
+) -> anyhow::Result<()> {
+    let schema = config
+        .tool_registry
+        .find(tool_name)
+        .map(|tool| tool.definition().function.parameters)
+        .or_else(|| {
+            exec_ctx
+                .runtime
+                .mcp_tool_state
+                .load()
+                .tool_defs
+                .iter()
+                .find(|tool| tool.function.name == tool_name)
+                .map(|tool| tool.function.parameters.clone())
+        });
+    let schema = match schema {
+        Some(schema) => Some(schema),
+        None => exec_ctx
+            .session_handle
+            .provider()
+            .await
+            .ok()
+            .and_then(|provider| {
+                provider.tools().and_then(|tools| {
+                    tools
+                        .iter()
+                        .find(|tool| tool.function.name == tool_name)
+                        .map(|tool| tool.function.parameters.clone())
+                })
+            }),
+    };
+    let Some(schema) = schema else {
+        return Ok(());
+    };
+    let validator = jsonschema::validator_for(&schema)
+        .map_err(|error| anyhow::anyhow!("invalid tool schema: {}", error))?;
+    validator
+        .validate(arguments)
+        .map_err(|error| anyhow::anyhow!(error.to_string()))
+}
+
+fn truncate_model_tool_output(
+    config: &AgentConfig,
+    exec_ctx: &ExecutionContext,
+    call_id: &str,
+    tool_name: &str,
+    blocks: Vec<Content>,
+    is_error: bool,
+) -> Vec<Content> {
+    if is_error {
+        return blocks;
+    }
+    use crate::tools::builtins::helpers::{
+        TruncationDirection, format_truncation_message_with_overflow, save_overflow_output,
+        truncate_output,
+    };
+    let policy = &config.execution_policy.tool_output;
+    let raw_text = blocks
+        .iter()
+        .filter_map(Content::as_text)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let truncation = truncate_output(
+        &raw_text,
+        policy.max_lines,
+        policy.max_bytes,
+        TruncationDirection::Head,
+    );
+    if !truncation.was_truncated {
+        return blocks;
+    }
+    let overflow = save_overflow_output(
+        &raw_text,
+        &policy.overflow_storage,
+        &exec_ctx.session_id,
+        call_id,
+        None,
+    );
+    let hint = config
+        .tool_registry
+        .find(tool_name)
+        .and_then(|tool| tool.truncation_hint());
+    let suffix = format_truncation_message_with_overflow(
+        &truncation,
+        TruncationDirection::Head,
+        Some(&overflow),
+        hint,
+    );
+    let mut result: Vec<Content> = blocks
+        .into_iter()
+        .filter(|block| block.as_text().is_none())
+        .collect();
+    result.insert(
+        0,
+        Content::text(format!("{}{}", truncation.content, suffix)),
+    );
+    result
 }
 
 /// Check if a tool call requires permission and request it if needed.
@@ -581,6 +647,7 @@ pub(super) async fn ensure_tool_permission(
         .hooks
         .run_permission_request(crate::hooks::PermissionRequestRequest {
             session_id: exec_ctx.session_id.clone(),
+            mcp_tool_state: Some(exec_ctx.runtime.mcp_tool_state.clone()),
             turn_id: turn_id.to_string(),
             cwd: exec_ctx.cwd().map(|path| path.to_path_buf()),
             model: exec_ctx
@@ -741,7 +808,7 @@ pub(super) async fn record_tool_side_effects(
     result: &mut ToolResult,
     exec_ctx: &ExecutionContext,
 ) -> Result<Option<WaitCondition>, anyhow::Error> {
-    if result.is_error {
+    if result.execution_is_error {
         return Ok(None);
     }
 
@@ -961,6 +1028,18 @@ pub(super) async fn store_all_tool_results(
             compacted_at: None,
         })
         .collect();
+    let hook_context_parts = adjusted_results.iter().flat_map(|result| {
+        result
+            .hook_contexts
+            .iter()
+            .map(|context| MessagePart::HookContext {
+                event_name: context.event_name.clone(),
+                handler_id: context.handler_id.clone(),
+                tool_use_id: context.tool_use_id.clone(),
+                content: context.content.clone(),
+            })
+    });
+    result_parts.extend(hook_context_parts);
     let snapshot_parts: Vec<_> = adjusted_results
         .iter()
         .filter_map(|result| result.snapshot_part.clone())

--- a/crates/agent/src/agent/execution/tool_calls.rs
+++ b/crates/agent/src/agent/execution/tool_calls.rs
@@ -304,24 +304,26 @@ pub(super) async fn execute_tool_call(
                 Ok(res) => (res, false, "mcp"),
                 Err(e) => (vec![Content::text(format!("Error: {}", e))], true, "mcp"),
             }
-        } else if !hook_allows_interactive
-            && !ensure_tool_permission(
-                config,
-                exec_ctx,
-                &call.id,
-                &call.function.name,
-                &args,
-                bridge,
-                exec_ctx.turn_id().unwrap_or_default(),
-            )
-            .instrument(info_span!(
-                "agent.tool.permission_wait",
-                tool_name = %call.function.name,
-                tool_call_id = %call.id,
-                session_id = %exec_ctx.session_id,
-            ))
-            .await
-            .map_err(|e| anyhow::anyhow!("Permission check failed: {}", e))?
+        } else if !ensure_tool_permission(
+            config,
+            exec_ctx,
+            &call.id,
+            &call.function.name,
+            &args,
+            bridge,
+            PermissionContext {
+                turn_id: exec_ctx.turn_id().unwrap_or_default(),
+                bypass_interactive_prompt: hook_allows_interactive,
+            },
+        )
+        .instrument(info_span!(
+            "agent.tool.permission_wait",
+            tool_name = %call.function.name,
+            tool_call_id = %call.id,
+            session_id = %exec_ctx.session_id,
+        ))
+        .await
+        .map_err(|e| anyhow::anyhow!("Permission check failed: {}", e))?
         {
             (
                 vec![Content::text("Error: permission denied")],
@@ -402,7 +404,8 @@ pub(super) async fn execute_tool_call(
         &call.function.name,
         result_blocks,
         is_error,
-    );
+    )
+    .await;
 
     // Extract text summary for event (display purposes)
     let result_text: String = result_blocks
@@ -524,14 +527,32 @@ async fn validate_tool_arguments(
     let Some(schema) = schema else {
         return Ok(());
     };
-    let validator = jsonschema::validator_for(&schema)
-        .map_err(|error| anyhow::anyhow!("invalid tool schema: {}", error))?;
+    let schema_key = serde_json::to_string(&schema)?;
+    let validator = {
+        let cache = exec_ctx.runtime.tool_validator_cache.lock();
+        cache.get(&schema_key).cloned()
+    };
+    let validator = match validator {
+        Some(validator) => validator,
+        None => {
+            let validator = Arc::new(
+                jsonschema::validator_for(&schema)
+                    .map_err(|error| anyhow::anyhow!("invalid tool schema: {}", error))?,
+            );
+            exec_ctx
+                .runtime
+                .tool_validator_cache
+                .lock()
+                .insert(schema_key, validator.clone());
+            validator
+        }
+    };
     validator
         .validate(arguments)
         .map_err(|error| anyhow::anyhow!(error.to_string()))
 }
 
-fn truncate_model_tool_output(
+async fn truncate_model_tool_output(
     config: &AgentConfig,
     exec_ctx: &ExecutionContext,
     call_id: &str,
@@ -561,12 +582,25 @@ fn truncate_model_tool_output(
     if !truncation.was_truncated {
         return blocks;
     }
-    let overflow = save_overflow_output(
-        &raw_text,
-        &policy.overflow_storage,
-        &exec_ctx.session_id,
-        call_id,
-        None,
+    let overflow_content = raw_text.clone();
+    let overflow_storage = policy.overflow_storage.clone();
+    let overflow_session_id = exec_ctx.session_id.clone();
+    let overflow_call_id = call_id.to_string();
+    let overflow = tokio::task::spawn_blocking(move || {
+        save_overflow_output(
+            &overflow_content,
+            &overflow_storage,
+            &overflow_session_id,
+            &overflow_call_id,
+            None,
+        )
+    })
+    .await
+    .unwrap_or_else(
+        |error| crate::tools::builtins::helpers::OverflowSaveResult {
+            path: None,
+            error: Some(format!("Failed to join overflow writer: {}", error)),
+        },
     );
     let hint = config
         .tool_registry
@@ -589,12 +623,17 @@ fn truncate_model_tool_output(
     result
 }
 
+pub(super) struct PermissionContext<'a> {
+    turn_id: &'a str,
+    bypass_interactive_prompt: bool,
+}
+
 /// Check if a tool call requires permission and request it if needed.
 ///
 /// Returns `true` if permission is granted (or not required), `false` if denied.
 #[instrument(
     name = "agent.tool.permission",
-    skip(config, exec_ctx, args, bridge),
+    skip(config, exec_ctx, args, bridge, permission),
     fields(
         session_id = %exec_ctx.session_id,
         tool_name = %tool_name,
@@ -611,7 +650,7 @@ pub(super) async fn ensure_tool_permission(
     tool_name: &str,
     args: &serde_json::Value,
     bridge: Option<&ClientBridgeSender>,
-    turn_id: &str,
+    permission: PermissionContext<'_>,
 ) -> Result<bool, agent_client_protocol::Error> {
     use crate::acp::protocol::{
         PermissionOption, PermissionOptionId, PermissionOptionKind, RequestPermissionOutcome,
@@ -643,12 +682,17 @@ pub(super) async fn ensure_tool_permission(
     }
     Span::current().record("cache_hit", false);
 
+    if permission.bypass_interactive_prompt {
+        Span::current().record("granted", true);
+        return Ok(true);
+    }
+
     let hook_decision = config
         .hooks
         .run_permission_request(crate::hooks::PermissionRequestRequest {
             session_id: exec_ctx.session_id.clone(),
             mcp_tool_state: Some(exec_ctx.runtime.mcp_tool_state.clone()),
-            turn_id: turn_id.to_string(),
+            turn_id: permission.turn_id.to_string(),
             cwd: exec_ctx.cwd().map(|path| path.to_path_buf()),
             model: exec_ctx
                 .llm_config()

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -264,7 +264,7 @@ pub(super) async fn transition_call_llm(
     exec_ctx: &ExecutionContext,
 ) -> Result<ExecutionState, anyhow::Error> {
     let session_id = &exec_ctx.session_id;
-    let request_messages = request.messages.to_vec();
+    let request_messages = request.messages.as_ref();
     let tools = &request.tools;
     debug!(
         "CallLlm: session={}, messages={}",
@@ -480,7 +480,7 @@ pub(super) async fn transition_call_llm(
                 }
 
                 let mut stream = match provider
-                    .chat_stream_with_tools(&messages_with_cache, Some(tools.as_ref()))
+                    .chat_stream_with_tools(messages_with_cache, Some(tools.as_ref()))
                     .await
                 {
                     Ok(stream) => stream,

--- a/crates/agent/src/agent/execution/transitions.rs
+++ b/crates/agent/src/agent/execution/transitions.rs
@@ -13,8 +13,8 @@ use crate::agent::session_actor::ensure_pre_turn_snapshot_ready;
 use crate::agent::utils::u32_from_usize;
 use crate::events::{AgentEventKind, ExecutionMetrics, StopType};
 use crate::middleware::{
-    ExecutionState, LlmResponse, ToolCall as MiddlewareToolCall, ToolFunction, ToolResult,
-    calculate_context_tokens,
+    ExecutionState, LlmResponse, PreparedModelRequest, ToolCall as MiddlewareToolCall,
+    ToolFunction, ToolResult, calculate_context_tokens,
 };
 use crate::model::{AgentMessage, MessagePart};
 use anyhow::Context as _;
@@ -115,9 +115,65 @@ pub(super) async fn transition_before_llm_call(
         );
     }
 
+    let mut messages = context.request_messages();
+    let trigger = if messages.last().is_some_and(|message| {
+        message
+            .content
+            .iter()
+            .any(querymt::chat::Content::is_tool_result)
+    }) {
+        "after_tool_batch"
+    } else {
+        "user_prompt"
+    };
+    let context_window = crate::model_info::get_model_info(&context.provider, &context.model)
+        .and_then(|info| info.limits.context)
+        .unwrap_or(u32::MAX as u64)
+        .min(u32::MAX as u64) as u32;
+    let hook_result = config
+        .hooks
+        .run_context(crate::hooks::ContextHookRequest {
+            session_id: exec_ctx.session_id.clone(),
+            mcp_tool_state: Some(exec_ctx.runtime.mcp_tool_state.clone()),
+            turn_id: exec_ctx.turn_id().unwrap_or_default().to_string(),
+            cwd: exec_ctx.cwd().map(|path| path.to_path_buf()),
+            model: context.model.to_string(),
+            permission_mode: exec_ctx.permission_mode().to_string(),
+            trigger: trigger.to_string(),
+            context_window,
+            messages,
+        })
+        .await?;
+    for notice in hook_result.notices {
+        config.emit_event(
+            &exec_ctx.session_id,
+            AgentEventKind::HookNotice {
+                event_name: notice.event_name,
+                message: notice.message,
+                is_error: notice.is_error,
+            },
+        );
+    }
+    messages = hook_result.messages.unwrap_or_default();
+    if hook_result.estimated_tokens > context_window as usize {
+        return Ok(ExecutionState::Stopped {
+            message: format!(
+                "Prepared request is approximately {} tokens, exceeding the {} token context window",
+                hook_result.estimated_tokens, context_window
+            )
+            .into(),
+            stop_type: StopType::ContextThreshold,
+            context: Some(context.clone()),
+        });
+    }
+    let messages = apply_cache_breakpoints(&messages);
     Ok(ExecutionState::CallLlm {
         context: context.clone(),
-        tools: Arc::from(tools.into_boxed_slice()),
+        request: Arc::new(PreparedModelRequest {
+            messages: Arc::from(messages.into_boxed_slice()),
+            tools: Arc::from(tools.into_boxed_slice()),
+            estimated_tokens: hook_result.estimated_tokens,
+        }),
     })
 }
 
@@ -192,32 +248,24 @@ fn validate_stream_terminal(
 /// tracks usage/costs, and emits LlmRequestStart/End events.
 #[instrument(
     name = "agent.transition.call_llm",
-    skip(config, context, tools, exec_ctx),
+    skip(config, context, request, exec_ctx),
     fields(
         session_id = %exec_ctx.session_id,
         provider = %context.provider,
         model = %context.model,
         message_count = context.messages.len(),
-        tool_count = tools.len()
+        tool_count = request.tools.len()
     )
 )]
 pub(super) async fn transition_call_llm(
     config: &AgentConfig,
     context: &Arc<crate::middleware::ConversationContext>,
-    tools: &Arc<[querymt::chat::Tool]>,
+    request: &Arc<PreparedModelRequest>,
     exec_ctx: &ExecutionContext,
 ) -> Result<ExecutionState, anyhow::Error> {
     let session_id = &exec_ctx.session_id;
-    let (stable_messages, latest_message) = context
-        .messages
-        .split_last()
-        .map(|(latest, stable)| (stable, Some(latest.clone())))
-        .unwrap_or((&[], None));
-    let mut request_messages = apply_cache_breakpoints(stable_messages);
-    request_messages.extend(context.fragment_messages());
-    if let Some(latest_message) = latest_message {
-        request_messages.push(latest_message);
-    }
+    let request_messages = request.messages.to_vec();
+    let tools = &request.tools;
     debug!(
         "CallLlm: session={}, messages={}",
         session_id,

--- a/crates/agent/src/agent/handle/send_agent_lifecycle.rs
+++ b/crates/agent/src/agent/handle/send_agent_lifecycle.rs
@@ -229,7 +229,9 @@ impl LocalAgentHandle {
     ) -> Result<CloseSessionResponse, Error> {
         let session_id = req.session_id.to_string();
         let result = self.stop_session(&session_id).await;
-        self.run_session_end_hook(&session_id, "close").await?;
+        if let Err(error) = self.run_session_end_hook(&session_id, "close").await {
+            tracing::warn!(session_id, %error, "session_end hook failed during close");
+        }
         self.clear_delegate_model_overrides(&session_id).await;
         result?;
         Ok(CloseSessionResponse::new())
@@ -244,7 +246,9 @@ impl LocalAgentHandle {
         // Closing is best-effort: deleting persisted history is the primary intent.
         // Route through the session binding so delegated runtimes are released too.
         let _ = self.stop_session(&session_id).await;
-        self.run_session_end_hook(&session_id, "delete").await?;
+        if let Err(error) = self.run_session_end_hook(&session_id, "delete").await {
+            tracing::warn!(session_id, %error, "session_end hook failed during delete");
+        }
 
         let exists = self
             .config

--- a/crates/agent/src/agent/handle/send_agent_lifecycle.rs
+++ b/crates/agent/src/agent/handle/send_agent_lifecycle.rs
@@ -190,12 +190,46 @@ impl LocalAgentHandle {
             .config_options(config_options))
     }
 
+    async fn run_session_end_hook(&self, session_id: &str, reason: &str) -> Result<(), Error> {
+        let permission_mode = {
+            let mode = *self
+                .default_mode
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            crate::hooks::permission_mode_label(mode).to_string()
+        };
+        let result = self
+            .config
+            .hooks
+            .run_session_end(crate::hooks::SessionEndRequest {
+                session_id: session_id.to_string(),
+                cwd: None,
+                model: String::new(),
+                permission_mode,
+                reason: reason.to_string(),
+            })
+            .await
+            .map_err(|error| Error::internal_error().data(error.to_string()))?;
+        for notice in result.notices {
+            self.config.emit_event(
+                session_id,
+                crate::events::AgentEventKind::HookNotice {
+                    event_name: notice.event_name,
+                    message: notice.message,
+                    is_error: notice.is_error,
+                },
+            );
+        }
+        Ok(())
+    }
+
     pub(super) async fn handle_close_session(
         &self,
         req: CloseSessionRequest,
     ) -> Result<CloseSessionResponse, Error> {
         let session_id = req.session_id.to_string();
         let result = self.stop_session(&session_id).await;
+        self.run_session_end_hook(&session_id, "close").await?;
         self.clear_delegate_model_overrides(&session_id).await;
         result?;
         Ok(CloseSessionResponse::new())
@@ -210,6 +244,7 @@ impl LocalAgentHandle {
         // Closing is best-effort: deleting persisted history is the primary intent.
         // Route through the session binding so delegated runtimes are released too.
         let _ = self.stop_session(&session_id).await;
+        self.run_session_end_hook(&session_id, "delete").await?;
 
         let exists = self
             .config

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -2034,14 +2034,6 @@ async fn execute_prompt_detached(
         );
         return Err(AgentError::Internal(reason));
     }
-    if !hook_result.additional_contexts.is_empty() {
-        log::debug!(
-            "Session {}: ignoring {} hook additional_context item(s) for MVP",
-            session_id,
-            hook_result.additional_contexts.len()
-        );
-    }
-
     config.emit_event(
         &session_id,
         AgentEventKind::PromptReceived {
@@ -2050,13 +2042,25 @@ async fn execute_prompt_detached(
         },
     );
 
+    let mut parts = vec![MessagePart::Prompt {
+        blocks: req.prompt.clone(),
+    }];
+    parts.extend(
+        hook_result
+            .context_contributions
+            .into_iter()
+            .map(|context| MessagePart::HookContext {
+                event_name: context.event_name,
+                handler_id: context.handler_id,
+                tool_use_id: context.tool_use_id,
+                content: context.content,
+            }),
+    );
     let agent_msg = AgentMessage {
         id: message_id.clone(),
         session_id: session_id.clone(),
         role: ChatRole::User,
-        parts: vec![MessagePart::Prompt {
-            blocks: req.prompt.clone(),
-        }],
+        parts,
         created_at: time::OffsetDateTime::now_utc().unix_timestamp(),
         parent_message_id: None,
         source_provider: None,

--- a/crates/agent/src/agent/session_materializer.rs
+++ b/crates/agent/src/agent/session_materializer.rs
@@ -647,13 +647,6 @@ impl SessionMaterializer {
                     },
                 );
             }
-            if !hook_result.additional_contexts.is_empty() {
-                log::debug!(
-                    "Session {}: ignoring {} session-start hook additional_context item(s) for MVP",
-                    prepared.session_id,
-                    hook_result.additional_contexts.len()
-                );
-            }
             if let Some(stop_reason) = hook_result.stop_reason {
                 log::warn!(
                     "Session {}: session-start hook requested stop: {}",

--- a/crates/agent/src/hooks/config.rs
+++ b/crates/agent/src/hooks/config.rs
@@ -12,6 +12,7 @@ pub struct HooksConfig {
     pub pre_tool_use: Vec<MatcherGroupConfig>,
     pub permission_request: Vec<MatcherGroupConfig>,
     pub post_tool_use: Vec<MatcherGroupConfig>,
+    pub context: Vec<MatcherGroupConfig>,
     pub stop: Vec<MatcherGroupConfig>,
     pub pre_compaction: Vec<MatcherGroupConfig>,
     pub post_compaction: Vec<MatcherGroupConfig>,
@@ -19,6 +20,7 @@ pub struct HooksConfig {
     pub delegation_start: Vec<MatcherGroupConfig>,
     pub post_delegation: Vec<MatcherGroupConfig>,
     pub delegation_failure: Vec<MatcherGroupConfig>,
+    pub session_end: Vec<MatcherGroupConfig>,
     #[schemars(skip)]
     #[serde(flatten)]
     pub extra: BTreeMap<String, serde_json::Value>,
@@ -35,15 +37,30 @@ pub struct MatcherGroupConfig {
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum HookHandlerConfig {
     Command(HookCommandConfig),
+    McpTool(HookMcpToolConfig),
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct HookCommandConfig {
+    pub id: Option<String>,
     pub command: String,
     pub timeout_sec: Option<u64>,
     pub status_message: Option<String>,
+    pub additional_context_limit: Option<u32>,
     pub env: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct HookMcpToolConfig {
+    pub id: Option<String>,
+    pub server: String,
+    pub tool: String,
+    pub input: Option<serde_json::Value>,
+    pub timeout_sec: Option<u64>,
+    pub status_message: Option<String>,
+    pub additional_context_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -53,6 +70,7 @@ pub enum HookEventConfig {
     PreToolUse,
     PermissionRequest,
     PostToolUse,
+    Context,
     Stop,
     PreCompaction,
     PostCompaction,
@@ -60,6 +78,7 @@ pub enum HookEventConfig {
     DelegationStart,
     PostDelegation,
     DelegationFailure,
+    SessionEnd,
 }
 
 impl HookEventConfig {
@@ -70,6 +89,7 @@ impl HookEventConfig {
             Self::PreToolUse => "pre_tool_use",
             Self::PermissionRequest => "permission_request",
             Self::PostToolUse => "post_tool_use",
+            Self::Context => "context",
             Self::Stop => "stop",
             Self::PreCompaction => "pre_compaction",
             Self::PostCompaction => "post_compaction",
@@ -77,8 +97,26 @@ impl HookEventConfig {
             Self::DelegationStart => "delegation_start",
             Self::PostDelegation => "post_delegation",
             Self::DelegationFailure => "delegation_failure",
+            Self::SessionEnd => "session_end",
         }
     }
+}
+
+fn validate_handler_fields(
+    event: HookEventConfig,
+    id: Option<&str>,
+    additional_context_limit: Option<u32>,
+) -> anyhow::Result<()> {
+    if id.is_some_and(|id| id.trim().is_empty()) {
+        anyhow::bail!("{} hook id must not be empty", event.label());
+    }
+    if additional_context_limit == Some(0) {
+        anyhow::bail!(
+            "{} hook additional_context_limit must be greater than zero",
+            event.label()
+        );
+    }
+    Ok(())
 }
 
 impl HooksConfig {
@@ -89,6 +127,7 @@ impl HooksConfig {
             HookEventConfig::PreToolUse => &self.pre_tool_use,
             HookEventConfig::PermissionRequest => &self.permission_request,
             HookEventConfig::PostToolUse => &self.post_tool_use,
+            HookEventConfig::Context => &self.context,
             HookEventConfig::Stop => &self.stop,
             HookEventConfig::PreCompaction => &self.pre_compaction,
             HookEventConfig::PostCompaction => &self.post_compaction,
@@ -96,6 +135,7 @@ impl HooksConfig {
             HookEventConfig::DelegationStart => &self.delegation_start,
             HookEventConfig::PostDelegation => &self.post_delegation,
             HookEventConfig::DelegationFailure => &self.delegation_failure,
+            HookEventConfig::SessionEnd => &self.session_end,
         }
     }
 
@@ -112,6 +152,7 @@ impl HooksConfig {
             HookEventConfig::PreToolUse,
             HookEventConfig::PermissionRequest,
             HookEventConfig::PostToolUse,
+            HookEventConfig::Context,
             HookEventConfig::Stop,
             HookEventConfig::PreCompaction,
             HookEventConfig::PostCompaction,
@@ -119,6 +160,7 @@ impl HooksConfig {
             HookEventConfig::DelegationStart,
             HookEventConfig::PostDelegation,
             HookEventConfig::DelegationFailure,
+            HookEventConfig::SessionEnd,
         ] {
             for (group_idx, group) in self.groups_for(event).iter().enumerate() {
                 if group.hooks.is_empty() {
@@ -134,6 +176,36 @@ impl HooksConfig {
                             if cmd.command.trim().is_empty() {
                                 anyhow::bail!("{} hook command must not be empty", event.label());
                             }
+                            validate_handler_fields(
+                                event,
+                                cmd.id.as_deref(),
+                                cmd.additional_context_limit,
+                            )?;
+                        }
+                        HookHandlerConfig::McpTool(mcp) => {
+                            if !matches!(
+                                event,
+                                HookEventConfig::PreToolUse
+                                    | HookEventConfig::PermissionRequest
+                                    | HookEventConfig::PostToolUse
+                                    | HookEventConfig::Context
+                            ) {
+                                anyhow::bail!(
+                                    "{} does not have execution-scoped MCP access",
+                                    event.label()
+                                );
+                            }
+                            if mcp.server.trim().is_empty() || mcp.tool.trim().is_empty() {
+                                anyhow::bail!(
+                                    "{} MCP hook server and tool must not be empty",
+                                    event.label()
+                                );
+                            }
+                            validate_handler_fields(
+                                event,
+                                mcp.id.as_deref(),
+                                mcp.additional_context_limit,
+                            )?;
                         }
                     }
                 }

--- a/crates/agent/src/hooks/engine.rs
+++ b/crates/agent/src/hooks/engine.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use tracing::Instrument;
 
 #[derive(Debug, Clone, Default)]
 pub struct Hooks {
@@ -427,6 +428,7 @@ impl Hooks {
         if !self.is_enabled() {
             return Ok(SessionEndResult::default());
         }
+        let session_id = request.session_id.clone();
         let input = SessionEndCommandInput {
             session_id: request.session_id,
             transcript_path: NullableString::from_string(None),
@@ -436,16 +438,25 @@ impl Hooks {
             permission_mode: request.permission_mode,
             reason: request.reason,
         };
-        let mut result = SessionEndResult::default();
-        for outcome in self
+        let outcomes = self
             .run_event(
                 HookEventConfig::SessionEnd,
                 None,
                 input.clone(),
                 request.cwd.as_deref(),
             )
-            .await?
-        {
+            .await;
+        self.pending_session_stop
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(&session_id);
+        self.pending_session_context
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(&session_id);
+
+        let mut result = SessionEndResult::default();
+        for outcome in outcomes? {
             result.notices.extend(outcome.notices);
             if outcome.hard_block_reason.is_some() {
                 result
@@ -1504,20 +1515,23 @@ impl Hooks {
             exit_code = tracing::field::Empty,
             duration_ms = tracing::field::Empty,
         );
-        let _entered = span.enter();
-        let output = match &handler.kind {
-            ResolvedHookKind::Command(command) => {
-                run_command_hook(
-                    &spec_from_command(command),
-                    cwd.unwrap_or_else(|| Path::new(".")),
-                    &stdin_json,
-                )
-                .await?
+        let output = async {
+            match &handler.kind {
+                ResolvedHookKind::Command(command) => {
+                    run_command_hook(
+                        &spec_from_command(command),
+                        cwd.unwrap_or_else(|| Path::new(".")),
+                        &stdin_json,
+                    )
+                    .await
+                }
+                ResolvedHookKind::McpTool(config) => {
+                    run_mcp_hook(config, input, mcp_tool_state).await
+                }
             }
-            ResolvedHookKind::McpTool(config) => {
-                run_mcp_hook(config, input, mcp_tool_state).await?
-            }
-        };
+        }
+        .instrument(span.clone())
+        .await?;
         record_hook_output(&span, &output, started.elapsed());
 
         let mut notices = Vec::new();
@@ -1781,7 +1795,7 @@ fn limit_context(context: Option<String>, token_limit: Option<u32>) -> Option<St
     if context.chars().count() <= max_chars {
         return Some(context);
     }
-    let half = max_chars.saturating_sub(80) / 2;
+    let half = (max_chars.saturating_sub(80) / 2).max(1);
     let head: String = context.chars().take(half).collect();
     let tail: String = context
         .chars()

--- a/crates/agent/src/hooks/engine.rs
+++ b/crates/agent/src/hooks/engine.rs
@@ -1,27 +1,34 @@
-use crate::hooks::config::{HookCommandConfig, HookEventConfig, HookHandlerConfig, HooksConfig};
-use crate::hooks::output_parser::{
-    ParsedDecision, ParsedPermissionDecision, parse_delegation_failure, parse_delegation_start,
-    parse_permission_request, parse_post_compaction, parse_post_delegation, parse_post_tool_use,
-    parse_pre_compaction, parse_pre_delegation, parse_pre_tool_use, parse_session_start,
-    parse_stop, parse_user_prompt_submit,
+use crate::hooks::config::{
+    HookCommandConfig, HookEventConfig, HookHandlerConfig, HookMcpToolConfig, HooksConfig,
 };
-use crate::hooks::runner::{CommandHookSpec, run_command_hook};
+use crate::hooks::output_parser::{
+    ParsedDecision, ParsedPermissionDecision, parse_context, parse_delegation_failure,
+    parse_delegation_start, parse_permission_request, parse_post_compaction, parse_post_delegation,
+    parse_post_tool_use, parse_pre_compaction, parse_pre_delegation, parse_pre_tool_use,
+    parse_session_start, parse_stop, parse_user_prompt_submit,
+};
+use crate::hooks::runner::{CommandHookSpec, CommandOutput, run_command_hook};
 use crate::hooks::schema::{
-    DelegationFailureCommandInput, DelegationStartCommandInput, NullableString,
-    PermissionRequestCommandInput, PostCompactionCommandInput, PostDelegationCommandInput,
-    PostToolUseCommandInput, PreCompactionCommandInput, PreDelegationCommandInput,
-    PreToolUseCommandInput, SessionStartCommandInput, StopCommandInput,
-    UserPromptSubmitCommandInput,
+    ContextCommandInput, DelegationFailureCommandInput, DelegationStartCommandInput,
+    NullableString, PermissionRequestCommandInput, PostCompactionCommandInput,
+    PostDelegationCommandInput, PostToolUseCommandInput, PreCompactionCommandInput,
+    PreDelegationCommandInput, PreToolUseCommandInput, SessionEndCommandInput,
+    SessionEndCommandOutputWire, SessionStartCommandInput, StopCommandInput,
+    StructuredToolResultWire, UserPromptSubmitCommandInput,
 };
 use log::warn;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Default)]
 pub struct Hooks {
     config: HooksConfig,
+    pending_session_context: Arc<Mutex<HashMap<String, Vec<HookContextContribution>>>>,
+    pending_session_stop: Arc<Mutex<HashMap<String, String>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -32,9 +39,60 @@ pub struct HookNotice {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookContextContribution {
+    pub event_name: String,
+    pub handler_id: String,
+    pub tool_use_id: Option<String>,
+    pub content: String,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedHookHandler {
+    id: String,
+    matcher: Option<String>,
+    kind: ResolvedHookKind,
+}
+
+#[derive(Debug, Clone)]
+enum ResolvedHookKind {
+    Command(HookCommandConfig),
+    McpTool(HookMcpToolConfig),
+}
+
+impl ResolvedHookHandler {
+    fn status_message(&self) -> Option<&str> {
+        match &self.kind {
+            ResolvedHookKind::Command(config) => config.status_message.as_deref(),
+            ResolvedHookKind::McpTool(config) => config.status_message.as_deref(),
+        }
+    }
+
+    fn additional_context_limit(&self) -> Option<u32> {
+        match &self.kind {
+            ResolvedHookKind::Command(config) => config.additional_context_limit,
+            ResolvedHookKind::McpTool(config) => config.additional_context_limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HookInvocationOutcome {
+    handler_id: String,
+    stdout: String,
+    hard_block_reason: Option<String>,
+    notices: Vec<HookNotice>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionRequestDecision {
     Allow,
     Deny { message: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreToolPermissionDecision {
+    Allow,
+    Ask,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -44,6 +102,20 @@ pub struct UpdatedDelegation {
     pub context: Option<String>,
     pub constraints: Option<String>,
     pub expected_output: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionEndRequest {
+    pub session_id: String,
+    pub cwd: Option<PathBuf>,
+    pub model: String,
+    pub permission_mode: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SessionEndResult {
+    pub notices: Vec<HookNotice>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,12 +149,14 @@ pub struct UserPromptSubmitResult {
     pub should_block: bool,
     pub block_reason: Option<String>,
     pub additional_contexts: Vec<String>,
+    pub context_contributions: Vec<HookContextContribution>,
     pub notices: Vec<HookNotice>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PreToolUseRequest {
     pub session_id: String,
+    pub mcp_tool_state: Option<Arc<crate::agent::core::McpToolState>>,
     pub turn_id: String,
     pub cwd: Option<PathBuf>,
     pub model: String,
@@ -96,14 +170,17 @@ pub struct PreToolUseRequest {
 pub struct PreToolUseResult {
     pub should_block: bool,
     pub block_reason: Option<String>,
+    pub permission_decision: Option<PreToolPermissionDecision>,
     pub updated_input: Option<Value>,
     pub additional_contexts: Vec<String>,
+    pub context_contributions: Vec<HookContextContribution>,
     pub notices: Vec<HookNotice>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PermissionRequestRequest {
     pub session_id: String,
+    pub mcp_tool_state: Option<Arc<crate::agent::core::McpToolState>>,
     pub turn_id: String,
     pub cwd: Option<PathBuf>,
     pub model: String,
@@ -118,25 +195,52 @@ pub struct PermissionRequestResult {
     pub notices: Vec<HookNotice>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+pub struct ContextHookRequest {
+    pub session_id: String,
+    pub mcp_tool_state: Option<Arc<crate::agent::core::McpToolState>>,
+    pub turn_id: String,
+    pub cwd: Option<PathBuf>,
+    pub model: String,
+    pub permission_mode: String,
+    pub trigger: String,
+    pub context_window: u32,
+    pub messages: Vec<querymt::chat::ChatMessage>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ContextHookResult {
+    pub messages: Option<Vec<querymt::chat::ChatMessage>>,
+    pub estimated_tokens: usize,
+    pub notices: Vec<HookNotice>,
+}
+
+#[derive(Clone)]
 pub struct PostToolUseRequest {
     pub session_id: String,
+    pub mcp_tool_state: Option<Arc<crate::agent::core::McpToolState>>,
     pub turn_id: String,
     pub cwd: Option<PathBuf>,
     pub model: String,
     pub permission_mode: String,
     pub tool_name: String,
     pub tool_input: Value,
-    pub tool_response: Value,
+    pub content: Vec<querymt::chat::Content>,
+    pub is_error: bool,
+    pub execution_is_error: bool,
+    pub tool_source: String,
     pub tool_use_id: String,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct PostToolUseResult {
+    pub content: Option<Vec<querymt::chat::Content>>,
+    pub is_error: Option<bool>,
     pub should_block: bool,
     pub block_reason: Option<String>,
     pub stop_reason: Option<String>,
     pub additional_contexts: Vec<String>,
+    pub context_contributions: Vec<HookContextContribution>,
     pub notices: Vec<HookNotice>,
 }
 
@@ -169,12 +273,14 @@ pub struct PreCompactionRequest {
     pub trigger: String,
     pub token_estimate: u32,
     pub message_count: u32,
+    pub messages: Vec<Value>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct PreCompactionResult {
     pub should_block: bool,
     pub block_reason: Option<String>,
+    pub custom_summary: Option<String>,
     pub additional_contexts: Vec<String>,
     pub notices: Vec<HookNotice>,
 }
@@ -291,7 +397,11 @@ pub struct DelegationFailureResult {
 impl Hooks {
     pub fn new(config: HooksConfig) -> anyhow::Result<Self> {
         config.validate()?;
-        Ok(Self { config })
+        Ok(Self {
+            config,
+            pending_session_context: Arc::default(),
+            pending_session_stop: Arc::default(),
+        })
     }
 
     pub fn disabled() -> Self {
@@ -302,6 +412,58 @@ impl Hooks {
         self.config.enabled
     }
 
+    pub fn take_session_context(&self, session_id: &str) -> Vec<HookContextContribution> {
+        self.pending_session_context
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(session_id)
+            .unwrap_or_default()
+    }
+
+    pub async fn run_session_end(
+        &self,
+        request: SessionEndRequest,
+    ) -> anyhow::Result<SessionEndResult> {
+        if !self.is_enabled() {
+            return Ok(SessionEndResult::default());
+        }
+        let input = SessionEndCommandInput {
+            session_id: request.session_id,
+            transcript_path: NullableString::from_string(None),
+            cwd: cwd_string(request.cwd.as_deref()),
+            hook_event_name: HookEventConfig::SessionEnd.label().to_string(),
+            model: request.model,
+            permission_mode: request.permission_mode,
+            reason: request.reason,
+        };
+        let mut result = SessionEndResult::default();
+        for outcome in self
+            .run_event(
+                HookEventConfig::SessionEnd,
+                None,
+                input.clone(),
+                request.cwd.as_deref(),
+            )
+            .await?
+        {
+            result.notices.extend(outcome.notices);
+            if outcome.hard_block_reason.is_some() {
+                result
+                    .notices
+                    .push(ignored_control_notice(HookEventConfig::SessionEnd));
+            }
+            if !outcome.stdout.trim().is_empty()
+                && let Err(error) =
+                    serde_json::from_str::<SessionEndCommandOutputWire>(&outcome.stdout)
+            {
+                result
+                    .notices
+                    .push(invalid_notice(HookEventConfig::SessionEnd, error.into()));
+            }
+        }
+        Ok(result)
+    }
+
     pub async fn run_session_start(
         &self,
         request: SessionStartRequest,
@@ -309,6 +471,7 @@ impl Hooks {
         if !self.is_enabled() {
             return Ok(SessionStartResult::default());
         }
+        let session_id = request.session_id.clone();
         let input = SessionStartCommandInput {
             session_id: request.session_id,
             transcript_path: NullableString::from_string(None),
@@ -320,7 +483,8 @@ impl Hooks {
         };
 
         let mut result = SessionStartResult::default();
-        for stdout in self
+        let mut contributions = Vec::new();
+        for outcome in self
             .run_event(
                 HookEventConfig::SessionStart,
                 None,
@@ -329,10 +493,21 @@ impl Hooks {
             )
             .await?
         {
-            match parse_session_start(&stdout) {
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.stop_reason.get_or_insert(reason);
+                break;
+            }
+            match parse_session_start(&outcome.stdout) {
                 Ok(Some(parsed)) => {
-                    if let Some(context) = parsed.additional_context {
-                        result.additional_contexts.push(context);
+                    if let Some(context) = limit_context(parsed.additional_context, None) {
+                        result.additional_contexts.push(context.clone());
+                        contributions.push(HookContextContribution {
+                            event_name: HookEventConfig::SessionStart.label().to_string(),
+                            handler_id: outcome.handler_id,
+                            tool_use_id: None,
+                            content: context,
+                        });
                     }
                     if !parsed.continue_processing && result.stop_reason.is_none() {
                         result.stop_reason = parsed
@@ -346,6 +521,20 @@ impl Hooks {
                     .push(invalid_notice(HookEventConfig::SessionStart, err)),
             }
         }
+        if let Some(reason) = result.stop_reason.clone() {
+            self.pending_session_stop
+                .lock()
+                .unwrap_or_else(|err| err.into_inner())
+                .insert(session_id.clone(), reason);
+        }
+        if !contributions.is_empty() {
+            self.pending_session_context
+                .lock()
+                .unwrap_or_else(|err| err.into_inner())
+                .entry(session_id)
+                .or_default()
+                .extend(contributions);
+        }
         Ok(result)
     }
 
@@ -356,6 +545,7 @@ impl Hooks {
         if !self.is_enabled() {
             return Ok(UserPromptSubmitResult::default());
         }
+        let session_id = request.session_id.clone();
         let input = UserPromptSubmitCommandInput {
             session_id: request.session_id,
             turn_id: request.turn_id,
@@ -368,7 +558,18 @@ impl Hooks {
         };
 
         let mut result = UserPromptSubmitResult::default();
-        for stdout in self
+        if let Some(reason) = self
+            .pending_session_stop
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(&session_id)
+        {
+            result.should_block = true;
+            result.block_reason = Some(reason);
+            return Ok(result);
+        }
+        result.context_contributions = self.take_session_context(&session_id);
+        for outcome in self
             .run_event(
                 HookEventConfig::UserPromptSubmit,
                 None,
@@ -377,26 +578,37 @@ impl Hooks {
             )
             .await?
         {
-            match parse_user_prompt_submit(&stdout) {
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.should_block = true;
+                result.block_reason.get_or_insert(reason);
+                break;
+            }
+            match parse_user_prompt_submit(&outcome.stdout) {
                 Ok(Some(parsed)) => {
-                    if let Some(context) = parsed.additional_context {
-                        result.additional_contexts.push(context);
+                    if let Some(context) = limit_context(parsed.additional_context, None) {
+                        result.additional_contexts.push(context.clone());
+                        result.context_contributions.push(HookContextContribution {
+                            event_name: HookEventConfig::UserPromptSubmit.label().to_string(),
+                            handler_id: outcome.handler_id,
+                            tool_use_id: None,
+                            content: context,
+                        });
                     }
                     if matches!(parsed.decision, Some(ParsedDecision::Block)) {
                         result.should_block = true;
-                        if result.block_reason.is_none() {
-                            result.block_reason = parsed
+                        result.block_reason.get_or_insert_with(|| {
+                            parsed
                                 .reason
-                                .or_else(|| Some("blocked by hook".to_string()));
-                        }
+                                .unwrap_or_else(|| "blocked by hook".to_string())
+                        });
+                        break;
                     }
                 }
                 Ok(None) => {}
-                Err(err) => {
-                    result
-                        .notices
-                        .push(invalid_notice(HookEventConfig::UserPromptSubmit, err));
-                }
+                Err(err) => result
+                    .notices
+                    .push(invalid_notice(HookEventConfig::UserPromptSubmit, err)),
             }
         }
         Ok(result)
@@ -409,53 +621,110 @@ impl Hooks {
         if !self.is_enabled() {
             return Ok(PreToolUseResult::default());
         }
-        let input = PreToolUseCommandInput {
-            session_id: request.session_id,
-            turn_id: request.turn_id,
-            transcript_path: NullableString::from_string(None),
-            cwd: cwd_string(request.cwd.as_deref()),
-            hook_event_name: HookEventConfig::PreToolUse.label().to_string(),
-            model: request.model,
-            permission_mode: request.permission_mode,
-            tool_name: request.tool_name.clone(),
-            tool_input: request.tool_input.clone(),
-            tool_use_id: request.tool_use_id,
-        };
 
+        let handlers =
+            self.matching_handlers(HookEventConfig::PreToolUse, Some(&request.tool_name));
+        let mut current_input = request.tool_input.clone();
         let mut result = PreToolUseResult::default();
-        for stdout in self
-            .run_event(
-                HookEventConfig::PreToolUse,
-                Some(&request.tool_name),
-                input.clone(),
-                request.cwd.as_deref(),
-            )
-            .await?
-        {
-            match parse_pre_tool_use(&stdout) {
+        for handler in handlers {
+            let input = PreToolUseCommandInput {
+                session_id: request.session_id.clone(),
+                turn_id: request.turn_id.clone(),
+                transcript_path: NullableString::from_string(None),
+                cwd: cwd_string(request.cwd.as_deref()),
+                hook_event_name: HookEventConfig::PreToolUse.label().to_string(),
+                model: request.model.clone(),
+                permission_mode: request.permission_mode.clone(),
+                tool_name: request.tool_name.clone(),
+                tool_input: current_input.clone(),
+                tool_use_id: request.tool_use_id.clone(),
+            };
+            let outcome = self
+                .invoke_handler(
+                    HookEventConfig::PreToolUse,
+                    &handler,
+                    &input,
+                    request.cwd.as_deref(),
+                    request.mcp_tool_state.as_ref(),
+                )
+                .await?;
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.should_block = true;
+                result.block_reason.get_or_insert(reason);
+                break;
+            }
+
+            match parse_pre_tool_use(&outcome.stdout) {
                 Ok(Some(parsed)) => {
-                    if let Some(context) = parsed.additional_context {
-                        result.additional_contexts.push(context);
-                    }
-                    if let Some(updated_input) = parsed.updated_input {
-                        result.updated_input = Some(updated_input);
+                    if let Some(context) = limit_context(
+                        parsed.additional_context,
+                        handler.additional_context_limit(),
+                    ) {
+                        result.additional_contexts.push(context.clone());
+                        result.context_contributions.push(HookContextContribution {
+                            event_name: HookEventConfig::PreToolUse.label().to_string(),
+                            handler_id: outcome.handler_id.clone(),
+                            tool_use_id: Some(request.tool_use_id.clone()),
+                            content: context,
+                        });
                     }
                     match parsed.permission_decision {
                         Some(ParsedPermissionDecision::Deny { message }) => {
                             result.should_block = true;
-                            if result.block_reason.is_none() {
-                                result.block_reason = Some(message);
+                            result.block_reason.get_or_insert(message);
+                        }
+                        Some(ParsedPermissionDecision::Allow) => {
+                            result.permission_decision = Some(PreToolPermissionDecision::Allow);
+                            if let Some(updated_input) = parsed.updated_input {
+                                if updated_input.is_object() {
+                                    current_input = updated_input;
+                                    result.updated_input = Some(current_input.clone());
+                                } else {
+                                    result.notices.push(control_notice(
+                                        HookEventConfig::PreToolUse,
+                                        format!(
+                                            "Ignoring non-object updated_input from hook '{}'",
+                                            outcome.handler_id
+                                        ),
+                                    ));
+                                }
                             }
                         }
-                        Some(ParsedPermissionDecision::Allow) | None => {}
+                        Some(ParsedPermissionDecision::Ask) => {
+                            result.permission_decision = Some(PreToolPermissionDecision::Ask);
+                            if parsed.updated_input.is_some() {
+                                result.notices.push(control_notice(
+                                    HookEventConfig::PreToolUse,
+                                    format!(
+                                        "Ignoring updated_input from hook '{}' without permission_decision allow",
+                                        outcome.handler_id
+                                    ),
+                                ));
+                            }
+                        }
+                        None => {
+                            if parsed.updated_input.is_some() {
+                                result.notices.push(control_notice(
+                                    HookEventConfig::PreToolUse,
+                                    format!(
+                                        "Ignoring updated_input from hook '{}' without permission_decision allow",
+                                        outcome.handler_id
+                                    ),
+                                ));
+                            }
+                        }
                     }
                     if matches!(parsed.decision, Some(ParsedDecision::Block)) {
                         result.should_block = true;
-                        if result.block_reason.is_none() {
-                            result.block_reason = parsed
+                        result.block_reason.get_or_insert_with(|| {
+                            parsed
                                 .reason
-                                .or_else(|| Some("blocked by hook".to_string()));
-                        }
+                                .unwrap_or_else(|| "blocked by hook".to_string())
+                        });
+                    }
+                    if result.should_block {
+                        break;
                     }
                 }
                 Ok(None) => {}
@@ -487,16 +756,24 @@ impl Hooks {
         };
 
         let mut result = PermissionRequestResult::default();
-        for stdout in self
-            .run_event(
-                HookEventConfig::PermissionRequest,
-                Some(&request.tool_name),
-                input.clone(),
-                request.cwd.as_deref(),
-            )
-            .await?
+        for handler in
+            self.matching_handlers(HookEventConfig::PermissionRequest, Some(&request.tool_name))
         {
-            match parse_permission_request(&stdout) {
+            let outcome = self
+                .invoke_handler(
+                    HookEventConfig::PermissionRequest,
+                    &handler,
+                    &input,
+                    request.cwd.as_deref(),
+                    request.mcp_tool_state.as_ref(),
+                )
+                .await?;
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.decision = Some(PermissionRequestDecision::Deny { message: reason });
+                break;
+            }
+            match parse_permission_request(&outcome.stdout) {
                 Ok(Some(parsed)) => match parsed.decision {
                     Some(ParsedPermissionDecision::Deny { message }) => {
                         result.decision = Some(PermissionRequestDecision::Deny { message });
@@ -505,7 +782,7 @@ impl Hooks {
                     Some(ParsedPermissionDecision::Allow) => {
                         result.decision = Some(PermissionRequestDecision::Allow);
                     }
-                    None => {}
+                    Some(ParsedPermissionDecision::Ask) | None => {}
                 },
                 Ok(None) => {}
                 Err(err) => {
@@ -518,6 +795,115 @@ impl Hooks {
         Ok(result)
     }
 
+    pub async fn run_context(
+        &self,
+        request: ContextHookRequest,
+    ) -> anyhow::Result<ContextHookResult> {
+        if !self.is_enabled() {
+            return Ok(ContextHookResult {
+                estimated_tokens: estimate_chat_tokens(&request.messages),
+                messages: Some(request.messages),
+                notices: Vec::new(),
+            });
+        }
+
+        let mut messages = request.messages.clone();
+        let mut notices = Vec::new();
+        for handler in self.matching_handlers(HookEventConfig::Context, None) {
+            let input = ContextCommandInput {
+                session_id: request.session_id.clone(),
+                turn_id: request.turn_id.clone(),
+                transcript_path: NullableString::from_string(None),
+                cwd: cwd_string(request.cwd.as_deref()),
+                hook_event_name: HookEventConfig::Context.label().to_string(),
+                model: request.model.clone(),
+                permission_mode: request.permission_mode.clone(),
+                trigger: request.trigger.clone(),
+                context_window: request.context_window,
+                estimated_tokens: estimate_chat_tokens(&messages).min(u32::MAX as usize) as u32,
+                messages: messages
+                    .iter()
+                    .map(serde_json::to_value)
+                    .collect::<Result<Vec<_>, _>>()?,
+            };
+            let outcome = self
+                .invoke_handler(
+                    HookEventConfig::Context,
+                    &handler,
+                    &input,
+                    request.cwd.as_deref(),
+                    request.mcp_tool_state.as_ref(),
+                )
+                .await?;
+            notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                notices.push(control_notice(
+                    HookEventConfig::Context,
+                    format!(
+                        "hook '{}' attempted to block: {}",
+                        outcome.handler_id, reason
+                    ),
+                ));
+                continue;
+            }
+            match parse_context(&outcome.stdout) {
+                Ok(Some(parsed)) => {
+                    if let Some(replacement) = parsed.messages {
+                        match replacement
+                            .into_iter()
+                            .map(serde_json::from_value)
+                            .collect::<Result<Vec<querymt::chat::ChatMessage>, _>>()
+                        {
+                            Ok(candidate)
+                                if validate_message_projection(&candidate).is_ok()
+                                    && preserves_tool_identities(&messages, &candidate) =>
+                            {
+                                messages = candidate;
+                            }
+                            Ok(candidate) => {
+                                let reason = validate_message_projection(&candidate)
+                                    .err()
+                                    .map(|error| error.to_string())
+                                    .unwrap_or_else(|| {
+                                        "projection changed or removed tool-call identities"
+                                            .to_string()
+                                    });
+                                notices.push(control_notice(
+                                    HookEventConfig::Context,
+                                    format!(
+                                        "Ignoring invalid message projection from hook '{}': {}",
+                                        outcome.handler_id, reason
+                                    ),
+                                ));
+                            }
+                            Err(err) => notices.push(control_notice(
+                                HookEventConfig::Context,
+                                format!(
+                                    "Ignoring malformed message projection from hook '{}': {}",
+                                    outcome.handler_id, err
+                                ),
+                            )),
+                        }
+                    }
+                    if let Some(context) = limit_context(
+                        parsed.additional_context,
+                        handler.additional_context_limit(),
+                    ) {
+                        append_request_context(&mut messages, &outcome.handler_id, &context);
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => notices.push(invalid_notice(HookEventConfig::Context, err)),
+            }
+        }
+        let estimated_tokens = estimate_chat_tokens(&messages);
+        Ok(ContextHookResult {
+            messages: Some(messages),
+            estimated_tokens,
+            notices,
+        })
+    }
+
     pub async fn run_post_tool_use(
         &self,
         request: PostToolUseRequest,
@@ -525,56 +911,116 @@ impl Hooks {
         if !self.is_enabled() {
             return Ok(PostToolUseResult::default());
         }
-        let input = PostToolUseCommandInput {
-            session_id: request.session_id,
-            turn_id: request.turn_id,
-            transcript_path: NullableString::from_string(None),
-            cwd: cwd_string(request.cwd.as_deref()),
-            hook_event_name: HookEventConfig::PostToolUse.label().to_string(),
-            model: request.model,
-            permission_mode: request.permission_mode,
-            tool_name: request.tool_name.clone(),
-            tool_input: request.tool_input,
-            tool_response: request.tool_response,
-            tool_use_id: request.tool_use_id,
-        };
 
+        let handlers =
+            self.matching_handlers(HookEventConfig::PostToolUse, Some(&request.tool_name));
+        let mut current_content = request.content.clone();
+        let mut current_is_error = request.is_error;
         let mut result = PostToolUseResult::default();
-        for stdout in self
-            .run_event(
-                HookEventConfig::PostToolUse,
-                Some(&request.tool_name),
-                input.clone(),
-                request.cwd.as_deref(),
-            )
-            .await?
-        {
-            match parse_post_tool_use(&stdout) {
+        for handler in handlers {
+            let input = PostToolUseCommandInput {
+                session_id: request.session_id.clone(),
+                turn_id: request.turn_id.clone(),
+                transcript_path: NullableString::from_string(None),
+                cwd: cwd_string(request.cwd.as_deref()),
+                hook_event_name: HookEventConfig::PostToolUse.label().to_string(),
+                model: request.model.clone(),
+                permission_mode: request.permission_mode.clone(),
+                tool_name: request.tool_name.clone(),
+                tool_input: request.tool_input.clone(),
+                tool_response: Value::String(flatten_content(&current_content)),
+                tool_result: StructuredToolResultWire {
+                    content: current_content
+                        .iter()
+                        .map(serde_json::to_value)
+                        .collect::<Result<Vec<_>, _>>()?,
+                    is_error: current_is_error,
+                    execution_is_error: request.execution_is_error,
+                    tool_source: request.tool_source.clone(),
+                },
+                tool_use_id: request.tool_use_id.clone(),
+            };
+            let outcome = self
+                .invoke_handler(
+                    HookEventConfig::PostToolUse,
+                    &handler,
+                    &input,
+                    request.cwd.as_deref(),
+                    request.mcp_tool_state.as_ref(),
+                )
+                .await?;
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                current_content = vec![querymt::chat::Content::text(reason.clone())];
+                current_is_error = true;
+                result.should_block = true;
+                result.block_reason.get_or_insert(reason);
+                break;
+            }
+
+            match parse_post_tool_use(&outcome.stdout) {
                 Ok(Some(parsed)) => {
-                    if let Some(context) = parsed.additional_context {
-                        result.additional_contexts.push(context);
+                    if let Some(context) = limit_context(
+                        parsed.additional_context,
+                        handler.additional_context_limit(),
+                    ) {
+                        result.additional_contexts.push(context.clone());
+                        result.context_contributions.push(HookContextContribution {
+                            event_name: HookEventConfig::PostToolUse.label().to_string(),
+                            handler_id: outcome.handler_id.clone(),
+                            tool_use_id: Some(request.tool_use_id.clone()),
+                            content: context,
+                        });
                     }
-                    if matches!(parsed.decision, Some(ParsedDecision::Block)) {
-                        result.should_block = true;
-                        if result.block_reason.is_none() {
-                            result.block_reason = parsed
-                                .reason
-                                .clone()
-                                .or_else(|| Some("blocked by hook".to_string()));
+                    if let Some(patch) = parsed.updated_output {
+                        if let Some(content) = patch.content {
+                            match content
+                                .into_iter()
+                                .map(serde_json::from_value)
+                                .collect::<Result<Vec<querymt::chat::Content>, _>>()
+                            {
+                                Ok(content) => current_content = content,
+                                Err(err) => result.notices.push(control_notice(
+                                    HookEventConfig::PostToolUse,
+                                    format!(
+                                        "Ignoring invalid updated_output content from hook '{}': {}",
+                                        outcome.handler_id, err
+                                    ),
+                                )),
+                            }
+                        }
+                        if let Some(is_error) = patch.is_error {
+                            current_is_error = is_error;
                         }
                     }
-                    if !parsed.continue_processing && result.stop_reason.is_none() {
-                        result.stop_reason = parsed.stop_reason.or(parsed.reason);
+                    if matches!(parsed.decision, Some(ParsedDecision::Block)) {
+                        let reason = parsed
+                            .reason
+                            .clone()
+                            .unwrap_or_else(|| "tool result blocked by hook".to_string());
+                        current_content = vec![querymt::chat::Content::text(reason.clone())];
+                        current_is_error = true;
+                        result.should_block = true;
+                        result.block_reason.get_or_insert(reason);
+                    }
+                    if !parsed.continue_processing {
+                        let reason = parsed
+                            .stop_reason
+                            .or(parsed.reason)
+                            .unwrap_or_else(|| "hook suppressed tool result".to_string());
+                        current_content = vec![querymt::chat::Content::text(reason.clone())];
+                        current_is_error = true;
+                        result.stop_reason.get_or_insert(reason);
                     }
                 }
                 Ok(None) => {}
-                Err(err) => {
-                    result
-                        .notices
-                        .push(invalid_notice(HookEventConfig::PostToolUse, err));
-                }
+                Err(err) => result
+                    .notices
+                    .push(invalid_notice(HookEventConfig::PostToolUse, err)),
             }
         }
+        result.content = Some(current_content);
+        result.is_error = Some(current_is_error);
         Ok(result)
     }
 
@@ -594,7 +1040,7 @@ impl Hooks {
         };
 
         let mut result = StopResult::default();
-        for stdout in self
+        for outcome in self
             .run_event(
                 HookEventConfig::Stop,
                 None,
@@ -603,7 +1049,13 @@ impl Hooks {
             )
             .await?
         {
-            match parse_stop(&stdout) {
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.should_continue = true;
+                result.block_reason.get_or_insert(reason);
+                break;
+            }
+            match parse_stop(&outcome.stdout) {
                 Ok(Some(parsed)) => {
                     if let Some(context) = parsed.additional_context {
                         result.additional_contexts.push(context);
@@ -651,38 +1103,59 @@ impl Hooks {
             trigger: request.trigger,
             token_estimate: request.token_estimate,
             message_count: request.message_count,
+            messages: request.messages,
+            candidate_summary: NullableString::from_string(None),
         };
 
         let mut result = PreCompactionResult::default();
-        for stdout in self
-            .run_event(
-                HookEventConfig::PreCompaction,
-                None,
-                input.clone(),
-                request.cwd.as_deref(),
-            )
-            .await?
-        {
-            match parse_pre_compaction(&stdout) {
+        for handler in self.matching_handlers(HookEventConfig::PreCompaction, None) {
+            let mut handler_input = input.clone();
+            handler_input.candidate_summary =
+                NullableString::from_string(result.custom_summary.clone());
+            let outcome = self
+                .invoke_handler(
+                    HookEventConfig::PreCompaction,
+                    &handler,
+                    &handler_input,
+                    request.cwd.as_deref(),
+                    None,
+                )
+                .await?;
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.should_block = true;
+                result.block_reason.get_or_insert(reason);
+                break;
+            }
+            match parse_pre_compaction(&outcome.stdout) {
                 Ok(Some(parsed)) => {
                     if let Some(context) = parsed.additional_context {
                         result.additional_contexts.push(context);
                     }
+                    if let Some(summary) = parsed.summary {
+                        if summary.trim().is_empty() {
+                            result.notices.push(control_notice(
+                                HookEventConfig::PreCompaction,
+                                "Ignoring blank hook-provided compaction summary".to_string(),
+                            ));
+                        } else {
+                            result.custom_summary = Some(summary);
+                        }
+                    }
                     if matches!(parsed.decision, Some(ParsedDecision::Block)) {
                         result.should_block = true;
-                        if result.block_reason.is_none() {
-                            result.block_reason = parsed
+                        result.block_reason.get_or_insert_with(|| {
+                            parsed
                                 .reason
-                                .or_else(|| Some("compaction blocked by hook".to_string()));
-                        }
+                                .unwrap_or_else(|| "compaction blocked by hook".to_string())
+                        });
+                        break;
                     }
                 }
                 Ok(None) => {}
-                Err(err) => {
-                    result
-                        .notices
-                        .push(invalid_notice(HookEventConfig::PreCompaction, err));
-                }
+                Err(err) => result
+                    .notices
+                    .push(invalid_notice(HookEventConfig::PreCompaction, err)),
             }
         }
         Ok(result)
@@ -711,7 +1184,7 @@ impl Hooks {
         };
 
         let mut result = PostCompactionResult::default();
-        for stdout in self
+        for outcome in self
             .run_event(
                 HookEventConfig::PostCompaction,
                 None,
@@ -720,7 +1193,18 @@ impl Hooks {
             )
             .await?
         {
-            match parse_post_compaction(&stdout) {
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.notices.push(control_notice(
+                    HookEventConfig::PostCompaction,
+                    format!(
+                        "hook '{}' attempted to block: {}",
+                        outcome.handler_id, reason
+                    ),
+                ));
+                break;
+            }
+            match parse_post_compaction(&outcome.stdout) {
                 Ok(Some(parsed)) => {
                     if let Some(context) = parsed.additional_context {
                         result.additional_contexts.push(context);
@@ -761,7 +1245,7 @@ impl Hooks {
         };
 
         let mut result = PreDelegationResult::default();
-        for stdout in self
+        for outcome in self
             .run_event(
                 HookEventConfig::PreDelegation,
                 Some(&request.target_agent_id),
@@ -770,7 +1254,13 @@ impl Hooks {
             )
             .await?
         {
-            match parse_pre_delegation(&stdout) {
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.should_block = true;
+                result.block_reason.get_or_insert(reason);
+                break;
+            }
+            match parse_pre_delegation(&outcome.stdout) {
                 Ok(Some(parsed)) => {
                     if let Some(context) = parsed.additional_context {
                         result.additional_contexts.push(context);
@@ -930,11 +1420,22 @@ impl Hooks {
             -> anyhow::Result<Option<crate::hooks::output_parser::ParsedDelegationLifecycle>>,
     {
         let mut result = ObservingHookResult::default();
-        for stdout in self
+        for outcome in self
             .run_event(event, Some(target_agent_id), input, cwd)
             .await?
         {
-            match parser(&stdout) {
+            result.notices.extend(outcome.notices);
+            if let Some(reason) = outcome.hard_block_reason {
+                result.notices.push(control_notice(
+                    event,
+                    format!(
+                        "hook '{}' attempted to block: {}",
+                        outcome.handler_id, reason
+                    ),
+                ));
+                continue;
+            }
+            match parser(&outcome.stdout) {
                 Ok(Some(parsed)) => {
                     if let Some(context) = parsed.additional_context {
                         result.additional_contexts.push(context);
@@ -950,42 +1451,132 @@ impl Hooks {
         Ok(result)
     }
 
+    fn matching_handlers(
+        &self,
+        event: HookEventConfig,
+        matcher: Option<&str>,
+    ) -> Vec<ResolvedHookHandler> {
+        let mut handlers = Vec::new();
+        for (group_idx, group) in self.config.groups_for(event).iter().enumerate() {
+            if !matches_group(group.matcher.as_deref(), matcher) {
+                continue;
+            }
+            for (handler_idx, hook) in group.hooks.iter().enumerate() {
+                let (configured_id, kind) = match hook {
+                    HookHandlerConfig::Command(command) => (
+                        command.id.clone(),
+                        ResolvedHookKind::Command(command.clone()),
+                    ),
+                    HookHandlerConfig::McpTool(config) => {
+                        (config.id.clone(), ResolvedHookKind::McpTool(config.clone()))
+                    }
+                };
+                handlers.push(ResolvedHookHandler {
+                    id: configured_id.unwrap_or_else(|| {
+                        format!("{}-{}-{}", event.label(), group_idx, handler_idx)
+                    }),
+                    matcher: group.matcher.clone(),
+                    kind,
+                });
+            }
+        }
+        handlers
+    }
+
+    async fn invoke_handler<T: Serialize>(
+        &self,
+        event: HookEventConfig,
+        handler: &ResolvedHookHandler,
+        input: &T,
+        cwd: Option<&Path>,
+        mcp_tool_state: Option<&Arc<crate::agent::core::McpToolState>>,
+    ) -> anyhow::Result<HookInvocationOutcome> {
+        let stdin_json = serde_json::to_string(input)?;
+        let started = Instant::now();
+        let span = tracing::info_span!(
+            "agent.hook.invoke",
+            event_name = event.label(),
+            handler_id = %handler.id,
+            matcher = handler.matcher.as_deref().unwrap_or(""),
+            status_message = handler.status_message().unwrap_or(""),
+            input_bytes = stdin_json.len(),
+            output_bytes = tracing::field::Empty,
+            exit_code = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        );
+        let _entered = span.enter();
+        let output = match &handler.kind {
+            ResolvedHookKind::Command(command) => {
+                run_command_hook(
+                    &spec_from_command(command),
+                    cwd.unwrap_or_else(|| Path::new(".")),
+                    &stdin_json,
+                )
+                .await?
+            }
+            ResolvedHookKind::McpTool(config) => {
+                run_mcp_hook(config, input, mcp_tool_state).await?
+            }
+        };
+        record_hook_output(&span, &output, started.elapsed());
+
+        let mut notices = Vec::new();
+        if let Some(system_message) = extract_system_message(&output.stdout) {
+            notices.push(HookNotice {
+                event_name: event.label().to_string(),
+                message: limit_system_message(&system_message),
+                is_error: false,
+            });
+        }
+        notices.extend(unsupported_control_notices(event, &output.stdout));
+
+        match output.exit_code {
+            Some(0) => Ok(HookInvocationOutcome {
+                handler_id: handler.id.clone(),
+                stdout: output.stdout,
+                hard_block_reason: None,
+                notices,
+            }),
+            Some(2) => Ok(HookInvocationOutcome {
+                handler_id: handler.id.clone(),
+                stdout: String::new(),
+                hard_block_reason: Some(nonempty_reason(
+                    output.stderr.trim(),
+                    "blocked by hook command",
+                )),
+                notices,
+            }),
+            Some(code) => anyhow::bail!(
+                "{} hook command '{}' failed with exit code {}: {}",
+                event.label(),
+                handler.id,
+                code,
+                output.stderr.trim()
+            ),
+            None => anyhow::bail!(
+                "{} hook command '{}' terminated without an exit code: {}",
+                event.label(),
+                handler.id,
+                output.stderr.trim()
+            ),
+        }
+    }
+
     async fn run_event<T: Serialize>(
         &self,
         event: HookEventConfig,
         matcher: Option<&str>,
         input: T,
         cwd: Option<&Path>,
-    ) -> anyhow::Result<Vec<String>> {
-        let mut outputs = Vec::new();
-        let stdin_json = serde_json::to_string(&input)?;
-        let cwd = cwd.unwrap_or_else(|| Path::new("."));
-
-        for group in self.config.groups_for(event) {
-            if !matches_group(group.matcher.as_deref(), matcher) {
-                continue;
-            }
-            for hook in &group.hooks {
-                match hook {
-                    HookHandlerConfig::Command(command) => {
-                        let spec = spec_from_command(command);
-                        let output = run_command_hook(&spec, cwd, &stdin_json).await?;
-                        match output.exit_code {
-                            Some(0) | None => outputs.push(output.stdout),
-                            Some(2) => outputs.push(output.stdout),
-                            Some(code) => anyhow::bail!(
-                                "{} hook command failed with exit code {}: {}",
-                                event.label(),
-                                code,
-                                output.stderr.trim()
-                            ),
-                        }
-                    }
-                }
-            }
+    ) -> anyhow::Result<Vec<HookInvocationOutcome>> {
+        let mut outcomes = Vec::new();
+        for handler in self.matching_handlers(event, matcher) {
+            outcomes.push(
+                self.invoke_handler(event, &handler, &input, cwd, None)
+                    .await?,
+            );
         }
-
-        Ok(outputs)
+        Ok(outcomes)
     }
 }
 
@@ -993,6 +1584,85 @@ impl Hooks {
 struct ObservingHookResult {
     additional_contexts: Vec<String>,
     notices: Vec<HookNotice>,
+}
+
+async fn run_mcp_hook<T: Serialize>(
+    config: &HookMcpToolConfig,
+    input: &T,
+    mcp_tool_state: Option<&Arc<crate::agent::core::McpToolState>>,
+) -> anyhow::Result<CommandOutput> {
+    use querymt::tool_decorator::CallFunctionTool;
+
+    let state = mcp_tool_state.ok_or_else(|| {
+        anyhow::anyhow!(
+            "MCP hook '{}.{}' has no execution-scoped MCP state",
+            config.server,
+            config.tool
+        )
+    })?;
+    let tool = state
+        .load()
+        .tools
+        .get(&config.tool)
+        .filter(|tool| tool.server_name() == config.server)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "MCP hook tool '{}.{}' is not connected",
+                config.server,
+                config.tool
+            )
+        })?;
+    let event_value = serde_json::to_value(input)?;
+    let arguments = match &config.input {
+        Some(template) => resolve_mcp_input_template(template, &event_value)?,
+        None => event_value,
+    };
+    let content = tokio::time::timeout(
+        Duration::from_secs(config.timeout_sec.unwrap_or(30)),
+        tool.call(arguments),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("MCP hook timed out"))??;
+    Ok(CommandOutput {
+        exit_code: Some(0),
+        stdout: flatten_content(&content),
+        stderr: String::new(),
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn resolve_mcp_input_template_for_test(
+    template: &Value,
+    event: &Value,
+) -> anyhow::Result<Value> {
+    resolve_mcp_input_template(template, event)
+}
+
+fn resolve_mcp_input_template(template: &Value, event: &Value) -> anyhow::Result<Value> {
+    match template {
+        Value::String(value) if value.starts_with("$event.") => {
+            let path = value.trim_start_matches("$event.");
+            let mut current = event;
+            for segment in path.split('.') {
+                current = current.get(segment).ok_or_else(|| {
+                    anyhow::anyhow!("unknown MCP hook event template path '$event.{}'", path)
+                })?;
+            }
+            Ok(current.clone())
+        }
+        Value::Array(values) => values
+            .iter()
+            .map(|value| resolve_mcp_input_template(value, event))
+            .collect::<anyhow::Result<Vec<_>>>()
+            .map(Value::Array),
+        Value::Object(values) => values
+            .iter()
+            .map(|(key, value)| Ok((key.clone(), resolve_mcp_input_template(value, event)?)))
+            .collect::<anyhow::Result<serde_json::Map<_, _>>>()
+            .map(Value::Object),
+        value => Ok(value.clone()),
+    }
 }
 
 fn spec_from_command(command: &HookCommandConfig) -> CommandHookSpec {
@@ -1031,12 +1701,204 @@ fn invalid_notice(event: HookEventConfig, err: anyhow::Error) -> HookNotice {
 }
 
 fn ignored_control_notice(event: HookEventConfig) -> HookNotice {
-    HookNotice {
-        event_name: event.label().to_string(),
-        message: format!(
+    control_notice(
+        event,
+        format!(
             "Ignoring control fields from {} hook output; this hook is observe-only",
             event.label()
         ),
+    )
+}
+
+fn control_notice(event: HookEventConfig, message: String) -> HookNotice {
+    HookNotice {
+        event_name: event.label().to_string(),
+        message,
         is_error: false,
     }
+}
+
+fn unsupported_control_notices(event: HookEventConfig, stdout: &str) -> Vec<HookNotice> {
+    let Ok(Value::Object(output)) = serde_json::from_str(stdout.trim()) else {
+        return Vec::new();
+    };
+    let mut fields = Vec::new();
+    if output.contains_key("continue")
+        && !matches!(
+            event,
+            HookEventConfig::SessionStart | HookEventConfig::PostToolUse | HookEventConfig::Stop
+        )
+    {
+        fields.push("continue");
+    }
+    if output.contains_key("stop_reason")
+        && !matches!(
+            event,
+            HookEventConfig::SessionStart | HookEventConfig::PostToolUse | HookEventConfig::Stop
+        )
+    {
+        fields.push("stop_reason");
+    }
+    if fields.is_empty() {
+        Vec::new()
+    } else {
+        vec![control_notice(
+            event,
+            format!(
+                "Ignoring unsupported {} field(s): {}",
+                event.label(),
+                fields.join(", ")
+            ),
+        )]
+    }
+}
+
+fn extract_system_message(stdout: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(stdout.trim()).ok()?;
+    value
+        .get("system_message")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .map(str::to_string)
+}
+
+fn limit_system_message(message: &str) -> String {
+    const MAX_CHARS: usize = 2_000;
+    if message.chars().count() <= MAX_CHARS {
+        message.to_string()
+    } else {
+        format!("{}...", message.chars().take(MAX_CHARS).collect::<String>())
+    }
+}
+
+fn limit_context(context: Option<String>, token_limit: Option<u32>) -> Option<String> {
+    let context = context?.trim().to_string();
+    if context.is_empty() {
+        return None;
+    }
+    let max_chars = token_limit.unwrap_or(2_500) as usize * 4;
+    if context.chars().count() <= max_chars {
+        return Some(context);
+    }
+    let half = max_chars.saturating_sub(80) / 2;
+    let head: String = context.chars().take(half).collect();
+    let tail: String = context
+        .chars()
+        .rev()
+        .take(half)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    Some(format!(
+        "{}\n...[hook context truncated]...\n{}",
+        head, tail
+    ))
+}
+
+fn append_request_context(
+    messages: &mut Vec<querymt::chat::ChatMessage>,
+    handler_id: &str,
+    content: &str,
+) {
+    let rendered = format!(
+        "<hook-context event=context handler={}>\n{}\n</hook-context>",
+        handler_id, content
+    );
+    if let Some(last) = messages.last_mut()
+        && last.role == querymt::chat::ChatRole::User
+    {
+        last.content.push(querymt::chat::Content::text(rendered));
+    } else {
+        messages.push(querymt::chat::ChatMessage {
+            role: querymt::chat::ChatRole::User,
+            content: vec![querymt::chat::Content::text(rendered)],
+            cache: None,
+        });
+    }
+}
+
+fn validate_message_projection(messages: &[querymt::chat::ChatMessage]) -> anyhow::Result<()> {
+    if messages.is_empty() {
+        anyhow::bail!("projection must contain at least one message");
+    }
+    let mut pending_tool_ids = std::collections::BTreeSet::new();
+    for message in messages {
+        if message.content.is_empty() {
+            anyhow::bail!("projection contains an empty message");
+        }
+        for content in &message.content {
+            match content {
+                querymt::chat::Content::ToolUse { id, .. } => {
+                    if !pending_tool_ids.insert(id.clone()) {
+                        anyhow::bail!("duplicate tool call id '{}'", id);
+                    }
+                }
+                querymt::chat::Content::ToolResult { id, .. } if !pending_tool_ids.remove(id) => {
+                    anyhow::bail!("unmatched tool result id '{}'", id);
+                }
+                querymt::chat::Content::ToolResult { .. } => {}
+                _ => {}
+            }
+        }
+    }
+    if let Some(id) = pending_tool_ids.first() {
+        anyhow::bail!("unmatched tool call id '{}'", id);
+    }
+    Ok(())
+}
+
+fn preserves_tool_identities(
+    current: &[querymt::chat::ChatMessage],
+    candidate: &[querymt::chat::ChatMessage],
+) -> bool {
+    fn identities(
+        messages: &[querymt::chat::ChatMessage],
+    ) -> std::collections::BTreeSet<(String, String)> {
+        messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .filter_map(|content| match content {
+                querymt::chat::Content::ToolUse { id, .. } => Some(("use".to_string(), id.clone())),
+                querymt::chat::Content::ToolResult { id, .. } => {
+                    Some(("result".to_string(), id.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+    identities(candidate).is_subset(&identities(current))
+}
+
+fn estimate_chat_tokens(messages: &[querymt::chat::ChatMessage]) -> usize {
+    messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .map(|content| serde_json::to_vec(content).map_or(0, |bytes| bytes.len() / 4))
+        .sum()
+}
+
+fn flatten_content(content: &[querymt::chat::Content]) -> String {
+    content
+        .iter()
+        .filter_map(|block| block.as_text())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn nonempty_reason(reason: &str, fallback: &str) -> String {
+    if reason.is_empty() {
+        fallback.to_string()
+    } else {
+        reason.to_string()
+    }
+}
+
+fn record_hook_output(span: &tracing::Span, output: &CommandOutput, duration: Duration) {
+    span.record("output_bytes", output.stdout.len() + output.stderr.len());
+    if let Some(code) = output.exit_code {
+        span.record("exit_code", code);
+    }
+    span.record("duration_ms", duration.as_millis() as u64);
 }

--- a/crates/agent/src/hooks/mod.rs
+++ b/crates/agent/src/hooks/mod.rs
@@ -8,16 +8,18 @@ pub mod schema;
 mod tests;
 
 pub use config::{
-    HookCommandConfig, HookEventConfig, HookHandlerConfig, HooksConfig, MatcherGroupConfig,
+    HookCommandConfig, HookEventConfig, HookHandlerConfig, HookMcpToolConfig, HooksConfig,
+    MatcherGroupConfig,
 };
 pub use engine::{
-    DelegationFailureRequest, DelegationFailureResult, DelegationStartRequest,
-    DelegationStartResult, HookNotice, Hooks, PermissionRequestDecision, PermissionRequestRequest,
-    PermissionRequestResult, PostCompactionRequest, PostCompactionResult, PostDelegationRequest,
-    PostDelegationResult, PostToolUseRequest, PostToolUseResult, PreCompactionRequest,
-    PreCompactionResult, PreDelegationRequest, PreDelegationResult, PreToolUseRequest,
-    PreToolUseResult, SessionStartRequest, SessionStartResult, StopRequest, StopResult,
-    UpdatedDelegation, UserPromptSubmitRequest, UserPromptSubmitResult,
+    ContextHookRequest, ContextHookResult, DelegationFailureRequest, DelegationFailureResult,
+    DelegationStartRequest, DelegationStartResult, HookContextContribution, HookNotice, Hooks,
+    PermissionRequestDecision, PermissionRequestRequest, PermissionRequestResult,
+    PostCompactionRequest, PostCompactionResult, PostDelegationRequest, PostDelegationResult,
+    PostToolUseRequest, PostToolUseResult, PreCompactionRequest, PreCompactionResult,
+    PreDelegationRequest, PreDelegationResult, PreToolUseRequest, PreToolUseResult,
+    SessionEndRequest, SessionEndResult, SessionStartRequest, SessionStartResult, StopRequest,
+    StopResult, UpdatedDelegation, UserPromptSubmitRequest, UserPromptSubmitResult,
 };
 
 pub fn permission_mode_label(mode: crate::agent::core::AgentMode) -> &'static str {

--- a/crates/agent/src/hooks/output_parser.rs
+++ b/crates/agent/src/hooks/output_parser.rs
@@ -1,10 +1,11 @@
 use crate::hooks::schema::{
-    BlockDecisionWire, DelegationFailureCommandOutputWire, DelegationStartCommandOutputWire,
-    PermissionRequestBehaviorWire, PermissionRequestCommandOutputWire,
-    PostCompactionCommandOutputWire, PostDelegationCommandOutputWire, PostToolUseCommandOutputWire,
-    PreCompactionCommandOutputWire, PreDelegationCommandOutputWire, PreToolUseCommandOutputWire,
-    PreToolUseDecisionWire, PreToolUsePermissionDecisionWire, SessionStartCommandOutputWire,
-    StopCommandOutputWire, UpdatedDelegationWire, UserPromptSubmitCommandOutputWire,
+    BlockDecisionWire, ContextCommandOutputWire, DelegationFailureCommandOutputWire,
+    DelegationStartCommandOutputWire, PermissionRequestBehaviorWire,
+    PermissionRequestCommandOutputWire, PostCompactionCommandOutputWire,
+    PostDelegationCommandOutputWire, PostToolUseCommandOutputWire, PreCompactionCommandOutputWire,
+    PreDelegationCommandOutputWire, PreToolUseCommandOutputWire, PreToolUseDecisionWire,
+    PreToolUsePermissionDecisionWire, SessionStartCommandOutputWire, StopCommandOutputWire,
+    UpdatedDelegationWire, UserPromptSubmitCommandOutputWire,
 };
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -18,6 +19,7 @@ pub enum ParsedDecision {
 pub enum ParsedPermissionDecision {
     Allow,
     Deny { message: String },
+    Ask,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -27,6 +29,12 @@ pub struct ParsedUpdatedDelegation {
     pub context: Option<String>,
     pub constraints: Option<String>,
     pub expected_output: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedContext {
+    pub messages: Option<Vec<Value>>,
+    pub additional_context: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -51,11 +59,18 @@ pub struct ParsedPermissionRequest {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct ParsedToolOutputPatch {
+    pub content: Option<Vec<Value>>,
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParsedPostToolUse {
     pub decision: Option<ParsedDecision>,
     pub reason: Option<String>,
     pub continue_processing: bool,
     pub stop_reason: Option<String>,
+    pub updated_output: Option<ParsedToolOutputPatch>,
     pub additional_context: Option<String>,
 }
 
@@ -79,6 +94,7 @@ pub struct ParsedStop {
 pub struct ParsedPreCompaction {
     pub decision: Option<ParsedDecision>,
     pub reason: Option<String>,
+    pub summary: Option<String>,
     pub additional_context: Option<String>,
 }
 
@@ -105,6 +121,19 @@ pub struct ParsedDelegationLifecycle {
 pub fn looks_like_json(stdout: &str) -> bool {
     let trimmed = stdout.trim_start();
     trimmed.starts_with('{') || trimmed.starts_with('[')
+}
+
+pub fn parse_context(stdout: &str) -> anyhow::Result<Option<ParsedContext>> {
+    let Some(output) = parse_json::<ContextCommandOutputWire>(stdout)? else {
+        return Ok(None);
+    };
+    let hook_specific = output.hook_specific_output;
+    Ok(Some(ParsedContext {
+        messages: hook_specific
+            .as_ref()
+            .and_then(|hook| hook.messages.clone()),
+        additional_context: hook_specific.and_then(|hook| hook.additional_context),
+    }))
 }
 
 pub fn parse_user_prompt_submit(stdout: &str) -> anyhow::Result<Option<ParsedUserPromptSubmit>> {
@@ -137,12 +166,7 @@ pub fn parse_pre_tool_use(stdout: &str) -> anyhow::Result<Option<ParsedPreToolUs
                     .and_then(|hook| hook.permission_decision_reason.clone())
                     .unwrap_or_else(|| "blocked by hook".to_string()),
             },
-            PreToolUsePermissionDecisionWire::Ask => ParsedPermissionDecision::Deny {
-                message: hook_specific
-                    .as_ref()
-                    .and_then(|hook| hook.permission_decision_reason.clone())
-                    .unwrap_or_else(|| "hook requested confirmation".to_string()),
-            },
+            PreToolUsePermissionDecisionWire::Ask => ParsedPermissionDecision::Ask,
         });
 
     let decision = match output.decision {
@@ -187,6 +211,7 @@ pub fn parse_post_tool_use(stdout: &str) -> anyhow::Result<Option<ParsedPostTool
     let Some(output) = parse_json::<PostToolUseCommandOutputWire>(stdout)? else {
         return Ok(None);
     };
+    let hook_specific = output.hook_specific_output;
     Ok(Some(ParsedPostToolUse {
         decision: output
             .decision
@@ -194,9 +219,14 @@ pub fn parse_post_tool_use(stdout: &str) -> anyhow::Result<Option<ParsedPostTool
         reason: output.reason,
         continue_processing: output.universal.r#continue,
         stop_reason: output.universal.stop_reason,
-        additional_context: output
-            .hook_specific_output
-            .and_then(|hook| hook.additional_context),
+        updated_output: hook_specific
+            .as_ref()
+            .and_then(|hook| hook.updated_output.as_ref())
+            .map(|patch| ParsedToolOutputPatch {
+                content: patch.content.clone(),
+                is_error: patch.is_error,
+            }),
+        additional_context: hook_specific.and_then(|hook| hook.additional_context),
     }))
 }
 
@@ -234,14 +264,17 @@ pub fn parse_pre_compaction(stdout: &str) -> anyhow::Result<Option<ParsedPreComp
     let Some(output) = parse_json::<PreCompactionCommandOutputWire>(stdout)? else {
         return Ok(None);
     };
+    let hook_specific = output.hook_specific_output;
     Ok(Some(ParsedPreCompaction {
         decision: output
             .decision
             .map(|BlockDecisionWire::Block| ParsedDecision::Block),
         reason: output.reason,
-        additional_context: output
-            .hook_specific_output
-            .and_then(|hook| hook.additional_context),
+        summary: hook_specific
+            .as_ref()
+            .and_then(|hook| hook.compaction.as_ref())
+            .map(|compaction| compaction.summary.clone()),
+        additional_context: hook_specific.and_then(|hook| hook.additional_context),
     }))
 }
 

--- a/crates/agent/src/hooks/schema.rs
+++ b/crates/agent/src/hooks/schema.rs
@@ -11,6 +11,8 @@ pub const PERMISSION_REQUEST_INPUT_FIXTURE: &str = "permission-request.command.i
 pub const PERMISSION_REQUEST_OUTPUT_FIXTURE: &str = "permission-request.command.output.schema.json";
 pub const POST_TOOL_USE_INPUT_FIXTURE: &str = "post-tool-use.command.input.schema.json";
 pub const POST_TOOL_USE_OUTPUT_FIXTURE: &str = "post-tool-use.command.output.schema.json";
+pub const CONTEXT_INPUT_FIXTURE: &str = "context.command.input.schema.json";
+pub const CONTEXT_OUTPUT_FIXTURE: &str = "context.command.output.schema.json";
 pub const USER_PROMPT_SUBMIT_INPUT_FIXTURE: &str = "user-prompt-submit.command.input.schema.json";
 pub const USER_PROMPT_SUBMIT_OUTPUT_FIXTURE: &str = "user-prompt-submit.command.output.schema.json";
 pub const SESSION_START_INPUT_FIXTURE: &str = "session-start.command.input.schema.json";
@@ -29,6 +31,8 @@ pub const POST_DELEGATION_INPUT_FIXTURE: &str = "post-delegation.command.input.s
 pub const POST_DELEGATION_OUTPUT_FIXTURE: &str = "post-delegation.command.output.schema.json";
 pub const DELEGATION_FAILURE_INPUT_FIXTURE: &str = "delegation-failure.command.input.schema.json";
 pub const DELEGATION_FAILURE_OUTPUT_FIXTURE: &str = "delegation-failure.command.output.schema.json";
+pub const SESSION_END_INPUT_FIXTURE: &str = "session-end.command.input.schema.json";
+pub const SESSION_END_OUTPUT_FIXTURE: &str = "session-end.command.output.schema.json";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
@@ -148,9 +152,31 @@ pub struct PermissionRequestHookSpecificOutputWire {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub struct ToolOutputPatchWire {
+    #[serde(default)]
+    pub content: Option<Vec<Value>>,
+    #[serde(default)]
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PostToolUseHookSpecificOutputWire {
     #[schemars(schema_with = "post_tool_use_hook_event_name_schema")]
     pub hook_event_name: String,
+    #[serde(default)]
+    pub updated_output: Option<ToolOutputPatchWire>,
+    #[serde(default)]
+    pub additional_context: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContextHookSpecificOutputWire {
+    #[schemars(schema_with = "context_hook_event_name_schema")]
+    pub hook_event_name: String,
+    #[serde(default)]
+    pub messages: Option<Vec<Value>>,
     #[serde(default)]
     pub additional_context: Option<String>,
 }
@@ -184,9 +210,17 @@ pub struct StopHookSpecificOutputWire {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub struct CompactionOutputWire {
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PreCompactionHookSpecificOutputWire {
     #[schemars(schema_with = "pre_compaction_hook_event_name_schema")]
     pub hook_event_name: String,
+    #[serde(default)]
+    pub compaction: Option<CompactionOutputWire>,
     #[serde(default)]
     pub additional_context: Option<String>,
 }
@@ -256,6 +290,16 @@ pub struct PostToolUseCommandOutputWire {
     pub reason: Option<String>,
     #[serde(default)]
     pub hook_specific_output: Option<PostToolUseHookSpecificOutputWire>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(rename = "context.command.output")]
+pub struct ContextCommandOutputWire {
+    #[serde(flatten)]
+    pub universal: HookUniversalOutputWire,
+    #[serde(default)]
+    pub hook_specific_output: Option<ContextHookSpecificOutputWire>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -364,6 +408,14 @@ pub struct DelegationFailureCommandOutputWire {
     pub hook_specific_output: Option<DelegationLifecycleHookSpecificOutputWire>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(rename = "session-end.command.output")]
+pub struct SessionEndCommandOutputWire {
+    #[serde(default)]
+    pub system_message: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(rename = "pre-tool-use.command.input")]
@@ -401,6 +453,15 @@ pub struct PermissionRequestCommandInput {
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub struct StructuredToolResultWire {
+    pub content: Vec<Value>,
+    pub is_error: bool,
+    pub execution_is_error: bool,
+    pub tool_source: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[schemars(rename = "post-tool-use.command.input")]
 pub struct PostToolUseCommandInput {
     pub session_id: String,
@@ -415,7 +476,27 @@ pub struct PostToolUseCommandInput {
     pub tool_name: String,
     pub tool_input: Value,
     pub tool_response: Value,
+    pub tool_result: StructuredToolResultWire,
     pub tool_use_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(rename = "context.command.input")]
+pub struct ContextCommandInput {
+    pub session_id: String,
+    pub turn_id: String,
+    pub transcript_path: NullableString,
+    pub cwd: String,
+    #[schemars(schema_with = "context_hook_event_name_schema")]
+    pub hook_event_name: String,
+    pub model: String,
+    #[schemars(schema_with = "permission_mode_schema")]
+    pub permission_mode: String,
+    pub trigger: String,
+    pub context_window: u32,
+    pub estimated_tokens: u32,
+    pub messages: Vec<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -481,6 +562,8 @@ pub struct PreCompactionCommandInput {
     pub trigger: String,
     pub token_estimate: u32,
     pub message_count: u32,
+    pub messages: Vec<Value>,
+    pub candidate_summary: NullableString,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -571,6 +654,21 @@ pub struct PostDelegationCommandInput {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(rename = "delegation-failure.command.input")]
+pub struct SessionEndCommandInput {
+    pub session_id: String,
+    pub transcript_path: NullableString,
+    pub cwd: String,
+    #[schemars(schema_with = "session_end_hook_event_name_schema")]
+    pub hook_event_name: String,
+    pub model: String,
+    #[schemars(schema_with = "permission_mode_schema")]
+    pub permission_mode: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(rename = "delegation-failure.command.input")]
 pub struct DelegationFailureCommandInput {
     pub session_id: String,
     pub turn_id: String,
@@ -616,6 +714,14 @@ pub fn write_schema_fixtures(schema_root: &Path) -> anyhow::Result<()> {
     write_schema(
         &generated_dir.join(POST_TOOL_USE_OUTPUT_FIXTURE),
         schema_json::<PostToolUseCommandOutputWire>()?,
+    )?;
+    write_schema(
+        &generated_dir.join(CONTEXT_INPUT_FIXTURE),
+        schema_json::<ContextCommandInput>()?,
+    )?;
+    write_schema(
+        &generated_dir.join(CONTEXT_OUTPUT_FIXTURE),
+        schema_json::<ContextCommandOutputWire>()?,
     )?;
     write_schema(
         &generated_dir.join(USER_PROMPT_SUBMIT_INPUT_FIXTURE),
@@ -689,6 +795,14 @@ pub fn write_schema_fixtures(schema_root: &Path) -> anyhow::Result<()> {
         &generated_dir.join(DELEGATION_FAILURE_OUTPUT_FIXTURE),
         schema_json::<DelegationFailureCommandOutputWire>()?,
     )?;
+    write_schema(
+        &generated_dir.join(SESSION_END_INPUT_FIXTURE),
+        schema_json::<SessionEndCommandInput>()?,
+    )?;
+    write_schema(
+        &generated_dir.join(SESSION_END_OUTPUT_FIXTURE),
+        schema_json::<SessionEndCommandOutputWire>()?,
+    )?;
 
     Ok(())
 }
@@ -753,6 +867,10 @@ fn post_tool_use_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
     string_const_schema("post_tool_use")
 }
 
+fn context_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
+    string_const_schema("context")
+}
+
 fn user_prompt_submit_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
     string_const_schema("user_prompt_submit")
 }
@@ -787,6 +905,10 @@ fn post_delegation_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema 
 
 fn delegation_failure_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
     string_const_schema("delegation_failure")
+}
+
+fn session_end_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {
+    string_const_schema("session_end")
 }
 
 fn delegation_lifecycle_hook_event_name_schema(_gen: &mut SchemaGenerator) -> Schema {

--- a/crates/agent/src/hooks/schema.rs
+++ b/crates/agent/src/hooks/schema.rs
@@ -653,7 +653,7 @@ pub struct PostDelegationCommandInput {
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[schemars(rename = "delegation-failure.command.input")]
+#[schemars(rename = "session-end.command.input")]
 pub struct SessionEndCommandInput {
     pub session_id: String,
     pub transcript_path: NullableString,

--- a/crates/agent/src/hooks/schema/generated/context.command.input.schema.json
+++ b/crates/agent/src/hooks/schema/generated/context.command.input.schema.json
@@ -10,20 +10,22 @@
     }
   },
   "properties": {
-    "candidate_summary": {
-      "$ref": "#/definitions/NullableString"
+    "context_window": {
+      "format": "uint32",
+      "minimum": 0,
+      "type": "integer"
     },
     "cwd": {
       "type": "string"
     },
-    "hook_event_name": {
-      "const": "pre_compaction",
-      "type": "string"
-    },
-    "message_count": {
+    "estimated_tokens": {
       "format": "uint32",
       "minimum": 0,
       "type": "integer"
+    },
+    "hook_event_name": {
+      "const": "context",
+      "type": "string"
     },
     "messages": {
       "items": true,
@@ -42,11 +44,6 @@
     },
     "session_id": {
       "type": "string"
-    },
-    "token_estimate": {
-      "format": "uint32",
-      "minimum": 0,
-      "type": "integer"
     },
     "transcript_path": {
       "$ref": "#/definitions/NullableString"
@@ -67,11 +64,10 @@
     "model",
     "permission_mode",
     "trigger",
-    "token_estimate",
-    "message_count",
-    "messages",
-    "candidate_summary"
+    "context_window",
+    "estimated_tokens",
+    "messages"
   ],
-  "title": "pre-compaction.command.input",
+  "title": "context.command.input",
   "type": "object"
 }

--- a/crates/agent/src/hooks/schema/generated/context.command.output.schema.json
+++ b/crates/agent/src/hooks/schema/generated/context.command.output.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "ContextHookSpecificOutputWire": {
+      "additionalProperties": false,
+      "properties": {
+        "additional_context": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hook_event_name": {
+          "const": "context",
+          "type": "string"
+        },
+        "messages": {
+          "default": null,
+          "items": true,
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "hook_event_name"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "continue": {
+      "default": true,
+      "type": "boolean"
+    },
+    "hook_specific_output": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ContextHookSpecificOutputWire"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "stop_reason": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "system_message": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "title": "context.command.output",
+  "type": "object"
+}

--- a/crates/agent/src/hooks/schema/generated/post-tool-use.command.input.schema.json
+++ b/crates/agent/src/hooks/schema/generated/post-tool-use.command.input.schema.json
@@ -7,6 +7,31 @@
         "string",
         "null"
       ]
+    },
+    "StructuredToolResultWire": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": true,
+          "type": "array"
+        },
+        "execution_is_error": {
+          "type": "boolean"
+        },
+        "is_error": {
+          "type": "boolean"
+        },
+        "tool_source": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "is_error",
+        "execution_is_error",
+        "tool_source"
+      ],
+      "type": "object"
     }
   },
   "properties": {
@@ -36,6 +61,9 @@
       "type": "string"
     },
     "tool_response": true,
+    "tool_result": {
+      "$ref": "#/definitions/StructuredToolResultWire"
+    },
     "tool_use_id": {
       "type": "string"
     },
@@ -57,6 +85,7 @@
     "tool_name",
     "tool_input",
     "tool_response",
+    "tool_result",
     "tool_use_id"
   ],
   "title": "post-tool-use.command.input",

--- a/crates/agent/src/hooks/schema/generated/post-tool-use.command.output.schema.json
+++ b/crates/agent/src/hooks/schema/generated/post-tool-use.command.output.schema.json
@@ -21,11 +21,43 @@
         "hook_event_name": {
           "const": "post_tool_use",
           "type": "string"
+        },
+        "updated_output": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToolOutputPatchWire"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "hook_event_name"
       ],
+      "type": "object"
+    },
+    "ToolOutputPatchWire": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "default": null,
+          "items": true,
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "is_error": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
       "type": "object"
     }
   },

--- a/crates/agent/src/hooks/schema/generated/pre-compaction.command.output.schema.json
+++ b/crates/agent/src/hooks/schema/generated/pre-compaction.command.output.schema.json
@@ -8,6 +8,18 @@
       ],
       "type": "string"
     },
+    "CompactionOutputWire": {
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary"
+      ],
+      "type": "object"
+    },
     "PreCompactionHookSpecificOutputWire": {
       "additionalProperties": false,
       "properties": {
@@ -17,6 +29,17 @@
             "string",
             "null"
           ]
+        },
+        "compaction": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CompactionOutputWire"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "hook_event_name": {
           "const": "pre_compaction",

--- a/crates/agent/src/hooks/schema/generated/session-end.command.input.schema.json
+++ b/crates/agent/src/hooks/schema/generated/session-end.command.input.schema.json
@@ -10,24 +10,12 @@
     }
   },
   "properties": {
-    "candidate_summary": {
-      "$ref": "#/definitions/NullableString"
-    },
     "cwd": {
       "type": "string"
     },
     "hook_event_name": {
-      "const": "pre_compaction",
+      "const": "session_end",
       "type": "string"
-    },
-    "message_count": {
-      "format": "uint32",
-      "minimum": 0,
-      "type": "integer"
-    },
-    "messages": {
-      "items": true,
-      "type": "array"
     },
     "model": {
       "type": "string"
@@ -40,38 +28,25 @@
       ],
       "type": "string"
     },
+    "reason": {
+      "type": "string"
+    },
     "session_id": {
       "type": "string"
     },
-    "token_estimate": {
-      "format": "uint32",
-      "minimum": 0,
-      "type": "integer"
-    },
     "transcript_path": {
       "$ref": "#/definitions/NullableString"
-    },
-    "trigger": {
-      "type": "string"
-    },
-    "turn_id": {
-      "type": "string"
     }
   },
   "required": [
     "session_id",
-    "turn_id",
     "transcript_path",
     "cwd",
     "hook_event_name",
     "model",
     "permission_mode",
-    "trigger",
-    "token_estimate",
-    "message_count",
-    "messages",
-    "candidate_summary"
+    "reason"
   ],
-  "title": "pre-compaction.command.input",
+  "title": "delegation-failure.command.input",
   "type": "object"
 }

--- a/crates/agent/src/hooks/schema/generated/session-end.command.input.schema.json
+++ b/crates/agent/src/hooks/schema/generated/session-end.command.input.schema.json
@@ -47,6 +47,6 @@
     "permission_mode",
     "reason"
   ],
-  "title": "delegation-failure.command.input",
+  "title": "session-end.command.input",
   "type": "object"
 }

--- a/crates/agent/src/hooks/schema/generated/session-end.command.output.schema.json
+++ b/crates/agent/src/hooks/schema/generated/session-end.command.output.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "system_message": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "title": "session-end.command.output",
+  "type": "object"
+}

--- a/crates/agent/src/hooks/tests.rs
+++ b/crates/agent/src/hooks/tests.rs
@@ -1,11 +1,14 @@
-use super::engine::{Hooks, PostToolUseRequest, PreToolUseRequest, StopRequest};
+use super::engine::{
+    ContextHookRequest, Hooks, PostToolUseRequest, PreCompactionRequest, PreToolUseRequest,
+    StopRequest,
+};
 use super::schema;
 use crate::hooks::config::{HookHandlerConfig, HooksConfig, MatcherGroupConfig};
 use crate::hooks::schema::{
     PermissionRequestCommandOutputWire, PreCompactionCommandOutputWire,
     PreDelegationCommandOutputWire, PreToolUseCommandInput, StopCommandOutputWire,
 };
-use crate::hooks::{HookCommandConfig, HookEventConfig};
+use crate::hooks::{HookCommandConfig, HookEventConfig, HookMcpToolConfig};
 use schemars::JsonSchema;
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -27,6 +30,8 @@ fn generated_hook_schemas_match_expected_fixtures() {
         schema::PERMISSION_REQUEST_OUTPUT_FIXTURE,
         schema::POST_TOOL_USE_INPUT_FIXTURE,
         schema::POST_TOOL_USE_OUTPUT_FIXTURE,
+        schema::CONTEXT_INPUT_FIXTURE,
+        schema::CONTEXT_OUTPUT_FIXTURE,
         schema::USER_PROMPT_SUBMIT_INPUT_FIXTURE,
         schema::USER_PROMPT_SUBMIT_OUTPUT_FIXTURE,
         schema::SESSION_START_INPUT_FIXTURE,
@@ -45,6 +50,8 @@ fn generated_hook_schemas_match_expected_fixtures() {
         schema::POST_DELEGATION_OUTPUT_FIXTURE,
         schema::DELEGATION_FAILURE_INPUT_FIXTURE,
         schema::DELEGATION_FAILURE_OUTPUT_FIXTURE,
+        schema::SESSION_END_INPUT_FIXTURE,
+        schema::SESSION_END_OUTPUT_FIXTURE,
     ] {
         let generated = std::fs::read(generated_dir.join(file_name)).expect("generated fixture");
         let expected = std::fs::read(expected_dir.join(file_name)).expect("expected fixture");
@@ -153,9 +160,11 @@ fn hooks_config_accepts_command_hooks() {
         session_start: vec![MatcherGroupConfig {
             matcher: None,
             hooks: vec![HookHandlerConfig::Command(HookCommandConfig {
+                id: None,
                 command: "echo ok".to_string(),
                 timeout_sec: Some(5),
                 status_message: Some("check".to_string()),
+                additional_context_limit: None,
                 env: BTreeMap::new(),
             })],
         }],
@@ -178,6 +187,7 @@ fn hook_event_labels_are_stable() {
         "permission_request"
     );
     assert_eq!(HookEventConfig::PostToolUse.label(), "post_tool_use");
+    assert_eq!(HookEventConfig::Context.label(), "context");
     assert_eq!(HookEventConfig::Stop.label(), "stop");
     assert_eq!(HookEventConfig::PreCompaction.label(), "pre_compaction");
     assert_eq!(HookEventConfig::PostCompaction.label(), "post_compaction");
@@ -188,6 +198,7 @@ fn hook_event_labels_are_stable() {
         HookEventConfig::DelegationFailure.label(),
         "delegation_failure"
     );
+    assert_eq!(HookEventConfig::SessionEnd.label(), "session_end");
 }
 
 #[tokio::test]
@@ -207,9 +218,11 @@ printf '{"continue":true,"decision":"block","reason":"blocked from script"}'
         pre_tool_use: vec![MatcherGroupConfig {
             matcher: Some("^shell$".to_string()),
             hooks: vec![HookHandlerConfig::Command(HookCommandConfig {
+                id: None,
                 command: format!("sh {}", script.display()),
                 timeout_sec: Some(5),
                 status_message: None,
+                additional_context_limit: None,
                 env: BTreeMap::new(),
             })],
         }],
@@ -220,6 +233,7 @@ printf '{"continue":true,"decision":"block","reason":"blocked from script"}'
         .expect("hooks")
         .run_pre_tool_use(PreToolUseRequest {
             session_id: "s1".to_string(),
+            mcp_tool_state: None,
             turn_id: "t1".to_string(),
             cwd: Some(dir.path().to_path_buf()),
             model: "mock".to_string(),
@@ -252,9 +266,11 @@ printf 'this is not json'
         post_tool_use: vec![MatcherGroupConfig {
             matcher: Some("^shell$".to_string()),
             hooks: vec![HookHandlerConfig::Command(HookCommandConfig {
+                id: None,
                 command: format!("sh {}", script.display()),
                 timeout_sec: Some(5),
                 status_message: None,
+                additional_context_limit: None,
                 env: BTreeMap::new(),
             })],
         }],
@@ -265,13 +281,17 @@ printf 'this is not json'
         .expect("hooks")
         .run_post_tool_use(PostToolUseRequest {
             session_id: "s1".to_string(),
+            mcp_tool_state: None,
             turn_id: "t1".to_string(),
             cwd: Some(dir.path().to_path_buf()),
             model: "mock".to_string(),
             permission_mode: "default".to_string(),
             tool_name: "shell".to_string(),
             tool_input: json!({"command": "echo hi"}),
-            tool_response: json!("ok"),
+            content: vec![querymt::chat::Content::text("ok")],
+            is_error: false,
+            execution_is_error: false,
+            tool_source: "builtin".to_string(),
             tool_use_id: "tool1".to_string(),
         })
         .await
@@ -306,9 +326,11 @@ printf '{"continue":false,"reason":"continue please","hook_specific_output":{"ho
         stop: vec![MatcherGroupConfig {
             matcher: None,
             hooks: vec![HookHandlerConfig::Command(HookCommandConfig {
+                id: None,
                 command: format!("sh {}", script.display()),
                 timeout_sec: Some(5),
                 status_message: None,
+                additional_context_limit: None,
                 env: BTreeMap::new(),
             })],
         }],
@@ -334,6 +356,227 @@ printf '{"continue":false,"reason":"continue please","hook_specific_output":{"ho
         result.additional_contexts,
         vec!["one more pass".to_string()]
     );
+}
+
+#[test]
+fn hooks_config_accepts_mcp_tool_hooks() {
+    let config = HooksConfig {
+        enabled: true,
+        context: vec![MatcherGroupConfig {
+            matcher: None,
+            hooks: vec![HookHandlerConfig::McpTool(HookMcpToolConfig {
+                id: Some("retriever".into()),
+                server: "memory".into(),
+                tool: "retrieve".into(),
+                input: Some(json!({"query":"$event.model"})),
+                timeout_sec: Some(5),
+                status_message: Some("Retrieving context".into()),
+                additional_context_limit: Some(500),
+            })],
+        }],
+        ..HooksConfig::default()
+    };
+    Hooks::new(config).expect("valid MCP hook config");
+}
+
+#[test]
+fn mcp_input_templates_only_resolve_explicit_event_paths() {
+    let event = json!({"model":"test-model","nested":{"value":7}});
+    let resolved = super::engine::resolve_mcp_input_template_for_test(
+        &json!({"query":"$event.model","value":"$event.nested.value"}),
+        &event,
+    )
+    .unwrap();
+    assert_eq!(resolved, json!({"query":"test-model","value":7}));
+    assert!(
+        super::engine::resolve_mcp_input_template_for_test(
+            &json!({"bad":"$event.missing"}),
+            &event,
+        )
+        .is_err()
+    );
+}
+
+fn command_hook(command: String) -> HookHandlerConfig {
+    HookHandlerConfig::Command(HookCommandConfig {
+        id: None,
+        command,
+        timeout_sec: Some(5),
+        status_message: None,
+        additional_context_limit: None,
+        env: BTreeMap::new(),
+    })
+}
+
+#[tokio::test]
+async fn exit_two_blocks_with_stderr_and_surfaces_system_message() {
+    let config = HooksConfig {
+        enabled: true,
+        pre_tool_use: vec![MatcherGroupConfig {
+            matcher: Some("^shell$".into()),
+            hooks: vec![command_hook(
+                "printf '{\"system_message\":\"ignored stdout\"}'; printf 'policy denied' >&2; exit 2"
+                    .into(),
+            )],
+        }],
+        ..HooksConfig::default()
+    };
+    let result = Hooks::new(config)
+        .unwrap()
+        .run_pre_tool_use(PreToolUseRequest {
+            session_id: "s".into(),
+            mcp_tool_state: None,
+            turn_id: "t".into(),
+            cwd: None,
+            model: "m".into(),
+            permission_mode: "default".into(),
+            tool_name: "shell".into(),
+            tool_input: json!({"command":"true"}),
+            tool_use_id: "u".into(),
+        })
+        .await
+        .unwrap();
+    assert!(result.should_block);
+    assert_eq!(result.block_reason.as_deref(), Some("policy denied"));
+    assert_eq!(result.notices[0].message, "ignored stdout");
+}
+
+#[tokio::test]
+async fn pre_tool_rewrites_chain_in_order() {
+    let second = r#"input=$(cat); case "$input" in *first*) printf '%s' '{"hook_specific_output":{"hook_event_name":"pre_tool_use","permission_decision":"allow","updated_input":{"command":"second"}}}' ;; *) exit 9 ;; esac"#;
+    let config = HooksConfig {
+        enabled: true,
+        pre_tool_use: vec![MatcherGroupConfig {
+            matcher: Some("^shell$".into()),
+            hooks: vec![
+                command_hook("printf '%s' '{\"hook_specific_output\":{\"hook_event_name\":\"pre_tool_use\",\"permission_decision\":\"allow\",\"updated_input\":{\"command\":\"first\"}}}'".into()),
+                command_hook(second.into()),
+            ],
+        }],
+        ..HooksConfig::default()
+    };
+    let result = Hooks::new(config)
+        .unwrap()
+        .run_pre_tool_use(PreToolUseRequest {
+            session_id: "s".into(),
+            mcp_tool_state: None,
+            turn_id: "t".into(),
+            cwd: None,
+            model: "m".into(),
+            permission_mode: "default".into(),
+            tool_name: "shell".into(),
+            tool_input: json!({"command":"original"}),
+            tool_use_id: "u".into(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.updated_input, Some(json!({"command":"second"})));
+}
+
+#[tokio::test]
+async fn post_tool_patches_chain_and_preserve_execution_truth() {
+    let second = r#"input=$(cat); case "$input" in *redacted*) printf '%s' '{"hook_specific_output":{"hook_event_name":"post_tool_use","updated_output":{"is_error":true}}}' ;; *) exit 9 ;; esac"#;
+    let config = HooksConfig {
+        enabled: true,
+        post_tool_use: vec![MatcherGroupConfig {
+            matcher: Some("^shell$".into()),
+            hooks: vec![
+                command_hook("printf '%s' '{\"hook_specific_output\":{\"hook_event_name\":\"post_tool_use\",\"updated_output\":{\"content\":[{\"type\":\"text\",\"text\":\"redacted\"}]}}}'".into()),
+                command_hook(second.into()),
+            ],
+        }],
+        ..HooksConfig::default()
+    };
+    let result = Hooks::new(config)
+        .unwrap()
+        .run_post_tool_use(PostToolUseRequest {
+            session_id: "s".into(),
+            mcp_tool_state: None,
+            turn_id: "t".into(),
+            cwd: None,
+            model: "m".into(),
+            permission_mode: "default".into(),
+            tool_name: "shell".into(),
+            tool_input: json!({}),
+            content: vec![querymt::chat::Content::text("secret")],
+            is_error: false,
+            execution_is_error: false,
+            tool_source: "builtin".into(),
+            tool_use_id: "u".into(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.content.unwrap()[0].as_text(), Some("redacted"));
+    assert_eq!(result.is_error, Some(true));
+}
+
+#[tokio::test]
+async fn context_replacement_is_request_only_and_chained() {
+    let config = HooksConfig {
+        enabled: true,
+        context: vec![MatcherGroupConfig {
+            matcher: None,
+            hooks: vec![command_hook("printf '%s' '{\"hook_specific_output\":{\"hook_event_name\":\"context\",\"messages\":[{\"role\":\"User\",\"content\":[{\"type\":\"text\",\"text\":\"projected\"}],\"cache\":null}],\"additional_context\":\"memory\"}}'".into())],
+        }],
+        ..HooksConfig::default()
+    };
+    let stored = vec![querymt::chat::ChatMessage {
+        role: querymt::chat::ChatRole::User,
+        content: vec![querymt::chat::Content::text("stored")],
+        cache: None,
+    }];
+    let result = Hooks::new(config)
+        .unwrap()
+        .run_context(ContextHookRequest {
+            session_id: "s".into(),
+            mcp_tool_state: None,
+            turn_id: "t".into(),
+            cwd: None,
+            model: "m".into(),
+            permission_mode: "default".into(),
+            trigger: "user_prompt".into(),
+            context_window: 1000,
+            messages: stored.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(stored[0].content[0].as_text(), Some("stored"));
+    let projected = result.messages.unwrap();
+    assert_eq!(projected[0].content[0].as_text(), Some("projected"));
+    assert!(
+        projected[0].content[1]
+            .as_text()
+            .unwrap()
+            .contains("memory")
+    );
+}
+
+#[tokio::test]
+async fn pre_compaction_accepts_custom_summary() {
+    let config = HooksConfig {
+        enabled: true,
+        pre_compaction: vec![MatcherGroupConfig {
+            matcher: None,
+            hooks: vec![command_hook("printf '%s' '{\"hook_specific_output\":{\"hook_event_name\":\"pre_compaction\",\"compaction\":{\"summary\":\"custom summary\"}}}'".into())],
+        }],
+        ..HooksConfig::default()
+    };
+    let result = Hooks::new(config)
+        .unwrap()
+        .run_pre_compaction(PreCompactionRequest {
+            session_id: "s".into(),
+            turn_id: "t".into(),
+            cwd: None,
+            model: "m".into(),
+            permission_mode: "default".into(),
+            trigger: "context_threshold".into(),
+            token_estimate: 100,
+            message_count: 2,
+            messages: Vec::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.custom_summary.as_deref(), Some("custom summary"));
 }
 
 fn assert_matches_schema<T>(value: &serde_json::Value)

--- a/crates/agent/src/hooks/tests.rs
+++ b/crates/agent/src/hooks/tests.rs
@@ -409,6 +409,52 @@ fn command_hook(command: String) -> HookHandlerConfig {
 }
 
 #[tokio::test]
+async fn session_end_system_message_becomes_notice() {
+    let config = HooksConfig {
+        enabled: true,
+        session_end: vec![MatcherGroupConfig {
+            matcher: None,
+            hooks: vec![command_hook(
+                "printf '%s' '{\"system_message\":\"session closed\"}'".into(),
+            )],
+        }],
+        ..HooksConfig::default()
+    };
+
+    let input = crate::hooks::schema::SessionEndCommandInput {
+        session_id: "s".into(),
+        transcript_path: crate::hooks::schema::NullableString::from_string(None),
+        cwd: ".".into(),
+        hook_event_name: "session_end".into(),
+        model: "m".into(),
+        permission_mode: "default".into(),
+        reason: "close".into(),
+    };
+    assert_matches_schema::<crate::hooks::schema::SessionEndCommandInput>(
+        &serde_json::to_value(input).unwrap(),
+    );
+    let output = json!({"system_message":"session closed"});
+    assert_matches_schema::<crate::hooks::schema::SessionEndCommandOutputWire>(&output);
+
+    let result = Hooks::new(config)
+        .unwrap()
+        .run_session_end(super::engine::SessionEndRequest {
+            session_id: "s".into(),
+            cwd: None,
+            model: "m".into(),
+            permission_mode: "default".into(),
+            reason: "close".into(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.notices.len(), 1);
+    assert_eq!(result.notices[0].event_name, "session_end");
+    assert_eq!(result.notices[0].message, "session closed");
+    assert!(!result.notices[0].is_error);
+}
+
+#[tokio::test]
 async fn exit_two_blocks_with_stderr_and_surfaces_system_message() {
     let config = HooksConfig {
         enabled: true,

--- a/crates/agent/src/middleware/context.rs
+++ b/crates/agent/src/middleware/context.rs
@@ -770,7 +770,11 @@ mod tests {
 
         let state = ExecutionState::CallLlm {
             context: context.clone(),
-            tools: Arc::from([]),
+            request: Arc::new(crate::middleware::PreparedModelRequest {
+                messages: Arc::from([]),
+                tools: Arc::from([]),
+                estimated_tokens: 0,
+            }),
         };
 
         let result = fixture.run_step(state).await.unwrap();

--- a/crates/agent/src/middleware/dedup_check.rs
+++ b/crates/agent/src/middleware/dedup_check.rs
@@ -1082,8 +1082,11 @@ mod tests {
             call_id: "1".to_string(),
             content: vec![querymt::chat::Content::text("ok")],
             is_error: false,
+            execution_is_error: false,
+            tool_source: "builtin".to_string(),
             tool_name: Some("write_file".to_string()),
             tool_arguments: None,
+            hook_contexts: Vec::new(),
             snapshot_part: Some(MessagePart::Snapshot {
                 root_hash: crate::hash::RapidHash::new(b"test"),
                 changed_paths: DiffPaths {

--- a/crates/agent/src/middleware/driver_tests.rs
+++ b/crates/agent/src/middleware/driver_tests.rs
@@ -1,4 +1,5 @@
 use crate::events::StopType;
+use crate::middleware::PreparedModelRequest;
 use crate::middleware::{
     AgentStats, CompositeDriver, ConversationContext, ExecutionState, LimitsConfig,
     LimitsMiddleware, MaxStepsMiddleware, MiddlewareDriver, PriceLimitMiddleware,
@@ -190,7 +191,11 @@ async fn test_max_steps_ignores_other_states() {
 
     let state = ExecutionState::CallLlm {
         context: context.clone(),
-        tools: Arc::from([]),
+        request: Arc::new(PreparedModelRequest {
+            messages: Arc::from([]),
+            tools: Arc::from([]),
+            estimated_tokens: 0,
+        }),
     };
     let result = middleware.on_step_start(state, None).await.unwrap();
     assert!(matches!(result, ExecutionState::CallLlm { .. }));

--- a/crates/agent/src/middleware/mod.rs
+++ b/crates/agent/src/middleware/mod.rs
@@ -20,7 +20,8 @@ pub use driver::{CompositeDriver, MiddlewareDriver};
 pub use error::{MiddlewareError, Result};
 pub use state::{
     AgentStats, ContextFragment, ContextPriority, ConversationContext, ExecutionState, LlmResponse,
-    ToolCall, ToolFunction, ToolResult, WaitCondition, WaitReason, calculate_context_tokens,
+    PreparedModelRequest, ToolCall, ToolFunction, ToolResult, WaitCondition, WaitReason,
+    calculate_context_tokens,
 };
 
 // Re-export model info types for convenience

--- a/crates/agent/src/middleware/state.rs
+++ b/crates/agent/src/middleware/state.rs
@@ -109,6 +109,14 @@ pub struct ContextFragment {
 
 /// Context passed to middleware during state transitions
 #[derive(Debug, Clone)]
+pub struct PreparedModelRequest {
+    pub messages: Arc<[ChatMessage]>,
+    pub tools: Arc<[querymt::chat::Tool]>,
+    pub estimated_tokens: usize,
+}
+
+/// Context passed to middleware during state transitions
+#[derive(Debug, Clone)]
 pub struct ConversationContext {
     pub session_id: Arc<str>,
     pub messages: Arc<[ChatMessage]>,
@@ -221,7 +229,29 @@ impl ConversationContext {
 
     pub fn request_messages(&self) -> Vec<ChatMessage> {
         let mut messages = self.messages.to_vec();
-        messages.extend(self.fragment_messages());
+        let fragments = self.fragment_messages();
+        if fragments.is_empty() {
+            return messages;
+        }
+
+        // Keep the latest durable turn last. This preserves delegation and other
+        // resumed-turn feedback while still avoiding a message between tool use
+        // and its immediately following result.
+        if let Some(last) = messages.last()
+            && last.role == ChatRole::User
+            && last.content.iter().any(Content::is_tool_result)
+        {
+            let mut latest = messages.pop().expect("latest message was present");
+            latest
+                .content
+                .extend(fragments.into_iter().flat_map(|fragment| fragment.content));
+            messages.push(latest);
+        } else if let Some(latest) = messages.pop() {
+            messages.extend(fragments);
+            messages.push(latest);
+        } else {
+            messages.extend(fragments);
+        }
         messages
     }
 
@@ -310,8 +340,11 @@ pub struct ToolResult {
     pub call_id: String,
     pub content: Vec<Content>,
     pub is_error: bool,
+    pub execution_is_error: bool,
+    pub tool_source: String,
     pub tool_name: Option<String>,
     pub tool_arguments: Option<String>,
+    pub hook_contexts: Vec<crate::hooks::HookContextContribution>,
     pub snapshot_part: Option<MessagePart>,
 }
 
@@ -327,10 +360,27 @@ impl ToolResult {
             call_id,
             content,
             is_error,
+            execution_is_error: is_error,
+            tool_source: "unknown".to_string(),
             tool_name,
             tool_arguments,
+            hook_contexts: Vec::new(),
             snapshot_part: None,
         }
+    }
+
+    pub fn with_execution(mut self, is_error: bool, source: impl Into<String>) -> Self {
+        self.execution_is_error = is_error;
+        self.tool_source = source.into();
+        self
+    }
+
+    pub fn with_hook_contexts(
+        mut self,
+        contexts: Vec<crate::hooks::HookContextContribution>,
+    ) -> Self {
+        self.hook_contexts = contexts;
+        self
     }
 
     pub fn with_snapshot(mut self, part: MessagePart) -> Self {
@@ -398,7 +448,7 @@ pub enum ExecutionState {
     /// Ready to call the LLM with tools
     CallLlm {
         context: Arc<ConversationContext>,
-        tools: Arc<[querymt::chat::Tool]>,
+        request: Arc<PreparedModelRequest>,
     },
 
     /// After receiving LLM response
@@ -470,6 +520,61 @@ impl ExecutionState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_messages_keep_latest_feedback_after_context_fragments() {
+        let latest = ChatMessage {
+            role: ChatRole::User,
+            content: vec![Content::text("Delegation completed")],
+            cache: None,
+        };
+        let context = ConversationContext::new(
+            Arc::from("session"),
+            Arc::from([latest]),
+            Arc::new(AgentStats::default()),
+            Arc::from("provider"),
+            Arc::from("model"),
+        )
+        .upsert_fragment(
+            "run_objective",
+            "objective".to_string(),
+            ContextPriority::High,
+        );
+
+        let messages = context.request_messages();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text(), "objective");
+        assert_eq!(messages[1].text(), "Delegation completed");
+    }
+
+    #[test]
+    fn request_messages_append_fragments_after_tool_results() {
+        let latest = ChatMessage {
+            role: ChatRole::User,
+            content: vec![Content::tool_result(
+                "call-1".to_string(),
+                vec![Content::text("result")],
+            )],
+            cache: None,
+        };
+        let context = ConversationContext::new(
+            Arc::from("session"),
+            Arc::from([latest]),
+            Arc::new(AgentStats::default()),
+            Arc::from("provider"),
+            Arc::from("model"),
+        )
+        .upsert_fragment(
+            "run_objective",
+            "objective".to_string(),
+            ContextPriority::High,
+        );
+
+        let messages = context.request_messages();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].content[0].is_tool_result());
+        assert_eq!(messages[0].content[1].as_text(), Some("objective"));
+    }
 
     #[test]
     fn test_tool_result_with_snapshot() {

--- a/crates/agent/src/middleware/state.rs
+++ b/crates/agent/src/middleware/state.rs
@@ -237,15 +237,15 @@ impl ConversationContext {
         // Keep the latest durable turn last. This preserves delegation and other
         // resumed-turn feedback while still avoiding a message between tool use
         // and its immediately following result.
-        if let Some(last) = messages.last()
-            && last.role == ChatRole::User
-            && last.content.iter().any(Content::is_tool_result)
-        {
-            let mut latest = messages.pop().expect("latest message was present");
-            latest
-                .content
-                .extend(fragments.into_iter().flat_map(|fragment| fragment.content));
-            messages.push(latest);
+        if messages.last().is_some_and(|last| {
+            last.role == ChatRole::User && last.content.iter().any(Content::is_tool_result)
+        }) {
+            if let Some(mut latest) = messages.pop() {
+                latest
+                    .content
+                    .extend(fragments.into_iter().flat_map(|fragment| fragment.content));
+                messages.push(latest);
+            }
         } else if let Some(latest) = messages.pop() {
             messages.extend(fragments);
             messages.push(latest);

--- a/crates/agent/src/middleware/state_tests.rs
+++ b/crates/agent/src/middleware/state_tests.rs
@@ -1,7 +1,7 @@
 use crate::events::StopType;
 use crate::middleware::{
-    AgentStats, ConversationContext, ExecutionState, LlmResponse, ToolResult, WaitCondition,
-    WaitReason,
+    AgentStats, ConversationContext, ExecutionState, LlmResponse, PreparedModelRequest, ToolResult,
+    WaitCondition, WaitReason,
 };
 use crate::test_utils::{mock_tool_call, test_context};
 use querymt::chat::{ChatMessage, ChatRole, Content, FinishReason};
@@ -26,7 +26,11 @@ fn test_execution_state_name_all_variants() {
         (
             ExecutionState::CallLlm {
                 context: context.clone(),
-                tools: Arc::from([]),
+                request: Arc::new(PreparedModelRequest {
+                    messages: Arc::from([]),
+                    tools: Arc::from([]),
+                    estimated_tokens: 0,
+                }),
             },
             "CallLlm",
         ),
@@ -90,7 +94,11 @@ fn test_execution_state_context_accessors() {
         },
         ExecutionState::CallLlm {
             context: context.clone(),
-            tools: Arc::from([]),
+            request: Arc::new(PreparedModelRequest {
+                messages: Arc::from([]),
+                tools: Arc::from([]),
+                estimated_tokens: 0,
+            }),
         },
         ExecutionState::AfterLlm {
             response: response.clone(),

--- a/crates/agent/src/model.rs
+++ b/crates/agent/src/model.rs
@@ -38,6 +38,13 @@ pub enum MessagePart {
         cost: Option<f64>,
     },
     ToolUse(ToolCall),
+    HookContext {
+        event_name: String,
+        handler_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
+        content: String,
+    },
     ToolResult {
         call_id: String,
         content: Vec<Content>,
@@ -90,6 +97,7 @@ impl MessagePart {
             MessagePart::StepStart { .. } => "step_start",
             MessagePart::StepFinish { .. } => "step_finish",
             MessagePart::ToolUse(_) => "tool_use",
+            MessagePart::HookContext { .. } => "hook_context",
             MessagePart::ToolResult { .. } => "tool_result",
             MessagePart::Patch { .. } => "patch",
             MessagePart::Snapshot { .. } => "snapshot",
@@ -212,6 +220,21 @@ impl AgentMessage {
                         serde_json::from_str(&tc.function.arguments)
                             .unwrap_or_else(|_| serde_json::Value::Object(Default::default())),
                     ));
+                }
+                MessagePart::HookContext {
+                    event_name,
+                    handler_id,
+                    tool_use_id,
+                    content,
+                } => {
+                    let tool_label = tool_use_id
+                        .as_deref()
+                        .map(|id| format!(" tool_use_id={}", id))
+                        .unwrap_or_default();
+                    blocks.push(Content::text(format!(
+                        "<hook-context event={} handler={}{}>\n{}\n</hook-context>",
+                        event_name, handler_id, tool_label, content
+                    )));
                 }
                 MessagePart::ToolResult {
                     call_id,

--- a/crates/agent/src/test_utils/drivers.rs
+++ b/crates/agent/src/test_utils/drivers.rs
@@ -499,7 +499,11 @@ impl MiddlewareDriver for BeforeLlmCallToCallLlmDriver {
         match state {
             ExecutionState::BeforeLlmCall { context } => Ok(ExecutionState::CallLlm {
                 context,
-                tools: Arc::from([]),
+                request: Arc::new(crate::middleware::PreparedModelRequest {
+                    messages: Arc::from([]),
+                    tools: Arc::from([]),
+                    estimated_tokens: 0,
+                }),
             }),
             other => Ok(other),
         }

--- a/docs/docs/agent/hooks.md
+++ b/docs/docs/agent/hooks.md
@@ -371,6 +371,8 @@ Relevant files include:
 - `crates/agent/src/hooks/schema/generated/pre-tool-use.command.output.schema.json`
 - `crates/agent/src/hooks/schema/generated/permission-request.command.input.schema.json`
 - `crates/agent/src/hooks/schema/generated/permission-request.command.output.schema.json`
+- `crates/agent/src/hooks/schema/generated/context.command.input.schema.json`
+- `crates/agent/src/hooks/schema/generated/context.command.output.schema.json`
 - `crates/agent/src/hooks/schema/generated/pre-compaction.command.input.schema.json`
 - `crates/agent/src/hooks/schema/generated/pre-compaction.command.output.schema.json`
 - `crates/agent/src/hooks/schema/generated/post-compaction.command.input.schema.json`
@@ -383,6 +385,8 @@ Relevant files include:
 - `crates/agent/src/hooks/schema/generated/post-delegation.command.output.schema.json`
 - `crates/agent/src/hooks/schema/generated/delegation-failure.command.input.schema.json`
 - `crates/agent/src/hooks/schema/generated/delegation-failure.command.output.schema.json`
+- `crates/agent/src/hooks/schema/generated/session-end.command.input.schema.json`
+- `crates/agent/src/hooks/schema/generated/session-end.command.output.schema.json`
 - `crates/agent/src/hooks/schema/generated/stop.command.input.schema.json`
 - `crates/agent/src/hooks/schema/generated/stop.command.output.schema.json`
 

--- a/docs/docs/agent/hooks.md
+++ b/docs/docs/agent/hooks.md
@@ -1,6 +1,6 @@
 # QueryMT Agent - Hooks
 
-Hooks let you run configured local commands at specific points in the agent lifecycle. They are useful for policy checks, audit logging, approval automation, tool input rewriting, compaction control, delegation control, and stop-time validation.
+Hooks let you run configured local commands at specific points in the agent lifecycle. They are useful for policy checks, audit logging, approval automation, ordered tool input and result transformation, non-destructive request projection, compaction control, delegation control, and stop-time validation.
 
 ## Overview
 
@@ -44,7 +44,9 @@ matcher = "^shell$"
 type = "command"
 command = "sh ./hooks/check-shell.sh"
 timeout_sec = 5
+id = "shell-policy"
 status_message = "Checking shell command"
+additional_context_limit = 2500
 
 [[agent.hooks.pre_compaction]]
 
@@ -71,9 +73,25 @@ timeout_sec = 5
 
 Because hooks live in `[agent.hooks]`, they work well with QueryMT profiles. For example, a review profile can enable stricter `stop` hooks while a coding profile can enable shell-policy hooks. See `crates/agent/examples/confs/hook_guarded_coder.toml` and the companion scripts in `crates/agent/examples/hooks/` for a complete runnable example.
 
+Handlers may also invoke an already-connected MCP tool directly:
+
+```toml
+[[agent.hooks.context]]
+
+[[agent.hooks.context.hooks]]
+type = "mcp_tool"
+id = "memory-retriever"
+server = "memory"
+tool = "retrieve_context"
+timeout_sec = 10
+input = { query = "$event.model", messages = "$event.messages" }
+```
+
+MCP hook handlers are bound to both `server` and `tool`, bypass the model-visible tool loop, and therefore cannot recursively trigger tool hooks. Template strings must be exact `$event.<field>` paths into the event payload; arbitrary interpolation is not supported. MCP handlers currently require an execution-scoped event (`pre_tool_use`, `permission_request`, `post_tool_use`, or `context`) where connected tool state is available. The MCP tool's text content is parsed with the same output contract as a command hook.
+
 ## Hook Command Protocol
 
-Each hook command:
+Each command hook:
 
 - runs as a local process
 - receives one JSON object on stdin
@@ -108,18 +126,31 @@ QueryMT currently supports these hook events:
 
 | Event | Matcher | Effect |
 |---|---|---|
-| `session_start` | none | Observe session creation |
-| `user_prompt_submit` | none | Block a prompt |
-| `pre_tool_use` | tool name regex | Block or rewrite tool input |
-| `permission_request` | tool name regex | Allow or deny permission prompts |
-| `post_tool_use` | tool name regex | Mark a tool result as blocked/error |
-| `pre_compaction` | none | Block compaction and replace the final stop reason shown to the user |
+| `session_start` | none | Gate the next run and contribute context to the next user turn |
+| `user_prompt_submit` | none | Block a prompt or persist provenance-labeled context with it |
+| `pre_tool_use` | tool name regex | Block, approve/defer permission, or chain tool-input rewrites |
+| `permission_request` | tool name regex | Allow or deny permission prompts; deny wins |
+| `post_tool_use` | tool name regex | Chain model-visible content/error patches without changing execution facts |
+| `context` | none | Replace the current request projection or add request-only context |
+| `pre_compaction` | none | Block compaction or provide a complete custom summary |
 | `post_compaction` | none | Append context to the stored compaction summary |
 | `pre_delegation` | target agent regex | Block or rewrite a delegation request before it is recorded |
 | `delegation_start` | target agent regex | Observe delegation start and append planning context for the child session |
 | `post_delegation` | target agent regex | Append context to the delegate summary injected back into the planner |
 | `delegation_failure` | target agent regex | Append context to the failure message injected back into the planner |
 | `stop` | none | Request one extra LLM step |
+| `session_end` | none | Observe explicit session close or deletion |
+
+Handlers run in configuration order. Transform-capable events rebuild each handler's input from the last accepted value. A pre-operation block is sticky. Invalid JSON and invalid replacements emit a durable `hook_notice` and retain the last valid value.
+
+Command exit behavior is:
+
+- exit `0`: parse stdout; empty stdout is a no-op
+- exit `2`: block with trimmed stderr as the reason; stdout does not control the operation
+- other non-zero exits, signals, and timeouts: hook infrastructure errors
+- `system_message`: emitted as a non-error durable notice and never inserted into model context
+
+`additional_context` defaults to an approximate 2500-token limit, configurable per handler with `additional_context_limit`. Prompt and tool contributions are persisted as typed, provenance-labeled message parts. Tool contributions are placed after every `tool_result` block in the combined result message. `context` contributions exist only in the prepared request and never mutate stored history.
 
 ## Examples
 
@@ -156,12 +187,47 @@ Expected hook output:
 {
   "hook_specific_output": {
     "hook_event_name": "pre_tool_use",
+    "permission_decision": "allow",
     "updated_input": {
       "command": "cargo test -p querymt-agent --lib"
     }
   }
 }
 ```
+
+Multiple matching `pre_tool_use` handlers see this rewritten object in order. A rewrite is accepted only with `permission_decision: "allow"`; `ask` follows normal interactive permission handling.
+
+### post_tool_use patch
+
+```json
+{
+  "hook_specific_output": {
+    "hook_event_name": "post_tool_use",
+    "updated_output": {
+      "content": [{ "type": "text", "text": "Redacted result" }],
+      "is_error": false
+    },
+    "additional_context": "Sensitive values were removed."
+  },
+  "system_message": "Tool output was sanitized."
+}
+```
+
+The `tool_response` input remains available as flattened text. The new `tool_result` input contains structured `content`, model-facing `is_error`, immutable `execution_is_error`, and `tool_source`. Post hooks run before final output truncation.
+
+### context projection
+
+```json
+{
+  "hook_specific_output": {
+    "hook_event_name": "context",
+    "messages": [],
+    "additional_context": "Request-only retrieved memory"
+  }
+}
+```
+
+A `context` replacement affects one logical request only. QueryMT rejects malformed projections, unmatched tool calls/results, or changes to existing tool-call identities, then recomputes cache hints after transformation. Provider retries reuse the prepared projection and do not rerun the hook.
 
 ### permission_request allow
 
@@ -193,6 +259,21 @@ Expected hook output:
   }
 }
 ```
+
+### custom compaction
+
+```json
+{
+  "hook_specific_output": {
+    "hook_event_name": "pre_compaction",
+    "compaction": { "summary": "Externally generated summary" }
+  }
+}
+```
+
+A non-blank custom summary skips the compaction model call. Each later handler receives the current candidate in `candidate_summary`; the last valid candidate wins. `pre_compaction.messages` contains the effective typed history used for compaction. QueryMT still owns token counts, message IDs, persistence, boundaries, and effective-history reload.
+
+Command hooks are the portable lifecycle mechanism. MCP-backed handlers are intended for automatic retrieval, sanitation, and policy calls against connected services; ordinary MCP tools remain separately registered and model-visible. Compiled middleware remains the right choice for in-process state-machine behavior.
 
 ### pre_compaction block
 


### PR DESCRIPTION
- Added `jsonschema` dependency for runtime tool argument validation.
- Introduced `context` and `session_end` hook events with full input/output schemas and MCP tool handler support.
- Refined tool execution: separated execution errors from validation errors, added `hook_contexts`, `execution_is_error`, and `tool_source` to tool results.
- Replaced `additional_contexts` mechanism with `context_contributions` (typed provenance) for consistent message construction across session start, user prompt, and hook events.
- Moved truncation logic to dedicated `truncate_model_tool_output` function, applying it once post-pipeline while preserving error state.
- Updated `PreparedModelRequest` to carry messages, tools, and estimated tokens; restructured `transition_before_llm` to use hook-adjusted messages and enforce context windows.
- Enhanced `Hooks` engine with `mcp_tool` handler resolution, `PreToolPermissionDecision`, and improved notice handling for commands and MCP invocations.
- Added validation, schema generation fixes, and comprehensive tests for new hook types, MCP integration, argument validation, and chained transformations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context and session-end hook events.
  * Added MCP-backed hook handlers with configurable inputs, timeouts, permissions, and context limits.
  * Hooks can inject context, transform tool inputs and outputs, block execution, and preserve execution metadata.
  * Added custom pre-compaction summaries and session-end notices.
  * User prompts and tool results now retain hook-provided context and provenance.

* **Bug Fixes**
  * Improved tool-argument validation, output handling, and execution-error reporting.

* **Documentation**
  * Expanded hook documentation with configuration examples and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->