### PR TITLE
feat(agent): advertise slash-command catalogs after ACP session bind

### DIFF
--- a/crates/agent/src/acp/shared.rs
+++ b/crates/agent/src/acp/shared.rs
@@ -149,6 +149,18 @@ pub(crate) async fn dispatch_rpc_message<S: SendAgent>(
     )
     .await;
 
+    // Reply first so the client can bind the session before catalog updates arrive.
+    if let Some(response) = output.response {
+        match serde_json::to_string(&response) {
+            Ok(json) => {
+                if tx.send(json).await.is_err() {
+                    return;
+                }
+            }
+            Err(err) => log::warn!("Failed to serialize JSON-RPC response: {}", err),
+        }
+    }
+
     for notification in output.notifications {
         let json = match serde_json::to_string(&notification) {
             Ok(json) => json,
@@ -159,15 +171,6 @@ pub(crate) async fn dispatch_rpc_message<S: SendAgent>(
         };
         if tx.send(json).await.is_err() {
             return;
-        }
-    }
-
-    if let Some(response) = output.response {
-        match serde_json::to_string(&response) {
-            Ok(json) => {
-                let _ = tx.send(json).await;
-            }
-            Err(err) => log::warn!("Failed to serialize JSON-RPC response: {}", err),
         }
     }
 }
