### PR TITLE
fix: openai tool call order

### DIFF
--- a/crates/providers/deepseek/src/lib.rs
+++ b/crates/providers/deepseek/src/lib.rs
@@ -273,6 +273,50 @@ pub extern "C" fn plugin_http_factory() -> *mut dyn HTTPLLMProviderFactory {
     Box::into_raw(Box::new(DeepseekFactory)) as *mut _
 }
 
+#[cfg(test)]
+mod tests {
+    use super::Deepseek;
+    use querymt::chat::{ChatMessage, Content, http::HTTPChatProvider};
+    use serde_json::Value;
+
+    #[test]
+    fn stream_request_keeps_context_inside_tool_response_batch() {
+        let provider: Deepseek = serde_json::from_value(serde_json::json!({
+            "api_key": "test-key",
+            "model": "deepseek-chat"
+        }))
+        .unwrap();
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use("call_1", "ls", serde_json::json!({"path": "."}))
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    "call_1".to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .text("<run-objective>Collect benchmark data</run-objective>")
+                .build(),
+        ];
+
+        let request = provider.chat_stream_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(api_messages.len(), 2);
+        assert_eq!(api_messages[1]["role"], "tool");
+        assert_eq!(api_messages[1]["tool_call_id"], "call_1");
+        assert!(
+            api_messages[1]["content"]
+                .as_str()
+                .unwrap()
+                .contains("<run-objective>")
+        );
+    }
+}
+
 #[cfg(feature = "extism")]
 mod extism_exports {
     use super::{Deepseek, DeepseekFactory};

--- a/crates/providers/kimi-code/src/lib.rs
+++ b/crates/providers/kimi-code/src/lib.rs
@@ -409,6 +409,41 @@ mod tests {
     }
 
     #[test]
+    fn stream_request_keeps_context_inside_tool_response_batch() {
+        use querymt::chat::Content;
+
+        let provider = test_provider();
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use("call_1", "ls", serde_json::json!({"path": "."}))
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    "call_1".to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .text("<run-objective>Collect benchmark data</run-objective>")
+                .build(),
+        ];
+
+        let request = provider.chat_stream_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(api_messages.len(), 2);
+        assert_eq!(api_messages[1]["role"], "tool");
+        assert_eq!(api_messages[1]["tool_call_id"], "call_1");
+        assert!(
+            api_messages[1]["content"]
+                .as_str()
+                .unwrap()
+                .contains("<run-objective>")
+        );
+    }
+
+    #[test]
     fn chat_request_injects_reasoning_content_for_assistant_tool_calls() {
         let provider = test_provider();
         let mut parser = provider

--- a/crates/providers/kimi-code/src/lib.rs
+++ b/crates/providers/kimi-code/src/lib.rs
@@ -199,7 +199,27 @@ impl ChatStreamParser for KimiCodeStreamParser {
             String::from_utf8_lossy(chunk)
         );
         let normalized = KimiCode::normalize_sse_data_prefix(chunk);
-        parse_openai_sse_chunk(&normalized, &mut self.tool_states)
+        let mut chunks = parse_openai_sse_chunk(&normalized, &mut self.tool_states)?;
+
+        // Kimi may omit tool call IDs and internally address those calls as
+        // `<function-name>:<index>`. Persist that ID so the subsequent tool
+        // response uses the same identifier when the conversation is replayed.
+        for chunk in &mut chunks {
+            match chunk {
+                StreamChunk::ToolUseStart { index, id, name } if id.is_empty() => {
+                    *id = format!("{name}:{index}");
+                    if let Some(state) = self.tool_states.get_mut(index) {
+                        state.id.clone_from(id);
+                    }
+                }
+                StreamChunk::ToolUseComplete { index, tool_call } if tool_call.id.is_empty() => {
+                    tool_call.id = format!("{}:{index}", tool_call.function.name);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(chunks)
     }
 }
 
@@ -700,6 +720,65 @@ mod tests {
             has_done,
             "expected Done with FinishReason::ToolCalls in {events3:?}"
         );
+    }
+
+    #[test]
+    fn missing_tool_call_id_is_stable_across_response_and_replay() {
+        use querymt::chat::{Content, StreamChunk};
+
+        let provider = test_provider();
+        let mut parser = provider
+            .chat_stream_parser()
+            .expect("stream parser should initialize");
+
+        let start = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}]}}]}
+
+"#;
+        let start_events = parser.parse_chunk(start).unwrap();
+        assert!(matches!(
+            &start_events[0],
+            StreamChunk::ToolUseStart { index: 0, id, name }
+                if id == "ls:0" && name == "ls"
+        ));
+
+        let finish = br#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+"#;
+        let complete = parser
+            .parse_chunk(finish)
+            .unwrap()
+            .into_iter()
+            .find_map(|chunk| match chunk {
+                StreamChunk::ToolUseComplete { tool_call, .. } => Some(tool_call),
+                _ => None,
+            })
+            .expect("tool call should complete");
+        assert_eq!(complete.id, "ls:0");
+
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use(
+                    complete.id.clone(),
+                    complete.function.name,
+                    serde_json::from_str(&complete.function.arguments).unwrap(),
+                )
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    complete.id,
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .build(),
+        ];
+        let request = provider.chat_stream_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(api_messages.len(), 2);
+        assert_eq!(api_messages[0]["tool_calls"][0]["id"], "ls:0");
+        assert_eq!(api_messages[1]["tool_call_id"], "ls:0");
     }
 
     #[test]

