### PR TITLE
fix(agent): rebase session control after revision conflict

### DIFF
--- a/crates/agent/src/agent/remote/actor_ref.rs
+++ b/crates/agent/src/agent/remote/actor_ref.rs
@@ -118,10 +118,14 @@ impl SessionActorRef {
     pub(super) fn map_local_prompt_send_error(
         error: kameo::error::SendError<messages::Prompt, AgentError>,
     ) -> AcpError {
-        AcpError::from(match error {
+        AcpError::from(Self::map_local_agent_send_error(error))
+    }
+
+    fn map_local_agent_send_error<M>(error: kameo::error::SendError<M, AgentError>) -> AgentError {
+        match error {
             kameo::error::SendError::HandlerError(err) => err,
             other => AgentError::RemoteActor(other.to_string()),
-        })
+        }
     }
 
     fn map_infallible_remote_send_error(
@@ -282,7 +286,7 @@ impl SessionActorRef {
             Self::Local(actor_ref) => actor_ref
                 .ask(messages::SetMode { mode })
                 .await
-                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+                .map_err(Self::map_local_agent_send_error),
 
             #[cfg(feature = "remote")]
             Self::Remote { actor_ref, .. } => actor_ref
@@ -334,7 +338,7 @@ impl SessionActorRef {
             Self::Local(actor_ref) => actor_ref
                 .ask(messages::SetReasoningEffort { effort })
                 .await
-                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+                .map_err(Self::map_local_agent_send_error),
 
             #[cfg(feature = "remote")]
             Self::Remote { actor_ref, .. } => actor_ref
@@ -358,7 +362,7 @@ impl SessionActorRef {
             Self::Local(actor_ref) => actor_ref
                 .ask(messages::GetSessionControl)
                 .await
-                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+                .map_err(Self::map_local_agent_send_error),
             #[cfg(feature = "remote")]
             Self::Remote { actor_ref, .. } => actor_ref
                 .ask(&messages::GetSessionControl)
@@ -389,7 +393,7 @@ impl SessionActorRef {
             Self::Local(actor_ref) => actor_ref
                 .ask(msg)
                 .await
-                .map_err(|error| AgentError::RemoteActor(error.to_string())),
+                .map_err(Self::map_local_agent_send_error),
             #[cfg(feature = "remote")]
             Self::Remote { actor_ref, .. } => actor_ref
                 .ask(&msg)
@@ -516,7 +520,7 @@ impl SessionActorRef {
             Self::Local(actor_ref) => actor_ref
                 .ask(msg)
                 .await
-                .map_err(|e| AgentError::RemoteActor(e.to_string())),
+                .map_err(Self::map_local_agent_send_error),
 
             #[cfg(feature = "remote")]
             Self::Remote { actor_ref, .. } => actor_ref

--- a/crates/agent/src/agent/remote/tests.rs
+++ b/crates/agent/src/agent/remote/tests.rs
@@ -20,6 +20,7 @@ use crate::test_utils::{
 };
 use kameo::actor::Spawn;
 use querymt::LLMParams;
+use querymt::chat::ReasoningEffort;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -225,6 +226,256 @@ async fn test_local_ref_mode_model_bindings_are_session_scoped() {
         .await
         .expect("second control state");
     assert_eq!(second_state.effective_model.model, "mock");
+}
+
+#[tokio::test]
+async fn stale_actor_rebases_mode_after_revision_conflict() {
+    let (config, _td) = test_agent_config().await;
+    let (fresh, session_id) = spawn_test_session_with_id(config.clone(), "stale-mode").await;
+    let initial = fresh
+        .get_session_control()
+        .await
+        .expect("initialize control state");
+    assert_eq!(initial.revision, 1);
+
+    let stale = SessionActorRef::Local(SessionActor::spawn(
+        SessionActor::new(
+            config.clone(),
+            session_id.clone(),
+            SessionRuntime::new(
+                None,
+                HashMap::new(),
+                crate::agent::core::McpToolState::empty(),
+            ),
+        )
+        .with_control_state(initial),
+    ));
+
+    let advanced = fresh
+        .set_mode(AgentMode::Plan)
+        .await
+        .expect("fresh actor advances revision");
+    assert_eq!(advanced.current.revision, 2);
+    assert_eq!(advanced.current.active_mode, AgentMode::Plan);
+
+    let rebased = stale
+        .set_mode(AgentMode::Build)
+        .await
+        .expect("stale actor rebases onto latest revision");
+    assert_eq!(rebased.current.active_mode, AgentMode::Build);
+    assert!(rebased.current.revision > 2);
+
+    let persisted = config
+        .provider
+        .history_store()
+        .get_session_control(&session_id)
+        .await
+        .expect("load persisted control")
+        .expect("control state exists");
+    assert_eq!(persisted.active_mode, AgentMode::Build);
+    assert_eq!(persisted.revision, rebased.current.revision);
+}
+
+#[tokio::test]
+async fn stale_actor_rebases_model_after_revision_conflict() {
+    let (config, _td) = test_agent_config().await;
+    let (fresh, session_id) = spawn_test_session_with_id(config.clone(), "stale-model").await;
+    let initial = fresh
+        .get_session_control()
+        .await
+        .expect("initialize control state");
+
+    let stale = SessionActorRef::Local(SessionActor::spawn(
+        SessionActor::new(
+            config,
+            session_id,
+            SessionRuntime::new(
+                None,
+                HashMap::new(),
+                crate::agent::core::McpToolState::empty(),
+            ),
+        )
+        .with_control_state(initial),
+    ));
+
+    fresh
+        .set_mode(AgentMode::Plan)
+        .await
+        .expect("fresh actor switches to plan");
+
+    let rebased = stale
+        .set_session_model(crate::agent::session_control::SessionModelSelection {
+            model_id: "mock/rebased-model".to_string(),
+            provider_node_id: None,
+        })
+        .await
+        .expect("stale actor rebases model onto current mode");
+    assert_eq!(rebased.current.active_mode, AgentMode::Plan);
+    assert_eq!(rebased.current.effective_model.model, "rebased-model");
+    assert_eq!(
+        rebased
+            .current
+            .binding_for(AgentMode::Plan)
+            .map(|binding| binding.model.as_str()),
+        Some("rebased-model")
+    );
+}
+
+#[tokio::test]
+async fn stale_actor_rebases_reasoning_effort_after_revision_conflict() {
+    let (config, _td) = test_agent_config().await;
+    let (fresh, session_id) = spawn_test_session_with_id(config.clone(), "stale-effort").await;
+    let initial = fresh
+        .get_session_control()
+        .await
+        .expect("initialize control state");
+
+    let stale = SessionActorRef::Local(SessionActor::spawn(
+        SessionActor::new(
+            config.clone(),
+            session_id.clone(),
+            SessionRuntime::new(
+                None,
+                HashMap::new(),
+                crate::agent::core::McpToolState::empty(),
+            ),
+        )
+        .with_control_state(initial),
+    ));
+
+    fresh
+        .set_mode(AgentMode::Review)
+        .await
+        .expect("fresh actor switches to review");
+
+    let rebased = stale
+        .set_reasoning_effort(Some(ReasoningEffort::High))
+        .await
+        .expect("stale actor rebases effort onto current mode");
+    assert_eq!(rebased.current.active_mode, AgentMode::Review);
+    assert_eq!(
+        rebased.current.reasoning_effort,
+        Some(ReasoningEffort::High)
+    );
+
+    let persisted = config
+        .provider
+        .history_store()
+        .get_session_control(&session_id)
+        .await
+        .expect("load persisted control")
+        .expect("control state exists");
+    assert_eq!(persisted.active_mode, AgentMode::Review);
+    assert_eq!(persisted.reasoning_effort, Some(ReasoningEffort::High));
+}
+
+#[tokio::test]
+async fn stale_actor_rebases_llm_config_after_revision_conflict() {
+    let (config, _td) = test_agent_config().await;
+    let (fresh, session_id) = spawn_test_session_with_id(config.clone(), "stale-config").await;
+    let initial = fresh
+        .get_session_control()
+        .await
+        .expect("initialize control state");
+
+    let stale = SessionActorRef::Local(SessionActor::spawn(
+        SessionActor::new(
+            config.clone(),
+            session_id.clone(),
+            SessionRuntime::new(
+                None,
+                HashMap::new(),
+                crate::agent::core::McpToolState::empty(),
+            ),
+        )
+        .with_control_state(initial),
+    ));
+
+    fresh
+        .set_reasoning_effort(Some(ReasoningEffort::Low))
+        .await
+        .expect("fresh actor sets effort");
+    fresh
+        .set_mode(AgentMode::Plan)
+        .await
+        .expect("fresh actor switches to plan");
+
+    stale
+        .set_llm_config(
+            LLMParams::new().provider("mock").model("rebased-config"),
+            None,
+        )
+        .await
+        .expect("stale actor rebases llm config onto current mode");
+
+    let persisted = config
+        .provider
+        .history_store()
+        .get_session_control(&session_id)
+        .await
+        .expect("load persisted control")
+        .expect("control state exists");
+    assert_eq!(persisted.active_mode, AgentMode::Plan);
+    assert_eq!(persisted.effective_model.model, "rebased-config");
+    assert_eq!(persisted.reasoning_effort, Some(ReasoningEffort::Low));
+    let llm = config
+        .provider
+        .history_store()
+        .get_llm_config(persisted.effective_model.llm_config_id)
+        .await
+        .expect("load llm config")
+        .expect("llm config exists");
+    let params: LLMParams = llm
+        .params
+        .as_ref()
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    assert_eq!(params.reasoning_effort, Some(ReasoningEffort::Low));
+}
+
+#[tokio::test]
+async fn set_llm_config_keeps_params_effort_when_uncontended() {
+    let (config, _td) = test_agent_config().await;
+    let (session, session_id) =
+        spawn_test_session_with_id(config.clone(), "uncontended-config").await;
+    session
+        .set_reasoning_effort(Some(ReasoningEffort::Low))
+        .await
+        .expect("set session effort");
+
+    session
+        .set_llm_config(
+            LLMParams::new()
+                .provider("mock")
+                .model("explicit-effort")
+                .reasoning_effort(ReasoningEffort::High),
+            None,
+        )
+        .await
+        .expect("uncontended llm config keeps params effort");
+
+    let persisted = config
+        .provider
+        .history_store()
+        .get_session_control(&session_id)
+        .await
+        .expect("load persisted control")
+        .expect("control state exists");
+    assert_eq!(persisted.reasoning_effort, Some(ReasoningEffort::Low));
+    assert_eq!(persisted.effective_model.model, "explicit-effort");
+    let llm = config
+        .provider
+        .history_store()
+        .get_llm_config(persisted.effective_model.llm_config_id)
+        .await
+        .expect("load llm config")
+        .expect("llm config exists");
+    let params: LLMParams = llm
+        .params
+        .as_ref()
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    assert_eq!(params.reasoning_effort, Some(ReasoningEffort::High));
 }
 
 #[tokio::test]

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -64,7 +64,7 @@ enum ControlTransitionIntent {
     ModelConfig {
         model_id: String,
         provider_node_id: Option<String>,
-        params: querymt::LLMParams,
+        params: Box<querymt::LLMParams>,
     },
     ReasoningEffort(Option<ReasoningEffort>),
 }
@@ -743,7 +743,7 @@ impl SessionActor {
                 provider_node_id,
                 params,
             } => {
-                let mut params = params.clone();
+                let mut params = params.as_ref().clone();
                 if rebased {
                     params.reasoning_effort = previous.reasoning_effort;
                 }
@@ -802,7 +802,7 @@ impl SessionActor {
         self.rebase_control_once(ControlTransitionIntent::ModelConfig {
             model_id,
             provider_node_id,
-            params,
+            params: Box::new(params),
         })
         .await
     }

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -58,6 +58,17 @@ fn parse_transport_model_id(model_id: &str, fallback_provider: &str) -> (String,
     }
 }
 
+enum ControlTransitionIntent {
+    Mode(AgentMode),
+    Model(crate::agent::session_control::SessionModelSelection),
+    ModelConfig {
+        model_id: String,
+        provider_node_id: Option<String>,
+        params: querymt::LLMParams,
+    },
+    ReasoningEffort(Option<ReasoningEffort>),
+}
+
 const ATTACHMENTS_PLACEHOLDER: &str = "(attachments included)";
 
 fn emit_hook_notices(config: &AgentConfig, session_id: &str, notices: Vec<HookNotice>) {
@@ -583,17 +594,17 @@ impl Message<SetLlmConfig> for SessionActor {
 }
 
 impl SessionActor {
-    async fn ensure_control_state(&mut self) -> Result<SessionControlState, AgentError> {
-        if let Some(state) = &self.control_state {
-            return Ok(state.clone());
-        }
+    fn apply_control_state(&mut self, state: SessionControlState) -> SessionControlState {
+        self.mode = state.active_mode;
+        self.reasoning_effort = state.reasoning_effort;
+        self.control_state = Some(state.clone());
+        state
+    }
 
+    async fn load_control_state_from_store(&mut self) -> Result<SessionControlState, AgentError> {
         let store = self.config.provider.history_store();
         if let Some(state) = store.get_session_control(&self.session_id).await? {
-            self.mode = state.active_mode;
-            self.reasoning_effort = state.reasoning_effort;
-            self.control_state = Some(state.clone());
-            return Ok(state);
+            return Ok(self.apply_control_state(state));
         }
 
         let config = match store.get_session_llm_config(&self.session_id).await? {
@@ -623,11 +634,33 @@ impl SessionActor {
             effective_model: binding,
             mode_models,
         };
-        let state = store
+        match store
             .commit_session_control(&self.session_id, 0, &state)
-            .await?;
-        self.control_state = Some(state.clone());
-        Ok(state)
+            .await
+        {
+            Ok(state) => Ok(self.apply_control_state(state)),
+            Err(error) => {
+                let agent_error = AgentError::from(error);
+                if agent_error.is_session_control_revision_conflict()
+                    && let Some(existing) = store.get_session_control(&self.session_id).await?
+                {
+                    return Ok(self.apply_control_state(existing));
+                }
+                Err(agent_error)
+            }
+        }
+    }
+
+    async fn ensure_control_state(&mut self) -> Result<SessionControlState, AgentError> {
+        if let Some(state) = &self.control_state {
+            return Ok(state.clone());
+        }
+        self.load_control_state_from_store().await
+    }
+
+    async fn reload_control_state(&mut self) -> Result<SessionControlState, AgentError> {
+        self.control_state = None;
+        self.load_control_state_from_store().await
     }
 
     async fn commit_control_transition(
@@ -636,16 +669,18 @@ impl SessionActor {
         mut proposed: SessionControlState,
     ) -> Result<SessionControlTransition, AgentError> {
         proposed.revision = previous.revision.saturating_add(1);
-        let current = self
+        let current = match self
             .config
             .provider
             .history_store()
             .commit_session_control(&self.session_id, previous.revision, &proposed)
-            .await?;
+            .await
+        {
+            Ok(current) => current,
+            Err(error) => return Err(AgentError::from(error)),
+        };
 
-        self.mode = current.active_mode;
-        self.reasoning_effort = current.reasoning_effort;
-        self.control_state = Some(current.clone());
+        self.apply_control_state(current.clone());
 
         if previous.active_mode != current.active_mode {
             self.config.emit_event(
@@ -675,11 +710,70 @@ impl SessionActor {
         Ok(SessionControlTransition { previous, current })
     }
 
+    async fn rebase_control_once(
+        &mut self,
+        intent: ControlTransitionIntent,
+    ) -> Result<SessionControlTransition, AgentError> {
+        let previous = self.ensure_control_state().await?;
+        match self.apply_control_intent(previous, &intent, false).await {
+            Ok(transition) => Ok(transition),
+            Err(error) if error.is_session_control_revision_conflict() => {
+                let previous = self.reload_control_state().await?;
+                self.apply_control_intent(previous, &intent, true).await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn apply_control_intent(
+        &mut self,
+        previous: SessionControlState,
+        intent: &ControlTransitionIntent,
+        rebased: bool,
+    ) -> Result<SessionControlTransition, AgentError> {
+        match intent {
+            ControlTransitionIntent::Mode(mode) => {
+                self.commit_mode_transition(previous, *mode).await
+            }
+            ControlTransitionIntent::Model(selection) => {
+                self.apply_model_selection(previous, selection).await
+            }
+            ControlTransitionIntent::ModelConfig {
+                model_id,
+                provider_node_id,
+                params,
+            } => {
+                let mut params = params.clone();
+                if rebased {
+                    params.reasoning_effort = previous.reasoning_effort;
+                }
+                self.apply_model_binding(
+                    previous,
+                    model_id.clone(),
+                    provider_node_id.clone(),
+                    params,
+                )
+                .await
+            }
+            ControlTransitionIntent::ReasoningEffort(effort) => {
+                self.commit_reasoning_effort(previous, *effort).await
+            }
+        }
+    }
+
     async fn transition_mode(
         &mut self,
         mode: AgentMode,
     ) -> Result<SessionControlTransition, AgentError> {
-        let previous = self.ensure_control_state().await?;
+        self.rebase_control_once(ControlTransitionIntent::Mode(mode))
+            .await
+    }
+
+    async fn commit_mode_transition(
+        &mut self,
+        previous: SessionControlState,
+        mode: AgentMode,
+    ) -> Result<SessionControlTransition, AgentError> {
         let mut proposed = previous.clone();
         let binding = proposed
             .binding_for(mode)
@@ -695,15 +789,7 @@ impl SessionActor {
         &mut self,
         selection: crate::agent::session_control::SessionModelSelection,
     ) -> Result<SessionControlTransition, AgentError> {
-        let previous = self.ensure_control_state().await?;
-        let (provider, model) =
-            parse_transport_model_id(&selection.model_id, &previous.effective_model.provider);
-        let mut params = querymt::LLMParams::new().provider(&provider).model(&model);
-        for prompt_part in self.get_session_system_prompt().await {
-            params = params.system(prompt_part);
-        }
-        params.reasoning_effort = previous.reasoning_effort;
-        self.transition_model_with_config(selection.model_id, selection.provider_node_id, params)
+        self.rebase_control_once(ControlTransitionIntent::Model(selection))
             .await
     }
 
@@ -713,7 +799,42 @@ impl SessionActor {
         provider_node_id: Option<String>,
         params: querymt::LLMParams,
     ) -> Result<SessionControlTransition, AgentError> {
-        let previous = self.ensure_control_state().await?;
+        self.rebase_control_once(ControlTransitionIntent::ModelConfig {
+            model_id,
+            provider_node_id,
+            params,
+        })
+        .await
+    }
+
+    async fn apply_model_selection(
+        &mut self,
+        previous: SessionControlState,
+        selection: &crate::agent::session_control::SessionModelSelection,
+    ) -> Result<SessionControlTransition, AgentError> {
+        let (provider, model) =
+            parse_transport_model_id(&selection.model_id, &previous.effective_model.provider);
+        let mut params = querymt::LLMParams::new().provider(&provider).model(&model);
+        for prompt_part in self.get_session_system_prompt().await {
+            params = params.system(prompt_part);
+        }
+        params.reasoning_effort = previous.reasoning_effort;
+        self.apply_model_binding(
+            previous,
+            selection.model_id.clone(),
+            selection.provider_node_id.clone(),
+            params,
+        )
+        .await
+    }
+
+    async fn apply_model_binding(
+        &mut self,
+        previous: SessionControlState,
+        model_id: String,
+        provider_node_id: Option<String>,
+        params: querymt::LLMParams,
+    ) -> Result<SessionControlTransition, AgentError> {
         let provider_name = params
             .provider
             .as_ref()
@@ -751,7 +872,15 @@ impl SessionActor {
         &mut self,
         effort: Option<ReasoningEffort>,
     ) -> Result<SessionControlTransition, AgentError> {
-        let previous = self.ensure_control_state().await?;
+        self.rebase_control_once(ControlTransitionIntent::ReasoningEffort(effort))
+            .await
+    }
+
+    async fn commit_reasoning_effort(
+        &mut self,
+        previous: SessionControlState,
+        effort: Option<ReasoningEffort>,
+    ) -> Result<SessionControlTransition, AgentError> {
         let store = self.config.provider.history_store();
         let mut proposed = previous.clone();
         proposed.reasoning_effort = effort;

--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -97,6 +97,9 @@ pub enum AgentError {
     #[error("invalid prompt content: {message}")]
     InvalidPromptContent { message: String },
 
+    #[error("session control revision conflict: expected {expected}, found {found}")]
+    SessionControlRevisionConflict { expected: u64, found: u64 },
+
     // --- Serialization ---
     #[error("serialization error: {0}")]
     Serialization(String),
@@ -145,6 +148,14 @@ impl From<AgentError> for AcpError {
             return AcpError::new(-32602, message.clone()).data(serde_json::json!({
                 "category": "prompt_content",
                 "message": message,
+            }));
+        }
+        if let AgentError::SessionControlRevisionConflict { expected, found } = &e {
+            return AcpError::new(-32603, e.to_string()).data(serde_json::json!({
+                "category": "session_control",
+                "kind": "revision_conflict",
+                "expected": expected,
+                "found": found,
             }));
         }
 
@@ -210,11 +221,20 @@ impl From<serde_json::Error> for AgentError {
     }
 }
 
+impl AgentError {
+    pub(crate) fn is_session_control_revision_conflict(&self) -> bool {
+        matches!(self, Self::SessionControlRevisionConflict { .. })
+    }
+}
+
 impl From<crate::session::error::SessionError> for AgentError {
     fn from(e: crate::session::error::SessionError) -> Self {
         use crate::session::error::SessionError;
         match e {
             SessionError::SessionNotFound(id) => AgentError::SessionNotFound { session_id: id },
+            SessionError::SessionControlRevisionConflict { expected, found } => {
+                AgentError::SessionControlRevisionConflict { expected, found }
+            }
             other => AgentError::Internal(other.to_string()),
         }
     }
@@ -240,6 +260,18 @@ mod tests {
         }
         .into();
         assert_eq!(error.code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn session_control_revision_conflict_maps_to_internal_error() {
+        let error: AcpError = AgentError::SessionControlRevisionConflict {
+            expected: 30,
+            found: 31,
+        }
+        .into();
+        assert_eq!(error.code, ErrorCode::InternalError);
+        assert!(error.message.contains("expected 30"));
+        assert!(error.message.contains("found 31"));
     }
 
     #[test]
@@ -517,6 +549,32 @@ mod tests {
         let session_err = crate::session::error::SessionError::TaskNotFound("t-1".to_string());
         let agent_err: AgentError = session_err.into();
         assert!(matches!(agent_err, AgentError::Internal(_)));
+    }
+
+    #[test]
+    fn from_session_error_revision_conflict_is_typed() {
+        let session_err = crate::session::error::SessionError::SessionControlRevisionConflict {
+            expected: 1,
+            found: 31,
+        };
+        let agent_err: AgentError = session_err.into();
+        assert!(matches!(
+            agent_err,
+            AgentError::SessionControlRevisionConflict {
+                expected: 1,
+                found: 31
+            }
+        ));
+    }
+
+    #[test]
+    fn invalid_operation_conflict_text_is_not_a_typed_conflict() {
+        let session_err = crate::session::error::SessionError::InvalidOperation(
+            "session control revision conflict".to_string(),
+        );
+        let agent_err: AgentError = session_err.into();
+        assert!(matches!(agent_err, AgentError::Internal(_)));
+        assert!(!agent_err.is_session_control_revision_conflict());
     }
 
     #[test]

--- a/crates/agent/src/session/error.rs
+++ b/crates/agent/src/session/error.rs
@@ -62,6 +62,10 @@ pub enum SessionError {
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
 
+    /// Session control CAS failed because another writer advanced the revision.
+    #[error("session control revision conflict: expected {expected}, found {found}")]
+    SessionControlRevisionConflict { expected: u64, found: u64 },
+
     /// Provider error (from LLM operations)
     #[error("Provider error: {0}")]
     ProviderError(#[from] LLMError),
@@ -101,6 +105,11 @@ impl From<SessionError> for LLMError {
             SessionError::InvalidForkPoint(msg)
             | SessionError::InvalidMessageIndex(msg)
             | SessionError::InvalidOperation(msg) => LLMError::InvalidRequest(msg),
+            SessionError::SessionControlRevisionConflict { expected, found } => {
+                LLMError::InvalidRequest(format!(
+                    "session control revision conflict: expected {expected}, found {found}"
+                ))
+            }
             SessionError::ForkPointTypeMismatch { expected, actual } => {
                 LLMError::InvalidRequest(format!(
                     "Fork point type mismatch: expected {}, got {}",

--- a/crates/agent/src/session/sqlite_storage/mod.rs
+++ b/crates/agent/src/session/sqlite_storage/mod.rs
@@ -107,6 +107,15 @@ impl SqliteStorage {
         F: FnOnce(&mut Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
+        self.run_blocking_session(move |conn| f(conn).map_err(SessionError::from))
+            .await
+    }
+
+    pub(super) async fn run_blocking_session<F, R>(&self, f: F) -> SessionResult<R>
+    where
+        F: FnOnce(&mut Connection) -> SessionResult<R> + Send + 'static,
+        R: Send + 'static,
+    {
         let conn_arc = self.conn.clone();
         tokio::task::spawn_blocking(move || {
             let mut conn = conn_arc.lock().unwrap();
@@ -114,7 +123,6 @@ impl SqliteStorage {
         })
         .await
         .map_err(|e| SessionError::Other(format!("Task execution failed: {}", e)))?
-        .map_err(SessionError::from)
     }
 
     /// Helper: Resolve session public_id → internal i64

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -767,26 +767,29 @@ impl SessionStore for SqliteStorage {
     ) -> SessionResult<SessionControlState> {
         let session_id = session_id.to_string();
         let state = state.clone();
-        let committed = self
-            .run_blocking(move |conn| {
-                let tx = conn.transaction()?;
-                let session_internal_id: i64 = tx.query_row(
-                    "SELECT id FROM sessions WHERE public_id = ?1",
-                    params![session_id],
-                    |row| row.get(0),
-                )?;
+        self.run_blocking_session(move |conn| {
+                let tx = conn.transaction().map_err(SessionError::from)?;
+                let session_internal_id: i64 = tx
+                    .query_row(
+                        "SELECT id FROM sessions WHERE public_id = ?1",
+                        params![session_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(SessionError::from)?;
                 let current_revision = tx
                     .query_row(
                         "SELECT revision FROM session_control_states WHERE session_id = ?1",
                         params![session_internal_id],
                         |row| row.get::<_, i64>(0).map(|revision| revision as u64),
                     )
-                    .optional()?
+                    .optional()
+                    .map_err(SessionError::from)?
                     .unwrap_or(0);
                 if current_revision != expected_revision {
-                    return Err(rusqlite::Error::InvalidParameterName(format!(
-                        "session_control_revision_conflict:{current_revision}"
-                    )));
+                    return Err(SessionError::SessionControlRevisionConflict {
+                        expected: expected_revision,
+                        found: current_revision,
+                    });
                 }
 
                 let now = OffsetDateTime::now_utc()
@@ -802,35 +805,31 @@ impl SessionStore for SqliteStorage {
                         reasoning_effort = excluded.reasoning_effort, revision = excluded.revision,
                         updated_at = excluded.updated_at",
                     params![session_internal_id, state.active_mode.as_str(), reasoning_effort, state.revision as i64, now],
-                )?;
+                )
+                .map_err(SessionError::from)?;
                 tx.execute(
                     "DELETE FROM session_mode_model_bindings WHERE session_id = ?1",
                     params![session_internal_id],
-                )?;
+                )
+                .map_err(SessionError::from)?;
                 for (mode, binding) in &state.mode_models {
                     tx.execute(
                         "INSERT INTO session_mode_model_bindings
                          (session_id, mode, model_id, provider, model, llm_config_id, provider_node_id)
                          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                         params![session_internal_id, mode, binding.model_id, binding.provider, binding.model, binding.llm_config_id, binding.provider_node_id],
-                    )?;
+                    )
+                    .map_err(SessionError::from)?;
                 }
                 tx.execute(
                     "UPDATE sessions SET llm_config_id = ?1, provider_node_id = ?2, updated_at = ?3 WHERE id = ?4",
                     params![state.effective_model.llm_config_id, state.effective_model.provider_node_id, now, session_internal_id],
-                )?;
-                tx.commit()?;
+                )
+                .map_err(SessionError::from)?;
+                tx.commit().map_err(SessionError::from)?;
                 Ok(state)
             })
-            .await;
-        committed.map_err(|error| match error {
-            SessionError::DatabaseError(message)
-                if message.contains("session_control_revision_conflict") =>
-            {
-                SessionError::InvalidOperation("session control revision conflict".to_string())
-            }
-            other => other,
-        })
+            .await
     }
 
     async fn set_profile_binding(&self, session_id: &str, profile_id: &str) -> SessionResult<()> {

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -260,7 +260,13 @@ async fn session_control_commit_is_revisioned_and_session_scoped() {
         .commit_session_control(&first.public_id, 0, &state)
         .await
         .expect_err("stale revision must fail");
-    assert!(stale.to_string().contains("revision conflict"));
+    assert!(matches!(
+        stale,
+        crate::session::error::SessionError::SessionControlRevisionConflict {
+            expected: 0,
+            found: 1
+        }
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #894

## Summary
`session/set_config_option` could fail with `session control revision conflict` and then stay broken. A stale `SessionActor` cache sent an old CAS revision; on conflict it never reloaded, so later mode/model/effort switches kept failing.

## Fix
- Reload control from the store on CAS conflict and retry the requested mode/model/effort once.
- Recover init CAS (`expected_revision = 0`) by loading the existing row.
- Return a typed `SessionControlRevisionConflict` instead of wrapping it as `Internal` / `remote actor error`.

Does not change per-mode bindings. Does not stop leftover actors on rematerialize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session control changes now recover cleanly when concurrent updates cause revision conflicts.
  - Stale session state is refreshed before applying mode, model, reasoning-effort, and configuration changes.
  - Reasoning effort is preserved correctly when updating model configuration.
  - Revision conflicts now provide structured error details for more reliable handling by clients.
  - Improved error consistency across session-control operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->