### PR TITLE
fix: Implemented the provider timeout and stale event-forwarder fixes

### DIFF
--- a/crates/agent/src/agent/remote/event_forwarder.rs
+++ b/crates/agent/src/agent/remote/event_forwarder.rs
@@ -12,18 +12,49 @@ use std::sync::Arc;
 
 #[cfg(feature = "remote")]
 use kameo::actor::RemoteActorRef;
+#[cfg(feature = "remote")]
+use kameo::error::{Infallible, RemoteSendError};
 
 #[cfg(feature = "remote")]
 use super::event_relay::{EventRelayActor, RelayedEvent};
 
+/// An owned event-forwarder task. Dropping the handle cancels the task.
+pub struct EventForwarderHandle {
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl EventForwarderHandle {
+    pub fn abort(&self) {
+        self.task.abort();
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+}
+
+impl Drop for EventForwarderHandle {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 /// Event forwarder that subscribes to an EventFanout and sends events to a
 /// remote EventRelayActor.
-///
-/// Spawns a background task that reads from the fanout receiver and forwards
-/// each event to the relay actor. The task is cancelled when the returned
-/// `tokio::task::JoinHandle` is aborted or the fanout sender is dropped.
 #[cfg(feature = "remote")]
 pub struct EventForwarder;
+
+#[cfg(feature = "remote")]
+fn destination_is_gone(error: &RemoteSendError<Infallible>) -> bool {
+    matches!(
+        error,
+        RemoteSendError::ActorNotRunning
+            | RemoteSendError::ActorStopped
+            | RemoteSendError::UnknownActor { .. }
+            | RemoteSendError::UnknownMessage { .. }
+            | RemoteSendError::BadActorType
+    )
+}
 
 #[cfg(feature = "remote")]
 impl EventForwarder {
@@ -34,15 +65,16 @@ impl EventForwarder {
     /// skipped.  This prevents N-times duplication when multiple remote
     /// sessions share the same `EventFanout`.
     ///
-    /// Returns a `JoinHandle` that can be used to abort the forwarder task.
+    /// Returns an owned handle which cancels the forwarder when dropped.
     pub fn start(
         fanout: Arc<crate::event_fanout::EventFanout>,
         relay_ref: RemoteActorRef<EventRelayActor>,
         source_label: String,
         filter_session_id: String,
-    ) -> tokio::task::JoinHandle<()> {
+    ) -> EventForwarderHandle {
         let mut rx = fanout.subscribe();
-        tokio::spawn(async move {
+        let relay_actor_id = relay_ref.id();
+        let task = tokio::spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(envelope) => {
@@ -63,18 +95,27 @@ impl EventForwarder {
                             "forwarding event to relay actor"
                         );
 
-                        if let Err(e) = relay_ref
+                        if let Err(error) = relay_ref
                             .tell(&RelayedEvent {
                                 event: event.clone(),
                             })
-                            .send()
+                            .mailbox_timeout(std::time::Duration::from_secs(3))
+                            .send_ack()
+                            .await
                         {
+                            let terminal = destination_is_gone(&error);
                             tracing::warn!(
                                 target: "remote::event_forwarder",
                                 source = %source_label,
-                                error = %e,
+                                session_id = %filter_session_id,
+                                relay_actor_id = %relay_actor_id,
+                                terminal,
+                                error = %error,
                                 "failed to forward event to relay actor"
                             );
+                            if terminal {
+                                break;
+                            }
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
@@ -95,7 +136,8 @@ impl EventForwarder {
                     }
                 }
             }
-        })
+        });
+        EventForwarderHandle { task }
     }
 }
 
@@ -112,7 +154,7 @@ impl EventForwarder {
         _relay_ref: (),
         _source_label: String,
         _filter_session_id: String,
-    ) -> tokio::task::JoinHandle<()> {
+    ) -> EventForwarderHandle {
         panic!("EventForwarder requires the 'remote' feature to be enabled")
     }
 }

--- a/crates/agent/src/agent/remote/event_relay_mesh_tests.rs
+++ b/crates/agent/src/agent/remote/event_relay_mesh_tests.rs
@@ -120,6 +120,47 @@ mod event_relay_mesh_tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_event_forwarder_stops_after_relay_actor_dies() {
+        let test_id = Uuid::now_v7().to_string();
+        let mesh = get_test_mesh().await;
+        let (relay_ref, _event_sink, dht_name) =
+            setup_relay("f1-dead", &test_id, "s-f1-dead").await;
+
+        let remote_relay = mesh
+            .lookup_actor::<EventRelayActor>(&dht_name)
+            .await
+            .expect("DHT lookup")
+            .expect("relay not in DHT");
+        let source_fanout = Arc::new(EventFanout::new());
+        let handle = EventForwarder::start(
+            source_fanout.clone(),
+            remote_relay,
+            "test-source-f1-dead".to_string(),
+            "s-f1-dead".to_string(),
+        );
+
+        relay_ref.kill();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        source_fanout.publish(EventEnvelope::Durable(crate::events::DurableEvent {
+            event_id: "e-f1-dead".into(),
+            stream_seq: 1,
+            session_id: "s-f1-dead".into(),
+            timestamp: 1000,
+            origin: EventOrigin::Local,
+            source_node: None,
+            kind: AgentEventKind::SessionCreated,
+        }));
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !handle.is_finished() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("forwarder should stop after ActorNotRunning");
+    }
+
     // ── F.2 ──────────────────────────────────────────────────────────────────
 
     #[tokio::test]

--- a/crates/agent/src/agent/session_actor.rs
+++ b/crates/agent/src/agent/session_actor.rs
@@ -188,8 +188,10 @@ pub struct SessionActor {
     #[cfg(feature = "remote")]
     pub(crate) mesh: Option<crate::agent::remote::MeshHandle>,
 
-    // Tracks EventForwarder task handles by relay actor so unsubscribe can abort.
-    pub(crate) relay_forwarder_handles: HashMap<u64, tokio::task::JoinHandle<()>>,
+    // Tracks owned EventForwarder tasks by relay actor so replacement, unsubscribe,
+    // and SessionActor teardown cancel the corresponding background task.
+    pub(crate) relay_forwarder_handles:
+        HashMap<u64, crate::agent::remote::event_forwarder::EventForwarderHandle>,
 }
 
 #[derive(Clone)]
@@ -1408,6 +1410,12 @@ impl Message<crate::agent::messages::SubscribeEvents> for SessionActor {
                         ))
                     })?
             };