@@ -843,6 +846,7 @@ pub async fn handle_rpc_message_with_context<S: SendAgent>(
 ) -> RpcDispatchOutput {
     let rpc_method = req.method.clone();
     let rpc_params = req.params.clone();
+    let mut notifications = Vec::new();
     let result: Result<serde_json::Value, Error> =
         run_with_acp_span(&rpc_method, &rpc_params, async {
             let method = req.method.clone();
@@ -878,7 +882,13 @@ pub async fn handle_rpc_message_with_context<S: SendAgent>(
                                 Ok(r) => {
                                     let session_id = r.session_id.to_string();
                                     let mut owners = session_owners.lock().await;
-                                    owners.insert(session_id, conn_id.to_string());
+                                    owners.insert(session_id.clone(), conn_id.to_string());
+                                    drop(owners);
+                                    if let Some(notification) =
+                                        available_commands_session_update(agent, &session_id).await
+                                    {
+                                        notifications.push(notification);
+                                    }
                                     Ok(serde_json::to_value(r).unwrap())
                                 }
                                 Err(e) => Err(e),
@@ -951,6 +961,11 @@ pub async fn handle_rpc_message_with_context<S: SendAgent>(
                                             .on_session_loaded(local_agent, &session_id, &mut value)
                                             .await?;
                                     }
+                                    if let Some(notification) =
+                                        available_commands_session_update(agent, &session_id).await
+                                    {
+                                        notifications.push(notification);
+                                    }
                                     Ok(value)
                                 }
 
@@ -962,11 +977,27 @@ pub async fn handle_rpc_message_with_context<S: SendAgent>(
                     }
                 }
                 m if m == AGENT_METHOD_NAMES.session_resume => {
-                    match serde_json::from_value(req.params) {
-                        Ok(params) => agent
-                            .resume_session(params)
-                            .await
-                            .map(|r| serde_json::to_value(r).unwrap()),
+                    match serde_json::from_value::<crate::acp::protocol::ResumeSessionRequest>(
+                        req.params,
+                    ) {
+                        Ok(params) => {
+                            let session_id = params.session_id.to_string();
+                            let response = agent.resume_session(params).await;
+                            match response {
+                                Ok(r) => {
+                                    let mut owners = session_owners.lock().await;
+                                    owners.insert(session_id.clone(), conn_id.to_string());
+                                    drop(owners);
+                                    if let Some(notification) =
+                                        available_commands_session_update(agent, &session_id).await
+                                    {
+                                        notifications.push(notification);
+                                    }
+                                    Ok(serde_json::to_value(r).unwrap())
+                                }
+                                Err(e) => Err(e),
+                            }
+                        }
                         Err(e) => Err(Error::invalid_params()
                             .data(serde_json::json!({"error": e.to_string()}))),
                     }
@@ -1199,9 +1230,22 @@ pub async fn handle_rpc_message_with_context<S: SendAgent>(
     };
 
     RpcDispatchOutput {
-        notifications: Vec::new(),
+        notifications,
         response,
     }
+}
+
+async fn available_commands_session_update<S: SendAgent>(
+    agent: &S,
+    session_id: &str,
+) -> Option<serde_json::Value> {
+    let notification = agent.available_slash_commands(session_id).await?;
+    let params = serde_json::to_value(&notification).ok()?;
+    Some(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": params,
+    }))
 }
 
 /// Create a method-specific ACP span, set remote parent if present, and
@@ -2317,6 +2361,160 @@ mod tests {
             response.result,
             Some(serde_json::json!({"sessionId": "s-plain"}))
         );
+        assert!(output.notifications.is_empty());
+    }
+
+    fn docs_slash_command() -> crate::slash_commands::SlashCommand {
+        crate::slash_commands::SlashCommand {
+            name: "docs".to_string(),
+            source: crate::slash_commands::SlashCommandSource::Global(std::path::PathBuf::from(
+                "/tmp",
+            )),
+            path: std::path::PathBuf::from("/tmp/docs.md"),
+            description: "Read the docs".to_string(),
+            argument_hint: None,
+            tags: Vec::new(),
+            template: "Read the docs".to_string(),
+            script: None,
+            requires_script: false,
+        }
+    }
+
+    fn assert_docs_catalog(notification: &serde_json::Value, session_id: &str) {
+        assert_eq!(notification["jsonrpc"], "2.0");
+        assert_eq!(notification["method"], "session/update");
+        assert_eq!(notification["params"]["sessionId"], session_id);
+        assert_eq!(
+            notification["params"]["update"]["sessionUpdate"],
+            "available_commands_update"
+        );
+        assert_eq!(
+            notification["params"]["update"]["availableCommands"][0]["name"],
+            "/docs"
+        );
+    }
+
+    async fn dispatch_session_rpc(
+        agent: &crate::agent::LocalAgentHandle,
+        method: &str,
+        params: serde_json::Value,
+    ) -> RpcDispatchOutput {
+        let session_owners: SessionOwnerMap = Arc::new(Mutex::new(HashMap::new()));
+        let pending_permissions: PermissionMap = Arc::new(Mutex::new(HashMap::new()));
+        let pending_elicitations: PendingElicitationMap = Arc::new(Mutex::new(HashMap::new()));
+        handle_rpc_message_with_context(
+            agent,
+            &session_owners,
+            &pending_permissions,
+            &pending_elicitations,
+            "conn-1",
+            RpcMessage {
+                jsonrpc: "2.0".to_string(),
+                method: method.to_string(),
+                params,
+                id: Some(serde_json::json!(1)),
+            },
+            RpcDispatchContext {
+                session_hooks: None,
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn session_new_load_and_resume_advertise_slash_commands() {
+        let mut registry = crate::slash_commands::SlashCommandRegistry::new();
+        registry.register(docs_slash_command());
+        let fixture = crate::test_utils::TestAgent::with_slash_command_registry(registry).await;
+
+        let created = dispatch_session_rpc(
+            fixture.handle.as_ref(),
+            AGENT_METHOD_NAMES.session_new,
+            serde_json::json!({"cwd": "/tmp", "mcpServers": []}),
+        )
+        .await;
+        let response = created.response.expect("session/new should respond");
+        assert!(response.error.is_none());
+        let session_id = response.result.as_ref().unwrap()["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+        assert_eq!(created.notifications.len(), 1);
+        assert_docs_catalog(&created.notifications[0], &session_id);
+
+        let loaded = dispatch_session_rpc(
+            fixture.handle.as_ref(),
+            AGENT_METHOD_NAMES.session_load,
+            serde_json::json!({"sessionId": session_id, "cwd": "/tmp", "mcpServers": []}),
+        )
+        .await;
+        assert!(
+            loaded
+                .response
+                .expect("session/load should respond")
+                .error
+                .is_none()
+        );
+        assert_eq!(loaded.notifications.len(), 1);
+        assert_docs_catalog(&loaded.notifications[0], &session_id);
+
+        let resumed = dispatch_session_rpc(
+            fixture.handle.as_ref(),
+            AGENT_METHOD_NAMES.session_resume,
+            serde_json::json!({"sessionId": session_id, "cwd": "/tmp"}),
+        )
+        .await;
+        assert!(
+            resumed
+                .response
+                .expect("session/resume should respond")
+                .error
+                .is_none()
+        );
+        assert_eq!(resumed.notifications.len(), 1);
+        assert_docs_catalog(&resumed.notifications[0], &session_id);
+    }
+
+    #[tokio::test]
+    async fn dispatch_rpc_message_sends_slash_catalog_after_response() {
+        let mut registry = crate::slash_commands::SlashCommandRegistry::new();
+        registry.register(docs_slash_command());
+        let fixture = crate::test_utils::TestAgent::with_slash_command_registry(registry).await;
+        let session_owners: SessionOwnerMap = Arc::new(Mutex::new(HashMap::new()));
+        let pending_permissions: PermissionMap = Arc::new(Mutex::new(HashMap::new()));
+        let pending_elicitations: PendingElicitationMap = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, mut rx) = mpsc::channel(8);
+
+        dispatch_rpc_message(
+            fixture.handle.clone(),
+            session_owners,
+            pending_permissions,
+            pending_elicitations,
+            "conn-1".to_string(),
+            RpcMessage {
+                jsonrpc: "2.0".to_string(),
+                method: AGENT_METHOD_NAMES.session_new.to_string(),
+                params: serde_json::json!({"cwd": "/tmp", "mcpServers": []}),
+                id: Some(serde_json::json!(1)),
+            },
+            tx,
+        )
+        .await;
+
+        let response: serde_json::Value =
+            serde_json::from_str(&rx.recv().await.expect("session/new response"))
+                .expect("response json");
+        assert_eq!(response["id"], 1);
+        let session_id = response["result"]["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+
+        let notification: serde_json::Value =
+            serde_json::from_str(&rx.recv().await.expect("catalog notification"))
+                .expect("notification json");
+        assert_docs_catalog(&notification, &session_id);
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/agent/src/acp/stdio.rs
+++ b/crates/agent/src/acp/stdio.rs
@@ -152,6 +152,19 @@ pub async fn load_session_with_replay(
     prepare_session_load(agent, req).instrument(span).await
 }
 
+async fn advertise_available_commands(
+    agent: &Arc<crate::agent::LocalAgentHandle>,
+    bridge_sender: &ClientBridgeSender,
+    session_id: &str,
+) {
+    let Some(notification) = agent.available_slash_commands(session_id).await else {
+        return;
+    };
+    if let Err(e) = bridge_sender.notify(notification).await {
+        log::debug!("Failed to advertise slash commands for session {session_id}: {e}");
+    }
+}
+
 async fn load_session_and_enqueue_replay(
     agent: &Arc<crate::agent::LocalAgentHandle>,
     bridge_sender: &ClientBridgeSender,
@@ -618,8 +631,15 @@ pub async fn serve_stdio(agent: Arc<crate::agent::LocalAgentHandle>) -> anyhow::
         .on_receive_request(
             {
                 let agent = agent.clone();
+                let bridge_sender = bridge_sender.clone();
                 async move |req: NewSessionRequest, responder, _cx| {
-                    responder.respond_with_result(agent.new_session(req).await)
+                    let result = agent.new_session(req).await;
+                    let session_id = result.as_ref().ok().map(|r| r.session_id.to_string());
+                    let send_result = responder.respond_with_result(result);
+                    if let Some(session_id) = session_id {
+                        advertise_available_commands(&agent, &bridge_sender, &session_id).await;
+                    }
+                    send_result
                 }
             },
             acp::on_receive_request!(),
@@ -651,9 +671,14 @@ pub async fn serve_stdio(agent: Arc<crate::agent::LocalAgentHandle>) -> anyhow::
                 let agent = agent.clone();
                 let bridge_sender = bridge_sender.clone();
                 async move |req: LoadSessionRequest, responder, _cx| {
-                    responder.respond_with_result(
-                        load_session_and_enqueue_replay(&agent, &bridge_sender, req).await,
-                    )
+                    let session_id = req.session_id.to_string();
+                    let result = load_session_and_enqueue_replay(&agent, &bridge_sender, req).await;
+                    let ok = result.is_ok();
+                    let send_result = responder.respond_with_result(result);
+                    if ok {
+                        advertise_available_commands(&agent, &bridge_sender, &session_id).await;
+                    }
+                    send_result
                 }
             },
             acp::on_receive_request!(),
@@ -679,8 +704,16 @@ pub async fn serve_stdio(agent: Arc<crate::agent::LocalAgentHandle>) -> anyhow::
         .on_receive_request(
             {
                 let agent = agent.clone();
+                let bridge_sender = bridge_sender.clone();
                 async move |req: ResumeSessionRequest, responder, _cx| {
-                    responder.respond_with_result(agent.resume_session(req).await)
+                    let session_id = req.session_id.to_string();
+                    let result = agent.resume_session(req).await;
+                    let ok = result.is_ok();
+                    let send_result = responder.respond_with_result(result);
+                    if ok {
+                        advertise_available_commands(&agent, &bridge_sender, &session_id).await;
+                    }
+                    send_result
                 }
             },
             acp::on_receive_request!(),

--- a/crates/agent/src/acp/websocket.rs
+++ b/crates/agent/src/acp/websocket.rs
@@ -1,7 +1,9 @@
 //! Standalone WebSocket ACP server.
 //!
 //! This module provides a pure ACP server over WebSocket without any dashboard UI.
-//! It uses the same client bridge pattern as the stdio transport for consistency.
+//! Session catalog updates are advertised on the JSON-RPC dispatch path after
+//! `session/new`, `session/load`, and `session/resume`. Live events still fan out
+//! per connection; WebSocket does not attach an agent-level client bridge.
 //!
 //! ## Usage
 //!

--- a/crates/agent/src/agent/handle/core.rs
+++ b/crates/agent/src/agent/handle/core.rs
@@ -76,6 +76,38 @@ impl LocalAgentHandle {
         self.profiles.load_full().as_ref().clone()
     }
 
+    /// Catalog belonging to the runtime that owns `session_id`.
+    ///
+    /// Profile sessions use that profile's registry, not this handle's.
+    pub(crate) async fn slash_command_catalog(
+        &self,
+        session_id: &str,
+    ) -> Option<crate::acp::protocol::SessionNotification> {
+        let registry = if let Some(profiles) = self.profiles() {
+            if let Some(binding) = profiles.session_binding(session_id).await {
+                profiles
+                    .runtime_for_profile(&binding.profile_id)
+                    .await
+                    .ok()?
+                    .agent()
+                    .handle()
+                    .config
+                    .slash_command_registry
+                    .clone()
+            } else {
+                self.config.slash_command_registry.clone()
+            }
+        } else {
+            self.config.slash_command_registry.clone()
+        };
+        if registry.is_empty() {
+            return None;
+        }
+        Some(crate::slash_commands::acp::build_commands_notification(
+            session_id, &registry,
+        ))
+    }
+
     pub(super) async fn session_config_options(
         &self,
         session_id: Option<&str>,

--- a/crates/agent/src/agent/handle/send_agent_impl.rs
+++ b/crates/agent/src/agent/handle/send_agent_impl.rs
@@ -92,6 +92,13 @@ impl SendAgent for LocalAgentHandle {
         self.handle_ext_notification(notif).await
     }
 
+    async fn available_slash_commands(
+        &self,
+        session_id: &str,
+    ) -> Option<crate::acp::protocol::SessionNotification> {
+        self.slash_command_catalog(session_id).await
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/agent/src/agent/handle/tests/core_a.rs
+++ b/crates/agent/src/agent/handle/tests/core_a.rs
@@ -855,3 +855,118 @@ async fn test_set_profile_config_option_accepts_same_bound_profile() {
             .any(|option| option.id.0.as_ref() == "reasoning_effort")
     );
 }
+
+fn advertised_command_names(
+    notification: &crate::acp::protocol::SessionNotification,
+) -> Vec<String> {
+    serde_json::to_value(notification).expect("serialize catalog")["update"]["availableCommands"]
+        .as_array()
+        .expect("availableCommands")
+        .iter()
+        .map(|command| command["name"].as_str().expect("command name").to_string())
+        .collect()
+}
+
+fn test_slash_command(name: &str, description: &str) -> crate::slash_commands::SlashCommand {
+    crate::slash_commands::SlashCommand {
+        name: name.to_string(),
+        source: crate::slash_commands::SlashCommandSource::Global(std::path::PathBuf::from("/tmp")),
+        path: std::path::PathBuf::from(format!("/tmp/{name}.md")),
+        description: description.to_string(),
+        argument_hint: None,
+        tags: Vec::new(),
+        template: description.to_string(),
+        script: None,
+        requires_script: false,
+    }
+}
+
+#[tokio::test]
+async fn test_slash_command_catalog_uses_profile_registry_and_skips_failed_lookup() {
+    let mut root_registry = crate::slash_commands::SlashCommandRegistry::new();
+    root_registry.register(test_slash_command("root", "Root command"));
+    let fixture = crate::test_utils::TestAgent::with_slash_command_registry(root_registry).await;
+
+    let profile_dir = tempfile::TempDir::new().expect("profile dir");
+    let commands = profile_dir.path().join("commands");
+    std::fs::create_dir_all(&commands).expect("commands dir");
+    std::fs::write(
+        commands.join("docs.md"),
+        "---\ndescription: Read the docs\n---\nBody\n",
+    )
+    .expect("docs command");
+    std::fs::write(
+        profile_dir.path().join("alpha.toml"),
+        format!(
+            r#"
+[agent]
+provider = "test"
+model = "test-model"
+system = "alpha"
+
+[agent.slash_commands]
+enabled = true
+include_global = false
+include_project = false
+paths = ["{}"]
+"#,
+            commands.display()
+        ),
+    )
+    .expect("alpha profile");
+
+    let catalog: Arc<dyn ProfileCatalog> = Arc::new(
+        crate::profiles::LocalProfileCatalog::builder()
+            .include_embedded_default(false)
+            .local_dir(profile_dir.path())
+            .build(),
+    );
+    let (plugin_registry, _temp_dir) = empty_plugin_registry().expect("plugin registry");
+    let profiles = Arc::new(ProfileRuntimeManager::with_infra_boxed(
+        catalog,
+        "alpha",
+        AgentInfra {
+            plugin_registry: Arc::new(plugin_registry),
+            storage: None,
+            session_mcp_attachment_source: None,
+            event_fanout: None,
+        },
+    ));
+    fixture.handle.set_profiles(profiles.clone());
+
+    let unbound = fixture
+        .handle
+        .slash_command_catalog("unbound")
+        .await
+        .expect("unbound session uses this handle's registry");
+    assert_eq!(
+        advertised_command_names(&unbound),
+        vec!["/root".to_string()]
+    );
+
+    profiles
+        .bind_session_to_profile("bound", "alpha")
+        .await
+        .expect("bind alpha");
+    let bound = fixture
+        .handle
+        .slash_command_catalog("bound")
+        .await
+        .expect("bound session uses the profile registry");
+    assert_eq!(advertised_command_names(&bound), vec!["/docs".to_string()]);
+
+    profiles
+        .set_session_binding(
+            "ghost",
+            test_profile_metadata("ghost", "ghost", None).session_binding(),
+        )
+        .await;
+    assert!(
+        fixture
+            .handle
+            .slash_command_catalog("ghost")
+            .await
+            .is_none(),
+        "failed profile lookup must not fall back to this handle's registry"
+    );
+}

--- a/crates/agent/src/agent/session_materializer.rs
+++ b/crates/agent/src/agent/session_materializer.rs
@@ -719,22 +719,6 @@ impl SessionMaterializer {
             },
         );
 
-        // Publish available slash commands via ACP bridge
-        if !self.config.slash_command_registry.is_empty()
-            && let Some(bridge_sender) = bridge
-        {
-            let notification = crate::slash_commands::acp::build_commands_notification(
-                &prepared.session_id,
-                &self.config.slash_command_registry,
-            );
-            let bridge = bridge_sender.clone();
-            tokio::spawn(async move {
-                if let Err(e) = bridge.notify(notification).await {
-                    log::debug!("Failed to publish available commands: {}", e);
-                }
-            });
-        }
-
         Ok(())
     }
 

--- a/crates/agent/src/api/agent.rs
+++ b/crates/agent/src/api/agent.rs
@@ -17,7 +17,8 @@ use crate::agent::agent_config_builder::AgentConfigBuilder;
 use crate::agent::core::{SnapshotPolicy, ToolPolicy};
 use crate::agent::session_mcp::SessionMcpAttachmentSource;
 use crate::config::{
-    ExecutionPolicy, HooksConfig, McpServerConfig, MiddlewareEntry, SingleAgentConfig, SkillsConfig,
+    ExecutionPolicy, HooksConfig, McpServerConfig, MiddlewareEntry, SingleAgentConfig,
+    SkillsConfig, SlashCommandsConfig,
 };
 use crate::event_fanout::EventFanout;
 use crate::middleware::{MIDDLEWARE_REGISTRY, MiddlewareDriver};
@@ -110,6 +111,7 @@ pub struct AgentBuilder {
     middleware_entries: Vec<MiddlewareEntry>,
     execution: Option<ExecutionPolicy>,
     skills_config: Option<SkillsConfig>,
+    slash_commands_config: Option<SlashCommandsConfig>,
     hooks_config: Option<HooksConfig>,
     /// MCP servers from TOML `[[mcp]]` config, attached to every new session.
     mcp_servers: Vec<McpServerConfig>,
@@ -149,6 +151,7 @@ impl AgentBuilder {
             middleware_entries: Vec::new(),
             execution: None,
             skills_config: None,
+            slash_commands_config: None,
             hooks_config: None,
             mcp_servers: Vec::new(),
             session_mcp_attachment_source: None,
@@ -269,6 +272,12 @@ impl AgentBuilder {
     /// Configure hooks.
     pub fn hooks(mut self, config: HooksConfig) -> Self {
         self.hooks_config = Some(config);
+        self
+    }
+
+    /// Configure slash-command discovery.
+    pub fn slash_commands(mut self, config: SlashCommandsConfig) -> Self {
+        self.slash_commands_config = Some(config);
         self
     }
 
@@ -482,6 +491,34 @@ impl AgentBuilder {
         if let Some(hooks_config) = self.hooks_config.take() {
             let hooks = crate::hooks::Hooks::new(hooks_config)?;
             builder = builder.with_hooks(hooks);
+        }
+
+        if let Some(slash_config) = self.slash_commands_config
+            && slash_config.enabled
+        {
+            let sources = crate::slash_commands::search_paths(
+                cwd.as_deref(),
+                slash_config.include_global,
+                slash_config.include_project,
+                &slash_config.paths,
+            );
+            let (registry, diagnostics) = crate::slash_commands::SlashCommandRegistry::from_sources(
+                &sources,
+                &slash_config.scripts,
+            );
+            for diagnostic in &diagnostics {
+                log::warn!(
+                    "Skipping invalid slash command {}: {}",
+                    diagnostic.path.display(),
+                    diagnostic.message
+                );
+            }
+            if registry.is_empty() {
+                log::info!("No slash commands discovered");
+            } else {
+                log::info!("Discovered slash commands: {}", registry.names().join(", "));
+            }
+            builder = builder.with_slash_command_registry(registry);
         }
 
         // Build initial config for middleware factories (temporary handle)
@@ -1005,6 +1042,7 @@ impl Agent {
         // Thread through config fields that were previously silently dropped
         builder.execution = Some(config.agent.execution);
         builder.skills_config = Some(config.agent.skills);
+        builder.slash_commands_config = Some(config.agent.slash_commands);
         builder.hooks_config = Some(config.agent.hooks);
 
         // Wire MCP servers from TOML `[[mcp]]` config.

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -185,6 +185,108 @@ async fn slash_commands_config_enabled_discovers_configured_paths() -> Result<()
     Ok(())
 }
 
+async fn agent_from_single_config(toml: &str) -> Result<Agent> {
+    let config: crate::config::SingleAgentConfig = toml::from_str(toml)?;
+    let (registry, _temp_dir) = empty_plugin_registry()?;
+    let storage =
+        Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
+    Agent::from_config(
+        config,
+        AgentInfra {
+            plugin_registry: Arc::new(registry),
+            storage: Some(storage),
+            session_mcp_attachment_source: None,
+            event_fanout: None,
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn from_single_config_propagates_slash_command_paths_and_include_flags() -> Result<()> {
+    let dir = tempfile::TempDir::new()?;
+    let extra = dir.path().join("extra-commands");
+    std::fs::create_dir_all(&extra)?;
+    std::fs::write(
+        extra.join("docs.md"),
+        "---\ndescription: Read the docs\n---\nBody\n",
+    )?;
+    let project_commands = dir.path().join(".qmt/commands");
+    std::fs::create_dir_all(&project_commands)?;
+    std::fs::write(
+        project_commands.join("project.md"),
+        "---\ndescription: Project command\n---\nBody\n",
+    )?;
+
+    let extra_only = format!(
+        r#"
+[agent]
+provider = "openai"
+model = "gpt-4o-mini"
+cwd = "{cwd}"
+
+[agent.slash_commands]
+enabled = true
+include_global = false
+include_project = false
+paths = ["{extra}"]
+"#,
+        cwd = dir.path().display(),
+        extra = extra.display(),
+    );
+    let extra_only_agent = agent_from_single_config(&extra_only).await?;
+    assert!(
+        extra_only_agent
+            .handle()
+            .config
+            .slash_command_registry
+            .get("docs")
+            .is_some()
+    );
+    assert!(
+        extra_only_agent
+            .handle()
+            .config
+            .slash_command_registry
+            .get("project")
+            .is_none(),
+        "include_project=false must not scan <cwd>/.qmt/commands"
+    );
+
+    let project_only = format!(
+        r#"
+[agent]
+provider = "openai"
+model = "gpt-4o-mini"
+cwd = "{cwd}"
+
+[agent.slash_commands]
+enabled = true
+include_global = false
+include_project = true
+"#,
+        cwd = dir.path().display(),
+    );
+    let project_only_agent = agent_from_single_config(&project_only).await?;
+    assert!(
+        project_only_agent
+            .handle()
+            .config
+            .slash_command_registry
+            .get("project")
+            .is_some()
+    );
+    assert!(
+        project_only_agent
+            .handle()
+            .config
+            .slash_command_registry
+            .get("docs")
+            .is_none()
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn shutdown_with_profiles_also_stops_independent_root() -> Result<()> {
     let dir = tempfile::TempDir::new()?;

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -4,6 +4,7 @@ use super::{
     Agent, AgentInfra, AgentProfiles, AgentSessions, ListSessionsOptions, SessionListMode,
 };
 use crate::acp::protocol::ListSessionsRequest as AcpListSessionsRequest;
+use crate::config::SlashCommandsConfig;
 use crate::events::{AgentEventKind, EventOrigin, ExecutionMetrics};
 use crate::model::AgentMessage;
 use crate::profiles::{LocalProfileCatalog, ProfileCatalog};
@@ -39,6 +40,23 @@ async fn test_agent_with_storage(
             session_mcp_attachment_source: None,
             event_fanout: None,
         })
+        .build()
+        .await
+}
+
+async fn agent_with_slash_config(config: SlashCommandsConfig) -> Result<Agent> {
+    let (registry, _temp_dir) = empty_plugin_registry()?;
+    let storage =
+        Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);
+    Agent::single()
+        .provider("openai", "gpt-4o-mini")
+        .infra(AgentInfra {
+            plugin_registry: Arc::new(registry),
+            storage: Some(storage),
+            session_mcp_attachment_source: None,
+            event_fanout: None,
+        })
+        .slash_commands(config)
         .build()
         .await
 }
@@ -106,6 +124,64 @@ async fn with_profiles_reuses_root_agent_for_active_profile() -> Result<()> {
         .await?;
 
     assert!(Arc::ptr_eq(&root_handle, &runtime.agent().handle()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn programmatic_builder_does_not_discover_slash_commands_by_default() -> Result<()> {
+    let agent = test_agent().await?;
+    assert!(agent.handle().config.slash_command_registry.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn slash_commands_config_disabled_does_not_scan_filesystem() -> Result<()> {
+    let dir = tempfile::TempDir::new()?;
+    let commands = dir.path().join("commands");
+    std::fs::create_dir_all(&commands)?;
+    std::fs::write(
+        commands.join("docs.md"),
+        "---\ndescription: Read the docs\n---\nBody\n",
+    )?;
+
+    let agent = agent_with_slash_config(SlashCommandsConfig {
+        enabled: false,
+        include_global: false,
+        include_project: false,
+        paths: vec![commands],
+        scripts: Default::default(),
+    })
+    .await?;
+    assert!(agent.handle().config.slash_command_registry.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn slash_commands_config_enabled_discovers_configured_paths() -> Result<()> {
+    let dir = tempfile::TempDir::new()?;
+    let commands = dir.path().join("commands");
+    std::fs::create_dir_all(&commands)?;
+    std::fs::write(
+        commands.join("docs.md"),
+        "---\ndescription: Read the docs\n---\nBody\n",
+    )?;
+
+    let agent = agent_with_slash_config(SlashCommandsConfig {
+        enabled: true,
+        include_global: false,
+        include_project: false,
+        paths: vec![commands],
+        scripts: Default::default(),
+    })
+    .await?;
+    assert!(
+        agent
+            .handle()
+            .config
+            .slash_command_registry
+            .get("docs")
+            .is_some()
+    );
     Ok(())
 }
 

--- a/crates/agent/src/send_agent.rs
+++ b/crates/agent/src/send_agent.rs
@@ -148,6 +148,17 @@ pub trait SendAgent: Send + Sync + Any {
     /// Receives extension notifications that don't require a response.
     async fn ext_notification(&self, notif: ExtNotification) -> Result<(), Error>;
 
+    /// Slash-command catalog for a session bound on this connection.
+    ///
+    /// Transports advertise this after `session/new`, `session/load`, and
+    /// `session/resume`. Default is no catalog.
+    async fn available_slash_commands(
+        &self,
+        _session_id: &str,
+    ) -> Option<crate::acp::protocol::SessionNotification> {
+        None
+    }
+
     /// Expose dynamic type for downcasting.
     fn as_any(&self) -> &dyn Any;
 }

--- a/crates/agent/src/slash_commands/discovery.rs
+++ b/crates/agent/src/slash_commands/discovery.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 ///
 /// Global: `~/.qmt/commands` and `<config-dir>/commands`
 /// Project: `<PROJECT_ROOT>/.qmt/commands`
-pub fn search_paths(
+pub(crate) fn search_paths(
     project_root: Option<&Path>,
     include_global: bool,
     include_project: bool,

--- a/crates/agent/src/slash_commands/discovery.rs
+++ b/crates/agent/src/slash_commands/discovery.rs
@@ -1,28 +1,76 @@
 use crate::slash_commands::parser::parse_command_file;
 use crate::slash_commands::types::{SlashCommand, SlashCommandDiagnostic, SlashCommandSource};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Build discovery sources from include flags and extra configured paths.
+///
+/// Global: `~/.qmt/commands` and `<config-dir>/commands`
+/// Project: `<PROJECT_ROOT>/.qmt/commands`
+pub fn search_paths(
+    project_root: Option<&Path>,
+    include_global: bool,
+    include_project: bool,
+    extra_paths: &[PathBuf],
+) -> Vec<SlashCommandSource> {
+    let mut paths = Vec::new();
+
+    if include_global {
+        if let Some(home) = dirs::home_dir() {
+            push_unique_source(
+                &mut paths,
+                SlashCommandSource::Global(home.join(".qmt/commands")),
+            );
+        }
+        if let Ok(cfg_dir) = querymt_utils::providers::config_dir() {
+            push_unique_source(
+                &mut paths,
+                SlashCommandSource::Global(cfg_dir.join("commands")),
+            );
+        }
+    }
+
+    if include_project && let Some(root) = project_root {
+        push_unique_source(
+            &mut paths,
+            SlashCommandSource::Project(root.join(".qmt/commands")),
+        );
+    }
+
+    for path in extra_paths {
+        push_unique_source(&mut paths, SlashCommandSource::Configured(path.clone()));
+    }
+
+    paths
+}
+
+fn source_dir(source: &SlashCommandSource) -> &Path {
+    match source {
+        SlashCommandSource::Global(path)
+        | SlashCommandSource::Project(path)
+        | SlashCommandSource::Configured(path) => path,
+    }
+}
+
+fn push_unique_source(paths: &mut Vec<SlashCommandSource>, source: SlashCommandSource) {
+    let path = source_dir(&source);
+    if let Some(existing) = paths
+        .iter_mut()
+        .find(|existing| source_dir(existing) == path)
+    {
+        if source.priority() > existing.priority() {
+            *existing = source;
+        }
+        return;
+    }
+    paths.push(source);
+}
 
 /// Build default discovery sources for slash commands.
 ///
 /// Global: `~/.qmt/commands`
 /// Project: `<PROJECT_ROOT>/.qmt/commands`
 pub fn default_search_paths(project_root: &Path) -> Vec<SlashCommandSource> {
-    let mut paths = Vec::new();
-
-    // Global paths
-    if let Some(home) = dirs::home_dir() {
-        paths.push(SlashCommandSource::Global(home.join(".qmt/commands")));
-    }
-    if let Ok(cfg_dir) = querymt_utils::providers::config_dir() {
-        paths.push(SlashCommandSource::Global(cfg_dir.join("commands")));
-    }
-
-    // Project path
-    paths.push(SlashCommandSource::Project(
-        project_root.join(".qmt/commands"),
-    ));
-
-    paths
+    search_paths(Some(project_root), true, true, &[])
 }
 
 /// Discover commands from a single source directory.
@@ -301,5 +349,52 @@ description: {}
         assert!(paths.iter().any(
             |p| matches!(p, SlashCommandSource::Project(pth) if pth.ends_with(".qmt/commands"))
         ));
+    }
+
+    #[test]
+    fn test_search_paths_honors_include_flags_and_extra_paths() {
+        let extra = PathBuf::from("/custom/commands");
+        let none = search_paths(Some(Path::new("/my/project")), false, false, &[]);
+        assert!(none.is_empty());
+
+        let configured = search_paths(None, false, true, std::slice::from_ref(&extra));
+        assert_eq!(configured.len(), 1);
+        assert!(matches!(
+            &configured[0],
+            SlashCommandSource::Configured(path) if path == &extra
+        ));
+
+        let project_only = search_paths(Some(Path::new("/my/project")), false, true, &[]);
+        assert_eq!(project_only.len(), 1);
+        assert!(matches!(
+            &project_only[0],
+            SlashCommandSource::Project(path) if path.ends_with(".qmt/commands")
+        ));
+    }
+
+    #[test]
+    fn test_search_paths_dedupes_equivalent_directories() {
+        let extra = PathBuf::from("/my/project/.qmt/commands");
+        let paths = search_paths(
+            Some(Path::new("/my/project")),
+            false,
+            true,
+            std::slice::from_ref(&extra),
+        );
+        assert_eq!(paths.len(), 1);
+        assert!(matches!(
+            &paths[0],
+            SlashCommandSource::Configured(path) if path == &extra
+        ));
+
+        let global = search_paths(None, true, false, &[]);
+        let mut seen = std::collections::HashSet::new();
+        for source in &global {
+            assert!(
+                seen.insert(source_dir(source).to_path_buf()),
+                "duplicate discovery path {:?}",
+                source_dir(source)
+            );
+        }
     }
 }

--- a/crates/agent/src/slash_commands/mod.rs
+++ b/crates/agent/src/slash_commands/mod.rs
@@ -38,7 +38,8 @@ pub mod registry;
 pub mod script;
 pub mod types;
 
-pub use discovery::{default_search_paths, discover_all, discover_from_source, search_paths};
+pub(crate) use discovery::search_paths;
+pub use discovery::{default_search_paths, discover_all, discover_from_source};
 pub use expander::{expand_invocation, try_expand, try_parse_invocation};
 pub use parser::parse_command_file;
 pub use registry::SlashCommandRegistry;

--- a/crates/agent/src/slash_commands/mod.rs
+++ b/crates/agent/src/slash_commands/mod.rs
@@ -38,7 +38,7 @@ pub mod registry;
 pub mod script;
 pub mod types;
 
-pub use discovery::{default_search_paths, discover_all, discover_from_source};
+pub use discovery::{default_search_paths, discover_all, discover_from_source, search_paths};
 pub use expander::{expand_invocation, try_expand, try_parse_invocation};
 pub use parser::parse_command_file;
 pub use registry::SlashCommandRegistry;

--- a/crates/agent/src/slash_commands/registry.rs
+++ b/crates/agent/src/slash_commands/registry.rs
@@ -102,26 +102,13 @@ impl SlashCommandRegistry {
     pub fn reload(
         &mut self,
         project_root: Option<&Path>,
+        include_global: bool,
+        include_project: bool,
         extra_paths: &[PathBuf],
         scripts_config: &SlashCommandScriptsConfig,
     ) -> Vec<SlashCommandDiagnostic> {
-        let mut sources = Vec::new();
-
-        if let Some(root) = project_root {
-            sources.extend(discovery::default_search_paths(root));
-        } else {
-            // Global-only when no project root
-            if let Some(home) = dirs::home_dir() {
-                sources.push(SlashCommandSource::Global(home.join(".qmt/commands")));
-            }
-            if let Ok(cfg_dir) = querymt_utils::providers::config_dir() {
-                sources.push(SlashCommandSource::Global(cfg_dir.join("commands")));
-            }
-        }
-
-        for p in extra_paths {
-            sources.push(SlashCommandSource::Configured(p.clone()));
-        }
+        let sources =
+            discovery::search_paths(project_root, include_global, include_project, extra_paths);
 
         let (commands, diagnostics) = discovery::discover_all(&sources);
 
@@ -252,7 +239,7 @@ mod tests {
         .unwrap();
 
         let scripts_config = SlashCommandScriptsConfig::default();
-        let diags = reg.reload(Some(dir.path()), &[], &scripts_config);
+        let diags = reg.reload(Some(dir.path()), true, true, &[], &scripts_config);
         assert!(diags.is_empty());
 
         // Old command is gone
@@ -261,5 +248,27 @@ mod tests {
         // But .qmt/commands doesn't exist in the temp dir, so let's check reload
         // actually cleared old and didn't add anything (no .qmt/commands dir)
         assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn test_reload_honors_include_flags() {
+        let mut reg = SlashCommandRegistry::new();
+        let dir = TempDir::new().unwrap();
+        let commands_dir = dir.path().join(".qmt/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+        fs::write(
+            commands_dir.join("project.md"),
+            "---\ndescription: Project command\n---\nBody\n",
+        )
+        .unwrap();
+
+        let scripts_config = SlashCommandScriptsConfig::default();
+        let diags = reg.reload(Some(dir.path()), false, false, &[], &scripts_config);
+        assert!(diags.is_empty());
+        assert!(reg.is_empty());
+
+        let diags = reg.reload(Some(dir.path()), false, true, &[], &scripts_config);
+        assert!(diags.is_empty());
+        assert!(reg.get("project").is_some());
     }
 }

--- a/crates/agent/src/test_utils/fixtures.rs
+++ b/crates/agent/src/test_utils/fixtures.rs
@@ -79,6 +79,31 @@ impl TestAgent {
         }
     }
 
+    pub async fn with_slash_command_registry(
+        registry: crate::slash_commands::SlashCommandRegistry,
+    ) -> Self {
+        let (plugin_registry, tempdir) = empty_plugin_registry().expect("empty plugin registry");
+        let storage = Arc::new(
+            SqliteStorage::connect(":memory:".into())
+                .await
+                .expect("create in-memory sqlite"),
+        );
+        let builder = AgentConfigBuilder::new(
+            Arc::new(plugin_registry),
+            storage.clone(),
+            LLMParams::new().provider("mock").model("mock"),
+        )
+        .with_slash_command_registry(registry);
+        let config = Arc::new(builder.build());
+        let handle = Arc::new(AgentHandle::from_config(config.clone()));
+        Self {
+            storage,
+            config,
+            handle,
+            _tempdir: tempdir,
+        }
+    }
+
     /// Like `new()` but with event journal wired (previously had event observer).
     ///
     /// Observer was a no-op; now this is identical to `new()` with event journal.


### PR DESCRIPTION
## Summary
- Advertise slash-command catalogs via `session/update` (`available_commands_update`) after `session/new`, `session/load`, and `session/resume`.
- Send the JSON-RPC response first so clients can bind the session before catalog notifications arrive.
- Resolve catalogs from the bound profile registry when present, and stop publishing them from session materialization.
- Wire `SlashCommandsConfig` through `AgentBuilder` and honor include flags / extra paths during discovery.

## Test plan
- [x] `cargo check -p querymt-agent`
- [x] `cargo fmt -p querymt-agent -- --check`
- [x] Fixed clippy findings in the new discovery tests (`cloned_ref_to_slice_refs`)
- [ ] `cargo clippy -p querymt-agent --all-targets --features dashboard,oauth -- -D warnings` still fails on pre-existing unused-code warnings unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Available slash commands are now advertised after creating, loading, or resuming a session.
  - Added configuration support for discovering slash commands from global, project, and custom locations.
  - Slash-command discovery now respects inclusion settings and avoids duplicate locations.

- **Bug Fixes**
  - Session responses are delivered before queued notifications, improving client responsiveness.
  - Slash-command notifications are no longer sent through the session finalization bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->