--- a/crates/providers/kimi-code/src/lib.rs
+++ b/crates/providers/kimi-code/src/lib.rs
@@ -11,7 +11,7 @@ use querymt::{
     HTTPLLMProvider,
     auth::ApiKeyResolver,
     chat::{
-        ChatMessage, ChatResponse, StreamChunk, StructuredOutputFormat, Tool, ToolChoice,
+        ChatMessage, ChatResponse, Content, StreamChunk, StructuredOutputFormat, Tool, ToolChoice,
         http::{ChatStreamParser, HTTPChatProvider},
     },
     completion::{CompletionRequest, CompletionResponse, http::HTTPCompletionProvider},
@@ -158,7 +158,8 @@ impl HTTPChatProvider for KimiCode {
         let mut resolved = self.clone();
         resolved.api_key = self.resolved_api_key();
         let profile = self.profile();
-        let mut request = openai_chat_request(&resolved, messages, tools)?;
+        let normalized_messages = KimiCode::normalize_messages(messages);
+        let mut request = openai_chat_request(&resolved, &normalized_messages, tools)?;
         KimiCode::apply_kimi_agent_headers(&mut request, &profile)?;
         Ok(request)
     }
@@ -172,7 +173,8 @@ impl HTTPChatProvider for KimiCode {
         resolved.api_key = self.resolved_api_key();
         resolved.stream = Some(true);
         let profile = self.profile();
-        let mut request = openai_chat_request(&resolved, messages, tools)?;
+        let normalized_messages = KimiCode::normalize_messages(messages);
+        let mut request = openai_chat_request(&resolved, &normalized_messages, tools)?;
         KimiCode::apply_kimi_agent_headers(&mut request, &profile)?;
         Ok(request)
     }
@@ -260,6 +262,38 @@ impl HTTPLLMProvider for KimiCode {
 impl KimiCode {
     fn default_base_url() -> Url {
         Url::parse("https://api.kimi.com/coding/v1/").unwrap()
+    }
+
+    fn normalize_messages(messages: &[ChatMessage]) -> Vec<ChatMessage> {
+        let mut normalized = Vec::with_capacity(messages.len());
+
+        for message in messages {
+            if message.content.iter().any(Content::is_tool_result) {
+                let mut tool_results = message.clone();
+                let supplemental = tool_results
+                    .content
+                    .iter()
+                    .filter(|block| !block.is_tool_result())
+                    .cloned()
+                    .collect::<Vec<_>>();
+                tool_results.content.retain(Content::is_tool_result);
+                let role = tool_results.role.clone();
+                let cache = tool_results.cache.clone();
+                normalized.push(tool_results);
+
+                if !supplemental.is_empty() {
+                    normalized.push(ChatMessage {
+                        role,
+                        content: supplemental,
+                        cache,
+                    });
+                }
+            } else {
+                normalized.push(message.clone());
+            }
+        }
+
+        normalized
     }
 
     fn resolved_api_key(&self) -> String {
@@ -429,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn stream_request_keeps_context_inside_tool_response_batch() {
+    fn stream_request_emits_context_after_tool_response_batch() {
         use querymt::chat::Content;
 
         let provider = test_provider();
@@ -452,11 +486,50 @@ mod tests {
         let body: Value = serde_json::from_slice(request.body()).unwrap();
         let api_messages = body["messages"].as_array().unwrap();
 
-        assert_eq!(api_messages.len(), 2);
+        assert_eq!(api_messages.len(), 3);
         assert_eq!(api_messages[1]["role"], "tool");
         assert_eq!(api_messages[1]["tool_call_id"], "call_1");
+        assert_eq!(api_messages[1]["content"], "specs.md");
+        assert_eq!(api_messages[2]["role"], "user");
         assert!(
-            api_messages[1]["content"]
+            api_messages[2]["content"]
+                .as_str()
+                .unwrap()
+                .contains("<run-objective>")
+        );
+    }
+
+    #[test]
+    fn non_stream_request_emits_context_after_tool_response_batch() {
+        use querymt::chat::Content;
+
+        let provider = test_provider();
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use("call_1", "ls", serde_json::json!({"path": "."}))
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    "call_1".to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .text("<run-objective>Collect benchmark data</run-objective>")
+                .build(),
+        ];
+
+        let request = provider.chat_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(api_messages.len(), 3);
+        assert_eq!(api_messages[1]["role"], "tool");
+        assert_eq!(api_messages[1]["tool_call_id"], "call_1");
+        assert_eq!(api_messages[1]["content"], "specs.md");
+        assert_eq!(api_messages[2]["role"], "user");
+        assert!(
+            api_messages[2]["content"]
                 .as_str()
                 .unwrap()
                 .contains("<run-objective>")
@@ -723,7 +796,24 @@ mod tests {
     }
 
     #[test]
-    fn missing_tool_call_id_is_stable_across_response_and_replay() {
+    fn non_streaming_response_preserves_opaque_tool_call_id() {
+        let provider = test_provider();
+        let response = http::Response::builder()
+            .status(200)
+            .body(
+                br#"{"choices":[{"finish_reason":"tool_calls","message":{"role":"assistant","content":null,"tool_calls":[{"id":"tool_LUbH2dHPwNU9pt1GrIYrywKV","type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}]}}]}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let response = provider.parse_chat(response).unwrap();
+        let tool_calls = response.tool_calls().expect("tool calls should be present");
+
+        assert_eq!(tool_calls[0].id, "tool_LUbH2dHPwNU9pt1GrIYrywKV");
+    }
+
+    #[test]
+    fn streaming_tool_call_id_is_stable_across_response_and_replay() {
         use querymt::chat::{Content, StreamChunk};
 
         let provider = test_provider();
@@ -731,14 +821,14 @@ mod tests {
             .chat_stream_parser()
             .expect("stream parser should initialize");
 
-        let start = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}]}}]}
+        let start = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"tool_LUbH2dHPwNU9pt1GrIYrywKV","type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}]}}]}
 
 "#;
         let start_events = parser.parse_chunk(start).unwrap();
         assert!(matches!(
             &start_events[0],
             StreamChunk::ToolUseStart { index: 0, id, name }
-                if id == "ls:0" && name == "ls"
+                if id == "tool_LUbH2dHPwNU9pt1GrIYrywKV" && name == "ls"
         ));
 
         let finish = br#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
@@ -753,7 +843,7 @@ mod tests {
                 _ => None,
             })
             .expect("tool call should complete");
-        assert_eq!(complete.id, "ls:0");
+        assert_eq!(complete.id, "tool_LUbH2dHPwNU9pt1GrIYrywKV");
 
         let messages = vec![
             ChatMessage::assistant()
@@ -777,8 +867,88 @@ mod tests {
         let api_messages = body["messages"].as_array().unwrap();
 
         assert_eq!(api_messages.len(), 2);
-        assert_eq!(api_messages[0]["tool_calls"][0]["id"], "ls:0");
-        assert_eq!(api_messages[1]["tool_call_id"], "ls:0");
+        assert_eq!(
+            api_messages[0]["tool_calls"][0]["id"],
+            "tool_LUbH2dHPwNU9pt1GrIYrywKV"
+        );
+        assert_eq!(
+            api_messages[1]["tool_call_id"],
+            "tool_LUbH2dHPwNU9pt1GrIYrywKV"
+        );
+    }
+
+    #[test]
+    fn replay_preserves_existing_opaque_tool_call_ids() {
+        use querymt::chat::Content;
+
+        let provider = test_provider();
+        let opaque_id = "tool_LUbH2dHPwNU9pt1GrIYrywKV";
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use(opaque_id, "ls", serde_json::json!({"path": "."}))
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    opaque_id.to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .build(),
+        ];
+
+        let request = provider.chat_stream_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(api_messages[0]["tool_calls"][0]["id"], opaque_id);
+        assert_eq!(api_messages[1]["tool_call_id"], opaque_id);
+    }
+
+    #[test]
+    fn replay_preserves_multiple_tool_call_ids_and_result_order() {
+        use querymt::chat::Content;
+
+        let provider = test_provider();
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use("opaque-ls-1", "ls", serde_json::json!({"path": "."}))
+                .tool_use("opaque-read", "read_tool", serde_json::json!({"path": "a"}))
+                .tool_use("opaque-ls-2", "ls", serde_json::json!({"path": "src"}))
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    "opaque-read".to_string(),
+                    Some("read_tool".to_string()),
+                    false,
+                    vec![Content::text("a")],
+                )
+                .tool_result(
+                    "opaque-ls-2".to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("src/lib.rs")],
+                )
+                .tool_result(
+                    "opaque-ls-1".to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("a")],
+                )
+                .build(),
+        ];
+
+        let request = provider.chat_stream_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        let tool_calls = api_messages[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls[0]["id"], "opaque-ls-1");
+        assert_eq!(tool_calls[1]["id"], "opaque-read");
+        assert_eq!(tool_calls[2]["id"], "opaque-ls-2");
+        assert_eq!(api_messages[1]["tool_call_id"], "opaque-read");
+        assert_eq!(api_messages[2]["tool_call_id"], "opaque-ls-2");
+        assert_eq!(api_messages[3]["tool_call_id"], "opaque-ls-1");
     }
 
     #[test]