+
+            // Completed forwarders no longer own a live subscription. Prune them
+            // before installing a generation so repeated reconnects cannot leave
+            // finished task handles in the session actor.
+            self.relay_forwarder_handles
+                .retain(|_, handle| !handle.is_finished());
 
             if let Some(prev_handle) = self.relay_forwarder_handles.remove(&msg.relay_actor_id) {
                 prev_handle.abort();

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -1388,15 +1388,22 @@ fn map_openai_error_envelope(
         .and_then(openai_error_kind)
         .or_else(|| type_norm.as_deref().and_then(openai_error_kind));
 
-    // Unclassified server-side codes are transient; anything else unknown
-    // defers to the caller's status-based guess.
-    let server_side = matches!(
-        code_norm.as_deref(),
-        Some("server_error" | "internal_server_error")
-    ) || matches!(
-        type_norm.as_deref(),
-        Some("server_error" | "internal_server_error")
-    );
+    // Some OpenAI-compatible providers put an HTTP status in the in-stream
+    // error code. Preserve semantic classifications above, then use server
+    // status codes as transient evidence when the SSE response has no status.
+    let numeric_server_code = code_norm
+        .as_deref()
+        .and_then(|code| code.parse::<u16>().ok())
+        .is_some_and(|code| code == 408 || code == 429 || (500..=599).contains(&code));
+    let server_side = numeric_server_code
+        || matches!(
+            code_norm.as_deref(),
+            Some("server_error" | "internal_server_error")
+        )
+        || matches!(
+            type_norm.as_deref(),
+            Some("server_error" | "internal_server_error")
+        );
     let kind = mapped.unwrap_or(if unknown_transient || server_side {
         ProviderErrorKind::UnknownTransient
     } else {
@@ -2245,6 +2252,44 @@ data: {"choices":[{"index":0,"delta":{"reasoning_content":"continued"}}]}
     fn parse_sse_unknown_error_without_server_evidence_is_permanent() {
         let mut tool_states = HashMap::new();
         let chunk = br#"data: {"error":{"message":"vendor failure","code":"vendor_specific"}}
+
+"#;
+
+        let error = parse_openai_sse_chunk(chunk, &mut tool_states).unwrap_err();
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownPermanent
+        ));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn parse_sse_numeric_gateway_timeout_is_retryable() {
+        for code in [serde_json::json!(504), serde_json::json!("504")] {
+            let mut tool_states = HashMap::new();
+            let chunk = format!(
+                "data: {{\"error\":{{\"message\":\"Upstream idle timeout exceeded\",\"code\":{code}}}}}\n\n"
+            );
+
+            let error = parse_openai_sse_chunk(chunk.as_bytes(), &mut tool_states)
+                .expect_err("504 error envelope should return an error");
+            match &error {
+                LLMError::ProviderResponseError(failure) => {
+                    assert_eq!(failure.message(), "Upstream idle timeout exceeded");
+                    assert_eq!(failure.code(), Some("504"));
+                    assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
+                }
+                other => panic!("expected ProviderResponseError, got {other}"),
+            }
+            assert!(error.is_retryable());
+        }
+    }
+
+    #[test]
+    fn parse_sse_numeric_client_error_remains_permanent() {
+        let mut tool_states = HashMap::new();
+        let chunk = br#"data: {"error":{"message":"vendor failure","code":499}}
 
 "#;
 

--- a/crates/providers/openai/src/api.rs
+++ b/crates/providers/openai/src/api.rs
@@ -886,24 +886,51 @@ pub fn openai_chat_request<C: OpenAIProviderConfig>(
 }
 
 pub fn openai_parse_chat<C: OpenAIProviderConfig>(
-    _cfg: &C,
+    cfg: &C,
     response: Response<Vec<u8>>,
 ) -> Result<Box<dyn ChatResponse>, LLMError> {
+    openai_parse_chat_with(cfg, response, None)
+}
+
+pub fn openai_parse_chat_with<C: OpenAIProviderConfig>(
+    _cfg: &C,
+    response: Response<Vec<u8>>,
+    provider_classifier: Option<OpenAIErrorClassifier>,
+) -> Result<Box<dyn ChatResponse>, LLMError> {
     if !response.status().is_success() {
-        return Err(classify_openai_http_error(&response));
+        return Err(classify_openai_http_error_with(
+            &response,
+            provider_classifier,
+        ));
     }
 
-    let json_resp: Result<OpenAIChatResponse, serde_json::Error> =
-        serde_json::from_slice(response.body());
-
-    let resp_text: String = "".to_string();
-    match json_resp {
-        Ok(response) => Ok(Box::new(response)),
-        Err(e) => Err(LLMError::ResponseFormatError {
-            message: format!("Failed to decode API response: {}", e),
-            raw_response: resp_text,
-        }),
+    let envelope: Value =
+        serde_json::from_slice(response.body()).map_err(|error| LLMError::ResponseFormatError {
+            message: format!("Failed to decode API response: {error}"),
+            raw_response: String::from_utf8_lossy(response.body()).into_owned(),
+        })?;
+    if let Some(error) = envelope.get("error") {
+        let explicit_request_id = envelope
+            .get("request_id")
+            .or_else(|| envelope.get("requestId"))
+            .or_else(|| envelope.get("id"))
+            .and_then(Value::as_str);
+        return Err(map_openai_error_envelope(
+            error,
+            &envelope,
+            explicit_request_id,
+            false,
+            provider_classifier,
+        )
+        .into());
     }
+
+    serde_json::from_value::<OpenAIChatResponse>(envelope)
+        .map(|response| Box::new(response) as Box<dyn ChatResponse>)
+        .map_err(|error| LLMError::ResponseFormatError {
+            message: format!("Failed to decode API response: {error}"),
+            raw_response: String::from_utf8_lossy(response.body()).into_owned(),
+        })
 }
 
 /// Extract the thinking/reasoning content from a ChatMessage, if any.
@@ -1341,13 +1368,25 @@ fn openai_error_kind(code: &str) -> Option<ProviderErrorKind> {
     }
 }
 
+/// Provider-specific classification layered over the shared OpenAI-compatible
+/// envelope parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenAIErrorClassification {
+    pub kind: ProviderErrorKind,
+    pub error_type: Option<String>,
+}
+
+pub type OpenAIErrorClassifier = fn(&Value) -> Option<OpenAIErrorClassification>;
+
 /// Map an OpenAI-compatible SSE/HTTP `{ "error": ... }` envelope into unified
-/// [`ProviderFailure`] kinds. Vendor `code`/`type` dialect stays here.
+/// [`ProviderFailure`] kinds. Provider-specific classifiers take precedence over
+/// the generic `code`/`type` dialect table.
 fn map_openai_error_envelope(
     error: &Value,
     envelope: &Value,
     explicit_request_id: Option<&str>,
     unknown_transient: bool,
+    provider_classifier: Option<OpenAIErrorClassifier>,
 ) -> ProviderFailure {
     let message = error
         .as_str()
@@ -1367,11 +1406,17 @@ fn map_openai_error_envelope(
             .map(str::to_owned)
             .or_else(|| value.as_i64().map(|number| number.to_string()))
     });
-    let error_type = error
-        .get("type")
-        .or_else(|| error.get("error_type"))
-        .and_then(Value::as_str)
-        .map(str::to_owned);
+    let provider_classification = provider_classifier.and_then(|classify| classify(error));
+    let error_type = provider_classification
+        .as_ref()
+        .and_then(|classification| classification.error_type.clone())
+        .or_else(|| {
+            error
+                .get("type")
+                .or_else(|| error.get("error_type"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
     let request_id = explicit_request_id.map(str::to_owned).or_else(|| {
         error
             .get("request_id")
@@ -1383,27 +1428,18 @@ fn map_openai_error_envelope(
         extract_retry_after_from_json(error).or_else(|| extract_retry_after_from_json(envelope));
     let code_norm = code.as_deref().map(normalize_error_token);
     let type_norm = error_type.as_deref().map(normalize_error_token);
-    let mapped = code_norm
-        .as_deref()
-        .and_then(openai_error_kind)
+    let mapped = provider_classification
+        .map(|classification| classification.kind)
+        .or_else(|| code_norm.as_deref().and_then(openai_error_kind))
         .or_else(|| type_norm.as_deref().and_then(openai_error_kind));
 
-    // Some OpenAI-compatible providers put an HTTP status in the in-stream
-    // error code. Preserve semantic classifications above, then use server
-    // status codes as transient evidence when the SSE response has no status.
-    let numeric_server_code = code_norm
-        .as_deref()
-        .and_then(|code| code.parse::<u16>().ok())
-        .is_some_and(|code| code == 408 || code == 429 || (500..=599).contains(&code));
-    let server_side = numeric_server_code
-        || matches!(
-            code_norm.as_deref(),
-            Some("server_error" | "internal_server_error")
-        )
-        || matches!(
-            type_norm.as_deref(),
-            Some("server_error" | "internal_server_error")
-        );
+    let server_side = matches!(
+        code_norm.as_deref(),
+        Some("server_error" | "internal_server_error")
+    ) || matches!(
+        type_norm.as_deref(),
+        Some("server_error" | "internal_server_error")
+    );
     let kind = mapped.unwrap_or(if unknown_transient || server_side {
         ProviderErrorKind::UnknownTransient
     } else {
@@ -1426,6 +1462,13 @@ fn map_openai_error_envelope(
 
 /// Classify an OpenAI-compatible HTTP error body.
 pub fn classify_openai_http_error(response: &Response<Vec<u8>>) -> LLMError {
+    classify_openai_http_error_with(response, None)
+}
+
+pub fn classify_openai_http_error_with(
+    response: &Response<Vec<u8>>,
+    provider_classifier: Option<OpenAIErrorClassifier>,
+) -> LLMError {
     let status = response.status().as_u16();
     let retry_after_secs = parse_retry_after(response.headers());
     let request_id = response
@@ -1442,6 +1485,7 @@ pub fn classify_openai_http_error(response: &Response<Vec<u8>>) -> LLMError {
             envelope,
             request_id,
             matches!(status, 429 | 500..=599),
+            provider_classifier,
         );
         let retry_after_secs = retry_after_secs.or(mapped.retry_after_secs());
         return mapped.with_retry_after_secs(retry_after_secs).into();
@@ -1454,6 +1498,14 @@ pub fn classify_openai_http_error(response: &Response<Vec<u8>>) -> LLMError {
 pub fn parse_openai_sse_chunk(
     chunk: &[u8],
     tool_states: &mut HashMap<usize, OpenAIToolUseState>,
+) -> Result<Vec<StreamChunk>, LLMError> {
+    parse_openai_sse_chunk_with(chunk, tool_states, None)
+}
+
+pub fn parse_openai_sse_chunk_with(
+    chunk: &[u8],
+    tool_states: &mut HashMap<usize, OpenAIToolUseState>,
+    provider_classifier: Option<OpenAIErrorClassifier>,
 ) -> Result<Vec<StreamChunk>, LLMError> {
     // Skip empty chunks
     if chunk.is_empty() {
@@ -1519,9 +1571,14 @@ pub fn parse_openai_sse_chunk(
                 .get("request_id")
                 .or_else(|| envelope.get("requestId"))
                 .and_then(Value::as_str);
-            return Err(
-                map_openai_error_envelope(error, &envelope, explicit_request_id, false).into(),
-            );
+            return Err(map_openai_error_envelope(
+                error,
+                &envelope,
+                explicit_request_id,
+                false,
+                provider_classifier,
+            )
+            .into());
         }
         let mut stream_chunk: OpenAIStreamChunk =
             serde_json::from_value(envelope).map_err(|e| LLMError::ResponseFormatError {
@@ -2265,24 +2322,22 @@ data: {"choices":[{"index":0,"delta":{"reasoning_content":"continued"}}]}
     }
 
     #[test]
-    fn parse_sse_numeric_gateway_timeout_is_retryable() {
+    fn parse_sse_numeric_vendor_code_is_not_assumed_to_be_http_status() {
         for code in [serde_json::json!(504), serde_json::json!("504")] {
             let mut tool_states = HashMap::new();
             let chunk = format!(
-                "data: {{\"error\":{{\"message\":\"Upstream idle timeout exceeded\",\"code\":{code}}}}}\n\n"
+                "data: {{\"error\":{{\"message\":\"vendor failure\",\"code\":{code}}}}}\n\n"
             );
 
             let error = parse_openai_sse_chunk(chunk.as_bytes(), &mut tool_states)
-                .expect_err("504 error envelope should return an error");
-            match &error {
-                LLMError::ProviderResponseError(failure) => {
-                    assert_eq!(failure.message(), "Upstream idle timeout exceeded");
-                    assert_eq!(failure.code(), Some("504"));
-                    assert_eq!(failure.kind(), ProviderErrorKind::UnknownTransient);
-                }
-                other => panic!("expected ProviderResponseError, got {other}"),
-            }
-            assert!(error.is_retryable());
+                .expect_err("error envelope should return an error");
+            assert!(matches!(
+                error,
+                LLMError::ProviderResponseError(ref failure)
+                    if failure.code() == Some("504")
+                        && failure.kind() == ProviderErrorKind::UnknownPermanent
+            ));
+            assert!(!error.is_retryable());
         }
     }
 

--- a/crates/providers/openrouter/src/lib.rs
+++ b/crates/providers/openrouter/src/lib.rs
@@ -276,7 +276,10 @@ mod extism_exports {
 mod tests {
     use super::{OpenRouter, OpenRouterFactory};
     use querymt::chat::{StreamChunk, http::HTTPChatProvider};
-    use querymt::{error::LLMError, plugin::HTTPLLMProviderFactory};
+    use querymt::{
+        error::{LLMError, ProviderErrorKind},
+        plugin::HTTPLLMProviderFactory,
+    };
     use serde_json::Value;
 
     fn test_provider() -> OpenRouter {
@@ -312,6 +315,30 @@ mod tests {
             .expect("stream request should build");
         let body: Value = serde_json::from_slice(req.body()).expect("body should be valid json");
         assert_eq!(body.get("stream"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn upstream_idle_timeout_is_retryable() {
+        for code in [serde_json::json!(504), serde_json::json!("504")] {
+            let provider = test_provider();
+            let mut parser = provider
+                .chat_stream_parser()
+                .expect("parser should initialize");
+            let chunk = format!(
+                "data: {{\"error\":{{\"message\":\"Upstream idle timeout exceeded\",\"code\":{code}}}}}\n\n"
+            );
+
+            let error = parser
+                .parse_chunk(chunk.as_bytes())
+                .expect_err("504 error envelope should return an error");
+            assert!(matches!(
+                error,
+                LLMError::ProviderResponseError(ref failure)
+                    if failure.kind() == ProviderErrorKind::UnknownTransient
+                        && failure.code() == Some("504")
+            ));
+            assert!(error.is_retryable());
+        }
     }
 
     #[test]

--- a/crates/providers/openrouter/src/lib.rs
+++ b/crates/providers/openrouter/src/lib.rs
@@ -1,8 +1,8 @@
 use http::{Method, Request, Response, header::CONTENT_TYPE};
 use qmt_openai::api::{
-    OpenAIProviderConfig, OpenAIToolUseState, classify_openai_http_error, openai_chat_request,
-    openai_embed_request, openai_parse_chat, openai_parse_embed, parse_openai_sse_chunk,
-    url_schema,
+    OpenAIErrorClassification, OpenAIProviderConfig, OpenAIToolUseState,
+    classify_openai_http_error_with, openai_chat_request, openai_embed_request,
+    openai_parse_chat_with, openai_parse_embed, parse_openai_sse_chunk_with, url_schema,
 };
 use querymt::{
     HTTPLLMProvider,
@@ -12,7 +12,7 @@ use querymt::{
     },
     completion::{CompletionRequest, CompletionResponse, http::HTTPCompletionProvider},
     embedding::http::HTTPEmbeddingProvider,
-    error::LLMError,
+    error::{LLMError, ProviderErrorKind},
     plugin::HTTPLLMProviderFactory,
 };
 use schemars::{JsonSchema, schema_for};
@@ -114,9 +114,123 @@ impl OpenAIProviderConfig for OpenRouter {
     }
 }
 
+fn normalize_openrouter_error_type(error_type: &str) -> String {
+    error_type
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['-', ' '], "_")
+}
+
+fn openrouter_error_kind(error_type: &str) -> Option<ProviderErrorKind> {
+    match error_type {
+        "provider_overloaded" => Some(ProviderErrorKind::ServerOverloaded),
+        "rate_limit_exceeded" => Some(ProviderErrorKind::RateLimited),
+        "context_length_exceeded" => Some(ProviderErrorKind::ContextWindowExceeded),
+        "authentication" => Some(ProviderErrorKind::Authentication),
+        "payment_required" => Some(ProviderErrorKind::QuotaExceeded),
+        "invalid_request"
+        | "invalid_prompt"
+        | "not_found"
+        | "precondition_failed"
+        | "payload_too_large"
+        | "unprocessable"
+        | "content_policy_violation"
+        | "refusal"
+        | "invalid_image"
+        | "image_too_large"
+        | "image_too_small"
+        | "unsupported_image_format"
+        | "image_not_found" => Some(ProviderErrorKind::InvalidRequest),
+        "permission_denied" | "token_limit_exceeded" | "string_too_long" => {
+            Some(ProviderErrorKind::UnknownPermanent)
+        }
+        "provider_unavailable" | "image_download_failed" | "server" | "timeout" | "unmapped" => {
+            Some(ProviderErrorKind::UnknownTransient)
+        }
+        // These describe successful length-limited completions when OpenRouter
+        // applies its documented transformation, not retryable provider errors.
+        "max_tokens_exceeded" => Some(ProviderErrorKind::UnknownPermanent),
+        _ => None,
+    }
+}
+
+fn classify_openrouter_error(error: &Value) -> Option<OpenAIErrorClassification> {
+    let typed_error = error
+        .get("metadata")
+        .and_then(|metadata| metadata.get("error_type"))
+        .or_else(|| error.get("error_type"))
+        .and_then(Value::as_str)
+        .map(normalize_openrouter_error_type);
+
+    if let Some(error_type) = typed_error.as_deref()
+        && let Some(kind) = openrouter_error_kind(error_type)
+    {
+        return Some(OpenAIErrorClassification {
+            kind,
+            error_type: typed_error,
+        });
+    }
+
+    let status = error.get("code").and_then(|code| {
+        code.as_u64()
+            .and_then(|code| u16::try_from(code).ok())
+            .or_else(|| code.as_str().and_then(|code| code.parse::<u16>().ok()))
+    })?;
+    let kind = match status {
+        400 | 403 | 404 | 422 => ProviderErrorKind::InvalidRequest,
+        401 => ProviderErrorKind::Authentication,
+        402 => ProviderErrorKind::QuotaExceeded,
+        408 | 500..=599 => ProviderErrorKind::UnknownTransient,
+        429 => ProviderErrorKind::RateLimited,
+        _ => return None,
+    };
+    Some(OpenAIErrorClassification {
+        kind,
+        error_type: typed_error,
+    })
+}
+
+fn normalize_openrouter_chat_error_response(response: Response<Vec<u8>>) -> Response<Vec<u8>> {
+    if !response.status().is_success() {
+        return response;
+    }
+
+    let Ok(mut envelope) = serde_json::from_slice::<Value>(response.body()) else {
+        return response;
+    };
+    if envelope.get("error").is_some() {
+        return response;
+    }
+    let choice_error = envelope
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| {
+            choice.get("error").or_else(|| {
+                choice
+                    .get("message")
+                    .and_then(|message| message.get("error"))
+            })
+        })
+        .cloned();
+    let Some(choice_error) = choice_error else {
+        return response;
+    };
+    let Some(object) = envelope.as_object_mut() else {
+        return response;
+    };
+    object.insert("error".to_owned(), choice_error);
+
+    let (parts, _) = response.into_parts();
+    Response::from_parts(
+        parts,
+        serde_json::to_vec(&envelope).expect("JSON value must serialize"),
+    )
+}
+
 impl HTTPChatProvider for OpenRouter {
     fn classify_chat_error(&self, response: &Response<Vec<u8>>) -> LLMError {
-        classify_openai_http_error(response)
+        classify_openai_http_error_with(response, Some(classify_openrouter_error))
     }
 
     fn chat_request(
@@ -138,7 +252,11 @@ impl HTTPChatProvider for OpenRouter {
     }
 
     fn parse_chat(&self, response: Response<Vec<u8>>) -> Result<Box<dyn ChatResponse>, LLMError> {
-        openai_parse_chat(self, response)
+        openai_parse_chat_with(
+            self,
+            normalize_openrouter_chat_error_response(response),
+            Some(classify_openrouter_error),
+        )
     }
 
     fn supports_streaming(&self) -> bool {
@@ -157,7 +275,11 @@ struct OpenRouterStreamParser {
 
 impl ChatStreamParser for OpenRouterStreamParser {
     fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<StreamChunk>, LLMError> {
-        parse_openai_sse_chunk(chunk, &mut self.tool_states)
+        parse_openai_sse_chunk_with(
+            chunk,
+            &mut self.tool_states,
+            Some(classify_openrouter_error),
+        )
     }
 }
 
@@ -275,6 +397,7 @@ mod extism_exports {
 #[cfg(test)]
 mod tests {
     use super::{OpenRouter, OpenRouterFactory};
+    use http::Response;
     use querymt::chat::{StreamChunk, http::HTTPChatProvider};
     use querymt::{
         error::{LLMError, ProviderErrorKind},
@@ -317,20 +440,24 @@ mod tests {
         assert_eq!(body.get("stream"), Some(&Value::Bool(true)));
     }
 
+    fn parse_stream_error(error: Value) -> LLMError {
+        let provider = test_provider();
+        let mut parser = provider
+            .chat_stream_parser()
+            .expect("parser should initialize");
+        let chunk = format!("data: {}\n\n", serde_json::json!({ "error": error }));
+        parser
+            .parse_chunk(chunk.as_bytes())
+            .expect_err("error envelope should return an error")
+    }
+
     #[test]
     fn upstream_idle_timeout_is_retryable() {
         for code in [serde_json::json!(504), serde_json::json!("504")] {
-            let provider = test_provider();
-            let mut parser = provider
-                .chat_stream_parser()
-                .expect("parser should initialize");
-            let chunk = format!(
-                "data: {{\"error\":{{\"message\":\"Upstream idle timeout exceeded\",\"code\":{code}}}}}\n\n"
-            );
-
-            let error = parser
-                .parse_chunk(chunk.as_bytes())
-                .expect_err("504 error envelope should return an error");
+            let error = parse_stream_error(serde_json::json!({
+                "message": "Upstream idle timeout exceeded",
+                "code": code
+            }));
             assert!(matches!(
                 error,
                 LLMError::ProviderResponseError(ref failure)
@@ -339,6 +466,106 @@ mod tests {
             ));
             assert!(error.is_retryable());
         }
+    }
+
+    #[test]
+    fn typed_error_takes_precedence_over_numeric_status() {
+        let error = parse_stream_error(serde_json::json!({
+            "message": "Request was rejected",
+            "code": 504,
+            "metadata": { "error_type": "invalid_request" }
+        }));
+
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::InvalidRequest
+                    && failure.error_type() == Some("invalid_request")
+                    && failure.code() == Some("504")
+        ));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn typed_generic_errors_are_retryable() {
+        for error_type in ["timeout", "server", "unmapped"] {
+            let error = parse_stream_error(serde_json::json!({
+                "message": "provider failed",
+                "code": 500,
+                "metadata": { "error_type": error_type }
+            }));
+            assert!(matches!(
+                error,
+                LLMError::ProviderResponseError(ref failure)
+                    if failure.kind() == ProviderErrorKind::UnknownTransient
+                        && failure.error_type() == Some(error_type)
+            ));
+            assert!(error.is_retryable(), "error_type={error_type}");
+        }
+    }
+
+    #[test]
+    fn typed_rate_limit_preserves_retry_hint() {
+        let error = parse_stream_error(serde_json::json!({
+            "message": "slow down",
+            "code": 429,
+            "retry_after": "3s",
+            "metadata": { "error_type": "rate_limit_exceeded" }
+        }));
+
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::RateLimited
+                    && failure.retry_after_secs() == Some(3)
+        ));
+    }
+
+    #[test]
+    fn successful_http_error_body_uses_openrouter_classifier() {
+        let provider = test_provider();
+        let response = Response::builder()
+            .status(200)
+            .body(
+                br#"{"id":"gen-1","error":{"code":504,"message":"timed out","metadata":{"error_type":"timeout"}}}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = provider
+            .parse_chat(response)
+            .err()
+            .expect("HTTP 200 error body should fail");
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.error_type() == Some("timeout")
+                    && failure.request_id() == Some("gen-1")
+        ));
+    }
+
+    #[test]
+    fn choice_level_http_error_uses_openrouter_classifier() {
+        let provider = test_provider();
+        let response = Response::builder()
+            .status(200)
+            .body(
+                br#"{"id":"gen-2","choices":[{"message":{"role":"assistant","content":"partial"},"finish_reason":"error","error":{"code":504,"message":"timed out","metadata":{"error_type":"timeout"}}}]}"#
+                    .to_vec(),
+            )
+            .unwrap();
+
+        let error = provider
+            .parse_chat(response)
+            .err()
+            .expect("choice-level error should fail");
+        assert!(matches!(
+            error,
+            LLMError::ProviderResponseError(ref failure)
+                if failure.kind() == ProviderErrorKind::UnknownTransient
+                    && failure.error_type() == Some("timeout")
+        ));
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Event forwarding now stops when its remote relay is no longer available, avoiding continued delivery attempts.
  - Forwarding tasks are automatically cancelled when their handles are dropped and cleaned up during reconnects.
  - OpenAI-compatible transient errors with numeric HTTP status codes, including 504, are now correctly treated as retryable.

- **Tests**
  - Added coverage for relay shutdown and retryable upstream idle timeout errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->