--- a/crates/providers/kimi-code/src/lib.rs
+++ b/crates/providers/kimi-code/src/lib.rs
@@ -878,6 +878,65 @@ mod tests {
     }
 
     #[test]
+    fn missing_tool_call_id_is_stable_across_response_and_replay() {
+        use querymt::chat::{Content, StreamChunk};
+
+        let provider = test_provider();
+        let mut parser = provider
+            .chat_stream_parser()
+            .expect("stream parser should initialize");
+
+        let start = br#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}]}}]}
+
+"#;
+        let start_events = parser.parse_chunk(start).unwrap();
+        assert!(matches!(
+            &start_events[0],
+            StreamChunk::ToolUseStart { index: 0, id, name }
+                if id == "ls:0" && name == "ls"
+        ));
+
+        let finish = br#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+"#;
+        let complete = parser
+            .parse_chunk(finish)
+            .unwrap()
+            .into_iter()
+            .find_map(|chunk| match chunk {
+                StreamChunk::ToolUseComplete { tool_call, .. } => Some(tool_call),
+                _ => None,
+            })
+            .expect("tool call should complete");
+        assert_eq!(complete.id, "ls:0");
+
+        let messages = vec![
+            ChatMessage::assistant()
+                .tool_use(
+                    complete.id.clone(),
+                    complete.function.name,
+                    serde_json::from_str(&complete.function.arguments).unwrap(),
+                )
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    complete.id,
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .build(),
+        ];
+        let request = provider.chat_stream_request(&messages, None).unwrap();
+        let body: Value = serde_json::from_slice(request.body()).unwrap();
+        let api_messages = body["messages"].as_array().unwrap();
+
+        assert_eq!(api_messages.len(), 2);
+        assert_eq!(api_messages[0]["tool_calls"][0]["id"], "ls:0");
+        assert_eq!(api_messages[1]["tool_call_id"], "ls:0");
+    }
+
+    #[test]
     fn replay_preserves_existing_opaque_tool_call_ids() {
         use querymt::chat::Content;
 

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -932,44 +932,39 @@ fn convert_chat_message_to_openai<'a>(
     // Check if this message contains any ToolUse blocks — those map to tool_calls.
     let has_tool_use = chat_msg.content.iter().any(|b| b.is_tool_use());
 
-    // Emit tool result blocks as separate messages
+    // Emit tool result blocks as separate messages. Any supplemental text on the
+    // same ChatMessage is request context associated with the result batch. Keep
+    // it inside the final tool response: some OpenAI-compatible APIs reject a
+    // user message interleaved between an assistant tool call and its responses.
     if has_tool_results {
-        for block in &chat_msg.content {
+        let supplemental_text = chat_msg
+            .content
+            .iter()
+            .filter(|block| !block.is_tool_result())
+            .filter_map(Content::as_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let last_tool_result_index = chat_msg.content.iter().rposition(Content::is_tool_result);
+
+        for (index, block) in chat_msg.content.iter().enumerate() {
             if let Content::ToolResult { id, content, .. } = block {
-                // Extract text from the tool result content blocks
-                let text: String = content
+                let mut text = content
                     .iter()
-                    .filter_map(|c| c.as_text().map(str::to_string))
+                    .filter_map(Content::as_text)
                     .collect::<Vec<_>>()
                     .join("\n");
+                if Some(index) == last_tool_result_index && !supplemental_text.is_empty() {
+                    if !text.is_empty() {
+                        text.push_str("\n\n");
+                    }
+                    text.push_str(&supplemental_text);
+                }
                 out.push(OpenAIChatMessage {
                     role: Cow::Borrowed("tool"),
                     tool_call_id: Some(Cow::Borrowed(id.as_str())),
                     tool_calls: None,
                     content: Some(Right(Cow::Owned(text))),
                     reasoning_content: None,
-                });
-            }
-        }
-        // If there are also non-tool-result blocks (e.g. text), emit those too
-        let non_tool_content: Vec<&Content> = chat_msg
-            .content
-            .iter()
-            .filter(|b| !b.is_tool_result())
-            .collect();
-        if !non_tool_content.is_empty() {
-            let text: String = non_tool_content
-                .iter()
-                .filter_map(|b| b.as_text().map(str::to_string))
-                .collect::<Vec<_>>()
-                .join("\n");
-            if !text.is_empty() {
-                out.push(OpenAIChatMessage {
-                    role,
-                    tool_call_id: None,
-                    tool_calls: None,
-                    content: Some(Right(Cow::Owned(text))),
-                    reasoning_content: extract_reasoning_content(chat_msg, include_reasoning),
                 });
             }
         }
@@ -1610,6 +1605,44 @@ mod tests {
             }
             other => panic!("expected AuthError, got {other}"),
         }
+    }
+
+    #[test]
+    fn tool_result_context_stays_in_the_tool_response_batch() {
+        use querymt::chat::{ChatMessage, Content};
+
+        let messages = [
+            ChatMessage::assistant()
+                .text("I'll inspect the workspace.")
+                .tool_use("call_1", "ls", serde_json::json!({"path": "."}))
+                .build(),
+            ChatMessage::user()
+                .tool_result(
+                    "call_1".to_string(),
+                    Some("ls".to_string()),
+                    false,
+                    vec![Content::text("specs.md")],
+                )
+                .text("<run-objective>Collect benchmark data</run-objective>")
+                .build(),
+        ];
+
+        let mut converted = Vec::new();
+        for message in &messages {
+            super::convert_chat_message_to_openai(message, &mut converted, true);
+        }
+        let converted = serde_json::to_value(converted).unwrap();
+        let messages = converted.as_array().unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+        assert_eq!(
+            messages[1]["content"],
+            "specs.md\n\n<run-objective>Collect benchmark data</run-objective>"
+        );
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming and non-streaming conversations involving assistant tool calls, tool results, and supplemental text.
  - Preserved tool metadata, context, and message ordering in affected requests.
  - Added stable handling for tool calls without IDs, including consistent IDs in follow-up responses.
  - Preserved response identifiers during tool-call completion and replay.

- **Tests**
  - Added regression coverage for tool-result context handling across DeepSeek, Kimi Code, and OpenAI integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->