### PR TITLE
feat(agent): add session-scoped delegate model assignments

### DIFF
--- a/crates/agent/src/acp/shared.rs
+++ b/crates/agent/src/acp/shared.rs
@@ -207,6 +207,7 @@ pub const QMT_NOTIFICATION_MESH_PEER_EXPIRED: &str = "querymt/mesh/peerExpired";
 pub const QMT_NOTIFICATION_MODELS_CHANGED: &str = "querymt/models/changed";
 pub const QMT_NOTIFICATION_SCHEDULES_CHANGED: &str = "querymt/schedules/changed";
 pub const QMT_NOTIFICATION_DELEGATION_UPDATE: &str = "querymt/session/delegationUpdate";
+pub const QMT_NOTIFICATION_DELEGATE_MODELS_CHANGED: &str = "querymt/session/delegateModelsChanged";
 
 fn ext_notification(method: &str, params: serde_json::Value) -> serde_json::Value {
     serde_json::json!({
@@ -269,6 +270,23 @@ pub fn schedules_changed_notification(
     )
 }
 
+pub fn delegate_models_changed_notification(
+    session_id: &str,
+    revision: Option<u64>,
+) -> serde_json::Value {
+    ext_notification(
+        QMT_NOTIFICATION_DELEGATE_MODELS_CHANGED,
+        serde_json::to_value(
+            crate::control::delegate_models::DelegateModelsChangedNotification {
+                version: crate::control::delegate_models::DELEGATE_MODELS_VERSION,
+                session_id: session_id.to_owned(),
+                revision: revision.into(),
+            },
+        )
+        .expect("serialize delegate models changed notification"),
+    )
+}
+
 pub fn delegation_update_notification(
     payload: crate::control::delegation_notifications::DelegationUpdateNotification,
 ) -> serde_json::Value {
@@ -284,6 +302,11 @@ fn normalize_querymt_ext_method(method: &str) -> &str {
 
 fn querymt_session_id_from_request(method: &str, params: &serde_json::Value) -> Option<String> {
     match normalize_querymt_ext_method(method) {
+        "querymt/session/delegateModels" | "querymt/session/setDelegateModel" => params
+            .get("session_id")
+            .or_else(|| params.get("sessionId"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
         "querymt/remote/attachSession" => {
             serde_json::from_value::<AttachRemoteSessionRequest>(params.clone())
                 .ok()
@@ -418,6 +441,12 @@ impl AcpLiveEventTranslator {
     }
 
     pub fn translate_notification(&mut self, event: &EventEnvelope) -> Option<serde_json::Value> {
+        if let AgentEventKind::DelegateModelsChanged { revision } = event.kind() {
+            return Some(delegate_models_changed_notification(
+                event.session_id(),
+                *revision,
+            ));
+        }
         if let Some(update) = self.translate_delegation_update(event) {
             return Some(delegation_update_notification(update));
         }
@@ -1351,6 +1380,26 @@ mod tests {
     use tokio::sync::oneshot;
     use tokio::sync::{Mutex, Notify};
     use tokio::time::{Duration, timeout};
+
+    #[test]
+    fn delegate_assignment_ext_requests_register_session_ownership() {
+        for method in [
+            "querymt/session/delegateModels",
+            "_querymt/session/setDelegateModel",
+        ] {
+            assert_eq!(
+                querymt_session_id_from_request(
+                    method,
+                    &serde_json::json!({"sessionId": "parent"})
+                ),
+                Some("parent".into())
+            );
+        }
+        assert_eq!(
+            querymt_session_id_from_request("querymt/capabilities", &serde_json::json!({})),
+            None
+        );
+    }
 
     #[test]
     fn elicitation_request_rejects_unknown_property_types() {

--- a/crates/agent/src/acp/stdio.rs
+++ b/crates/agent/src/acp/stdio.rs
@@ -464,33 +464,57 @@ fn spawn_event_bridge_forwarder(
                             .flatten();
                         (delegation_update, session_update)
                     };
-                    let result = if let Some(update) = delegation_update {
-                        let params = serde_json::value::RawValue::from_string(
-                            serde_json::to_string(&update).unwrap_or_else(|_| "null".to_string()),
-                        )
-                        .map(Arc::from)
-                        .map_err(acp::Error::into_internal_error);
-                        match params {
-                            Ok(params) => {
-                                bridge
-                                    .notify_ext(crate::acp::protocol::ExtNotification::new(
-                                        QMT_NOTIFICATION_DELEGATION_UPDATE,
-                                        params,
-                                    ))
-                                    .await
-                            }
-                            Err(err) => Err(err),
+                    let result =
+                        if let crate::events::AgentEventKind::DelegateModelsChanged { revision } =
+                            event.kind()
+                        {
+                            let notification =
+                                crate::acp::shared::delegate_models_changed_notification(
+                                    event.session_id(),
+                                    *revision,
+                                );
+                            let params = serde_json::value::RawValue::from_string(
+                                notification["params"].to_string(),
+                            )
+                            .map(Arc::from)
+                            .map_err(acp::Error::into_internal_error);
+                            match params {
+                            Ok(params) => bridge
+                                .notify_ext(crate::acp::protocol::ExtNotification::new(
+                                    crate::acp::shared::QMT_NOTIFICATION_DELEGATE_MODELS_CHANGED,
+                                    params,
+                                ))
+                                .await,
+                            Err(error) => Err(error),
                         }
-                    } else if let Some(update) = session_update {
-                        bridge
-                            .notify(SessionNotification::new(
-                                SessionId::from(event.session_id().to_owned()),
-                                update,
-                            ))
-                            .await
-                    } else {
-                        continue;
-                    };
+                        } else if let Some(update) = delegation_update {
+                            let params = serde_json::value::RawValue::from_string(
+                                serde_json::to_string(&update)
+                                    .unwrap_or_else(|_| "null".to_string()),
+                            )
+                            .map(Arc::from)
+                            .map_err(acp::Error::into_internal_error);
+                            match params {
+                                Ok(params) => {
+                                    bridge
+                                        .notify_ext(crate::acp::protocol::ExtNotification::new(
+                                            QMT_NOTIFICATION_DELEGATION_UPDATE,
+                                            params,
+                                        ))
+                                        .await
+                                }
+                                Err(err) => Err(err),
+                            }
+                        } else if let Some(update) = session_update {
+                            bridge
+                                .notify(SessionNotification::new(
+                                    SessionId::from(event.session_id().to_owned()),
+                                    update,
+                                ))
+                                .await
+                        } else {
+                            continue;
+                        };
 
                     if let Err(e) = result {
                         log::info!(
@@ -919,6 +943,56 @@ mod stdio_tests {
                 Some("stored-message-id")
             );
         }
+    }
+
+    #[tokio::test]
+    async fn delegate_assignment_invalidation_uses_typed_stdio_bridge() {
+        let fixture = crate::test_utils::TestAgent::new().await;
+        let (bridge_tx, mut bridge_rx) = mpsc::channel(4);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let forwarder = spawn_event_bridge_forwarder(
+            fixture.config.event_sink.fanout().clone(),
+            ClientBridgeSender::new(bridge_tx),
+            fixture.handle.clone(),
+            Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            Arc::new(std::sync::Mutex::new(AcpLiveEventTranslator::new())),
+            shutdown_tx,
+        );
+        tokio::task::yield_now().await;
+        fixture
+            .config
+            .event_sink
+            .fanout()
+            .publish(crate::events::EventEnvelope::Durable(
+                crate::events::DurableEvent {
+                    event_id: "assignment-event".into(),
+                    stream_seq: 1,
+                    session_id: "parent".into(),
+                    timestamp: 0,
+                    origin: crate::events::EventOrigin::Local,
+                    source_node: None,
+                    kind: crate::events::AgentEventKind::DelegateModelsChanged {
+                        revision: Some(7),
+                    },
+                },
+            ));
+        let message = timeout(Duration::from_secs(2), bridge_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let ClientBridgeMessage::ExtNotification(notification) = message else {
+            panic!("expected extension notification");
+        };
+        assert_eq!(
+            notification.method.as_ref(),
+            crate::acp::shared::QMT_NOTIFICATION_DELEGATE_MODELS_CHANGED
+        );
+        let params: serde_json::Value = serde_json::from_str(notification.params.get()).unwrap();
+        assert_eq!(
+            params,
+            serde_json::json!({ "version": 1, "session_id": "parent", "revision": 7 })
+        );
+        forwarder.abort();
     }
 
     #[tokio::test]

--- a/crates/agent/src/agent/delegation_loop_tests.rs
+++ b/crates/agent/src/agent/delegation_loop_tests.rs
@@ -3,7 +3,7 @@ use crate::agent::core::ToolPolicy;
 use crate::agent::execution::CycleOutcome;
 use crate::agent::execution_context::ExecutionContext;
 use crate::delegation::{AgentInfo, DefaultAgentRegistry, DelegationOrchestrator};
-use crate::events::StopType;
+use crate::events::{AgentEventKind, StopType};
 use crate::middleware::{
     AgentStats, ConversationContext, DelegationGuardMiddleware, ExecutionState, LlmResponse,
     MiddlewareDriver,
@@ -896,16 +896,19 @@ async fn test_delegate_model_override_applies_before_prompt() {
         .await;
     harness
         .config
-        .delegate_model_overrides
-        .set(
-            harness.exec_ctx.session_id.clone(),
+        .provider
+        .history_store()
+        .set_delegate_assignment(
+            &harness.exec_ctx.session_id,
             "agent",
-            crate::delegation::DelegateModelOverride {
+            Some(crate::delegation::DelegateModelOverride {
                 model_id: "mock/override-model".into(),
                 node_id: None,
-            },
+            }),
+            Some(0),
         )
-        .await;
+        .await
+        .unwrap();
 
     let outcome = harness.run_single_delegation().await;
 
@@ -913,6 +916,28 @@ async fn test_delegate_model_override_applies_before_prompt() {
     let (child_model, child_params) = harness.child_llm_params().await;
     assert_eq!(child_model, "override-model");
     assert_eq!(child_params.reasoning_effort, Some(ReasoningEffort::High));
+    let events = harness
+        .config
+        .event_sink
+        .journal()
+        .load_session_stream(&harness.exec_ctx.session_id, None, None)
+        .await
+        .unwrap();
+    let fork = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            AgentEventKind::SessionForked {
+                selected_model_id,
+                selected_provider_node_id,
+                ..
+            } => Some((
+                selected_model_id.as_deref(),
+                selected_provider_node_id.as_deref(),
+            )),
+            _ => None,
+        })
+        .expect("delegation fork event");
+    assert_eq!(fork, (Some("mock/override-model"), None));
 }
 
 #[tokio::test]

--- a/crates/agent/src/agent/delegation_loop_tests.rs
+++ b/crates/agent/src/agent/delegation_loop_tests.rs
@@ -884,6 +884,70 @@ async fn test_delegate_inherits_parent_auto_reasoning_effort() {
 }
 
 #[tokio::test]
+async fn test_delegate_reasoning_override_wins_over_parent() {
+    let mut harness = TestHarness::new_with_delegate_reasoning(
+        vec![],
+        DelegateBehavior::AlwaysOk,
+        Some(ReasoningEffort::Low),
+    )
+    .await;
+    harness
+        .set_parent_reasoning_effort(Some(ReasoningEffort::High))
+        .await;
+    harness
+        .config
+        .provider
+        .history_store()
+        .set_delegate_assignment_with_reasoning(
+            &harness.exec_ctx.session_id,
+            "agent",
+            None,
+            Some(Some(crate::delegation::DelegateReasoningEffort::Medium)),
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let outcome = harness.run_single_delegation().await;
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    let (_, child_params) = harness.child_llm_params().await;
+    assert_eq!(child_params.reasoning_effort, Some(ReasoningEffort::Medium));
+}
+
+#[tokio::test]
+async fn test_delegate_explicit_auto_reasoning_overrides_parent() {
+    let mut harness = TestHarness::new_with_delegate_reasoning(
+        vec![],
+        DelegateBehavior::AlwaysOk,
+        Some(ReasoningEffort::Low),
+    )
+    .await;
+    harness
+        .set_parent_reasoning_effort(Some(ReasoningEffort::High))
+        .await;
+    harness
+        .config
+        .provider
+        .history_store()
+        .set_delegate_assignment_with_reasoning(
+            &harness.exec_ctx.session_id,
+            "agent",
+            None,
+            Some(Some(crate::delegation::DelegateReasoningEffort::Auto)),
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let outcome = harness.run_single_delegation().await;
+
+    assert_eq!(outcome, CycleOutcome::Completed);
+    let (_, child_params) = harness.child_llm_params().await;
+    assert_eq!(child_params.reasoning_effort, None);
+}
+
+#[tokio::test]
 async fn test_delegate_model_override_applies_before_prompt() {
     let mut harness = TestHarness::new_with_delegate_reasoning(
         vec![],

--- a/crates/agent/src/agent/handle/ext.rs
+++ b/crates/agent/src/agent/handle/ext.rs
@@ -12,6 +12,7 @@ impl LocalAgentHandle {
             "querymt/profile/agents" => self.handle_ext_profile_agents(req).await,
             "querymt/profile/setActive" => self.handle_ext_set_active_profile(req).await,
             "querymt/session/setDelegateModel" => self.handle_ext_set_delegate_model(req).await,
+            "querymt/session/delegateModels" => self.handle_ext_delegate_models(req).await,
             "querymt/refreshModels" => self.handle_ext_refresh_models().await,
             "querymt/modelInfo" => self.handle_ext_model_info(req).await,
             "querymt/chat" | "querymt/tokenCount" => Err(Error::from(

--- a/crates/agent/src/agent/handle/ext_profiles.rs
+++ b/crates/agent/src/agent/handle/ext_profiles.rs
@@ -159,18 +159,32 @@ impl LocalAgentHandle {
             Vec::new()
         };
         agents.sort_by(|left, right| left.id.cmp(&right.id));
+        let legacy_routes = if state.is_none() {
+            Some(
+                handle
+                    .config
+                    .delegate_model_overrides
+                    .list_parent_routes(session_id)
+                    .await,
+            )
+        } else {
+            None
+        };
         let mut assignments = Vec::with_capacity(agents.len());
         for agent in agents {
-            let model = match &state {
-                Some(state) => state.overrides.get(&agent.id).cloned(),
-                None => {
-                    handle
-                        .config
-                        .delegate_model_overrides
-                        .get(session_id, &agent.id)
-                        .await
-                }
+            let route = match &state {
+                Some(state) => crate::delegation::DelegateRouteOverrides {
+                    model: state.overrides.get(&agent.id).cloned(),
+                    reasoning_effort: state.reasoning_overrides.get(&agent.id).copied(),
+                },
+                None => legacy_routes
+                    .as_ref()
+                    .and_then(|routes| routes.get(&agent.id))
+                    .cloned()
+                    .unwrap_or_default(),
             };
+            let model = route.model;
+            let reasoning_effort = route.reasoning_effort;
             assignments.push(DelegateAssignmentInfo {
                 agent_id: agent.id.clone(),
                 name: agent.name,
@@ -183,31 +197,42 @@ impl LocalAgentHandle {
                 model: model.into(),
                 configured_default_model_id: Self::configured_delegate_model_id(&handle, &agent.id)
                     .into(),
+                reasoning_effort: reasoning_effort.into(),
             });
         }
         // Keep orphan overrides visible after a profile edit; never silently turn them into inheritance.
-        let orphaned_overrides = match &state {
+        let routes = match &state {
             Some(state) => state
                 .overrides
-                .iter()
-                .filter(|(id, _)| handle.agent_registry().get_agent(id).is_none())
-                .map(|(id, model)| OrphanedDelegateAssignment {
-                    agent_id: id.clone(),
-                    model: model.clone(),
+                .keys()
+                .chain(state.reasoning_overrides.keys())
+                .cloned()
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .map(|agent_id| {
+                    (
+                        agent_id.clone(),
+                        crate::delegation::DelegateRouteOverrides {
+                            model: state.overrides.get(&agent_id).cloned(),
+                            reasoning_effort: state.reasoning_overrides.get(&agent_id).copied(),
+                        },
+                    )
                 })
                 .collect(),
-            None => handle
-                .config
-                .delegate_model_overrides
-                .list_parent(session_id)
-                .await
-                .into_iter()
-                .filter(|(id, _)| handle.agent_registry().get_agent(id).is_none())
-                .map(|(agent_id, model)| OrphanedDelegateAssignment { agent_id, model })
-                .collect(),
+            None => legacy_routes.unwrap_or_default(),
         };
+        let orphaned_overrides = routes
+            .into_iter()
+            .filter(|(agent_id, _)| handle.agent_registry().get_agent(agent_id).is_none())
+            .map(|(agent_id, route)| OrphanedDelegateAssignment {
+                model: route.model.into(),
+                reasoning_effort: route.reasoning_effort.into(),
+                agent_id,
+            })
+            .collect();
         ext_json_response(&DelegateAssignmentsInfo {
             version: DELEGATE_MODELS_VERSION,
+            reasoning_effort_supported: true,
             session_id: session_id.to_owned(),
             profile_id: binding.profile_id,
             revision: state.as_ref().map(|state| state.revision).into(),
@@ -296,20 +321,33 @@ impl LocalAgentHandle {
                 "This storage backend does not support revision-checked delegate assignments",
             ));
         }
+        let orphan_route = match &before {
+            Some(state) => crate::delegation::DelegateRouteOverrides {
+                model: state.overrides.get(agent_id).cloned(),
+                reasoning_effort: state.reasoning_overrides.get(agent_id).copied(),
+            },
+            None => {
+                profile_handle
+                    .config
+                    .delegate_model_overrides
+                    .get_route(session_id, agent_id)
+                    .await
+            }
+        };
+        let stored_orphan = orphan_route.model.is_some() || orphan_route.reasoning_effort.is_some();
+        let clears_orphan = parsed.model_id.0.is_none()
+            && match &parsed.reasoning_effort {
+                crate::control::delegate_models::OptionalNullable::Missing => {
+                    orphan_route.reasoning_effort.is_none()
+                }
+                crate::control::delegate_models::OptionalNullable::Null => true,
+                crate::control::delegate_models::OptionalNullable::Value(_) => false,
+            };
         if profile_handle
             .agent_registry()
             .get_agent(agent_id)
             .is_none()
-            && !(parsed.model_id.0.is_none()
-                && match &before {
-                    Some(state) => state.overrides.contains_key(agent_id),
-                    None => profile_handle
-                        .config
-                        .delegate_model_overrides
-                        .get(session_id, agent_id)
-                        .await
-                        .is_some(),
-                })
+            && !(stored_orphan && clears_orphan)
         {
             return Err(Error::invalid_params().data(serde_json::json!({
                 "message": "unknown delegate agent",
@@ -383,10 +421,11 @@ impl LocalAgentHandle {
         let persisted = if before.is_some() {
             Some(
                 store
-                    .set_delegate_assignment(
+                    .set_delegate_assignment_with_reasoning(
                         session_id,
                         agent_id,
                         model.clone(),
+                        parsed.reasoning_effort.as_update(),
                         parsed.expected_revision,
                     )
                     .await
@@ -413,14 +452,27 @@ impl LocalAgentHandle {
             None
         };
         // The legacy cache is only used by storage backends without durable support.
-        let legacy_changed = if persisted.is_none() {
-            profile_handle
-                .config
-                .delegate_model_overrides
-                .update(session_id, agent_id, model.clone())
-                .await
+        let legacy_write = if persisted.is_none() {
+            Some(
+                profile_handle
+                    .config
+                    .delegate_model_overrides
+                    .update_route(
+                        session_id,
+                        agent_id,
+                        model.clone(),
+                        parsed.reasoning_effort.as_update(),
+                    )
+                    .await,
+            )
         } else {
-            false
+            None
+        };
+        let legacy_changed = legacy_write.as_ref().is_some_and(|(changed, _)| *changed);
+        let reasoning_effort = match (&persisted, &legacy_write) {
+            (Some(write), _) => write.assignments.reasoning_overrides.get(agent_id).copied(),
+            (None, Some((_, route))) => route.reasoning_effort,
+            (None, None) => None,
         };
         let revision = persisted.as_ref().map(|write| write.assignments.revision);
         if legacy_changed || persisted.as_ref().is_some_and(|write| write.changed) {
@@ -431,9 +483,11 @@ impl LocalAgentHandle {
         }
         ext_json_response(&SetDelegateModelResponse {
             version: DELEGATE_MODELS_VERSION,
+            reasoning_effort_supported: true,
             session_id: session_id.to_owned(),
             agent_id: agent_id.to_owned(),
             model: model.into(),
+            reasoning_effort: reasoning_effort.into(),
             revision: revision.into(),
             durable: persisted.is_some(),
         })

--- a/crates/agent/src/agent/handle/ext_profiles.rs
+++ b/crates/agent/src/agent/handle/ext_profiles.rs
@@ -101,6 +101,7 @@ impl LocalAgentHandle {
                 "name": agent.name,
                 "description": agent.description,
                 "capabilities": agent.capabilities,
+                "configured_default_model_id": Self::configured_delegate_model_id(&runtime.agent().handle(), &agent.id),
             })
         }));
 
@@ -110,21 +111,132 @@ impl LocalAgentHandle {
         }))
     }
 
+    /// Read current assignments without loading a session actor or applying client preferences.
+    pub(super) async fn handle_ext_delegate_models(
+        &self,
+        req: ExtRequest,
+    ) -> Result<ExtResponse, Error> {
+        use crate::control::delegate_models::{
+            DELEGATE_MODELS_VERSION, DelegateAssignmentInfo, DelegateAssignmentSource,
+            DelegateAssignmentsInfo, DelegateModelsRequest, OrphanedDelegateAssignment,
+        };
+
+        let parsed: DelegateModelsRequest = serde_json::from_str(req.params.get())
+            .map_err(|error| Error::invalid_params().data(error.to_string()))?;
+        let session_id = parsed.session_id.trim();
+        if session_id.is_empty() {
+            return Err(Error::invalid_params().data("session_id must be nonempty"));
+        }
+        let profiles = self.profiles().ok_or_else(Error::invalid_params)?;
+        let binding = profiles.session_binding(session_id).await.ok_or_else(|| {
+            Error::invalid_params().data("session is not bound to an available profile")
+        })?;
+        let runtime = profiles
+            .runtime_for_profile(&binding.profile_id)
+            .await
+            .map_err(|error| {
+                Error::internal_error().data(format_prefixed_error_chain(
+                    "Failed to load bound profile",
+                    &error,
+                ))
+            })?;
+        let handle = runtime.agent().handle();
+        let store = handle.config.provider.history_store();
+        let session = store
+            .get_session(session_id)
+            .await
+            .map_err(Error::into_internal_error)?
+            .ok_or_else(|| Error::invalid_params().data("unknown session"))?;
+        let state = store
+            .get_delegate_assignments(session_id)
+            .await
+            .map_err(Error::into_internal_error)?;
+        let editable = binding.agent_id.is_none()
+            && session.fork_origin != Some(crate::session::domain::ForkOrigin::Delegation);
+        let mut agents = if editable {
+            handle.agent_registry().list_agents()
+        } else {
+            Vec::new()
+        };
+        agents.sort_by(|left, right| left.id.cmp(&right.id));
+        let mut assignments = Vec::with_capacity(agents.len());
+        for agent in agents {
+            let model = match &state {
+                Some(state) => state.overrides.get(&agent.id).cloned(),
+                None => {
+                    handle
+                        .config
+                        .delegate_model_overrides
+                        .get(session_id, &agent.id)
+                        .await
+                }
+            };
+            assignments.push(DelegateAssignmentInfo {
+                agent_id: agent.id.clone(),
+                name: agent.name,
+                description: agent.description,
+                source: if model.is_some() {
+                    DelegateAssignmentSource::Override
+                } else {
+                    DelegateAssignmentSource::ProfileDefault
+                },
+                model: model.into(),
+                configured_default_model_id: Self::configured_delegate_model_id(&handle, &agent.id)
+                    .into(),
+            });
+        }
+        // Keep orphan overrides visible after a profile edit; never silently turn them into inheritance.
+        let orphaned_overrides = match &state {
+            Some(state) => state
+                .overrides
+                .iter()
+                .filter(|(id, _)| handle.agent_registry().get_agent(id).is_none())
+                .map(|(id, model)| OrphanedDelegateAssignment {
+                    agent_id: id.clone(),
+                    model: model.clone(),
+                })
+                .collect(),
+            None => handle
+                .config
+                .delegate_model_overrides
+                .list_parent(session_id)
+                .await
+                .into_iter()
+                .filter(|(id, _)| handle.agent_registry().get_agent(id).is_none())
+                .map(|(agent_id, model)| OrphanedDelegateAssignment { agent_id, model })
+                .collect(),
+        };
+        ext_json_response(&DelegateAssignmentsInfo {
+            version: DELEGATE_MODELS_VERSION,
+            session_id: session_id.to_owned(),
+            profile_id: binding.profile_id,
+            revision: state.as_ref().map(|state| state.revision).into(),
+            durable: state.is_some(),
+            editable,
+            assignments,
+            orphaned_overrides,
+        })
+    }
+
+    // This is profile configuration, not a resolved Mesh route or historical execution identity.
+    fn configured_delegate_model_id(handle: &LocalAgentHandle, agent_id: &str) -> Option<String> {
+        let target = handle.agent_registry().get_handle(agent_id)?;
+        let local = target.as_any().downcast_ref::<LocalAgentHandle>()?;
+        let config = local.config.provider.initial_config();
+        Some(format!(
+            "{}/{}",
+            config.provider.as_deref()?,
+            config.model.as_deref()?
+        ))
+    }
+
     pub(super) async fn handle_ext_set_delegate_model(
         &self,
         req: ExtRequest,
     ) -> Result<ExtResponse, Error> {
-        #[derive(serde::Deserialize)]
-        struct SetDelegateModelRequest {
-            #[serde(alias = "sessionId")]
-            session_id: String,
-            #[serde(alias = "agentId")]
-            agent_id: String,
-            #[serde(default, alias = "modelId")]
-            model_id: Option<String>,
-            #[serde(default, alias = "nodeId")]
-            node_id: Option<String>,
-        }
+        use crate::control::delegate_models::{
+            DELEGATE_MODELS_VERSION, SetDelegateModelRequest, SetDelegateModelResponse,
+        };
 
         let parsed: SetDelegateModelRequest =
             serde_json::from_str(req.params.get()).map_err(|e| {
@@ -162,23 +274,42 @@ impl LocalAgentHandle {
                 }))
             })?;
         let profile_handle = runtime.agent().handle();
-        if profile_handle
-            .registry
-            .lock()
+        let store = profile_handle.config.provider.history_store();
+        let session = store
+            .get_session(session_id)
             .await
-            .get(session_id)
-            .is_none()
+            .map_err(Error::into_internal_error)?
+            .ok_or_else(|| Error::invalid_params().data("unknown session for bound profile"))?;
+        if binding.agent_id.is_some()
+            || session.fork_origin == Some(crate::session::domain::ForkOrigin::Delegation)
         {
-            return Err(Error::invalid_params().data(serde_json::json!({
-                "message": "unknown session for bound profile",
-                "sessionId": session_id,
-                "profileId": binding.profile_id,
-            })));
+            return Err(
+                Error::invalid_params().data("Configure delegate models on their parent session")
+            );
+        }
+        let before = store
+            .get_delegate_assignments(session_id)
+            .await
+            .map_err(Error::into_internal_error)?;
+        if before.is_none() && parsed.expected_revision.is_some() {
+            return Err(Error::invalid_params().data(
+                "This storage backend does not support revision-checked delegate assignments",
+            ));
         }
         if profile_handle
             .agent_registry()
             .get_agent(agent_id)
             .is_none()
+            && !(parsed.model_id.is_none()
+                && match &before {
+                    Some(state) => state.overrides.contains_key(agent_id),
+                    None => profile_handle
+                        .config
+                        .delegate_model_overrides
+                        .get(session_id, agent_id)
+                        .await
+                        .is_some(),
+                })
         {
             return Err(Error::invalid_params().data(serde_json::json!({
                 "message": "unknown delegate agent",
@@ -196,12 +327,12 @@ impl LocalAgentHandle {
                         "message": "model_id must be null or a non-empty string",
                     })));
                 }
-                let node_id = parsed
-                    .node_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(str::to_string);
+                let node_id = parsed.node_id.as_deref().map(str::trim).map(str::to_string);
+                if node_id.as_ref().is_some_and(String::is_empty) {
+                    return Err(
+                        Error::invalid_params().data("node_id must be null or a non-empty string")
+                    );
+                }
                 #[cfg(not(feature = "remote"))]
                 if node_id.is_some() {
                     return Err(Error::invalid_params().data(serde_json::json!({
@@ -222,22 +353,8 @@ impl LocalAgentHandle {
                 let model_exists = models
                     .iter()
                     .any(|entry| entry.id == model_id && entry.node_id == node_id);
-                let current_delegate_model = profile_handle
-                    .agent_registry()
-                    .get_handle(agent_id)
-                    .and_then(|handle| {
-                        handle
-                            .as_any()
-                            .downcast_ref::<LocalAgentHandle>()
-                            .and_then(|handle| {
-                                let config = handle.config.provider.initial_config();
-                                Some(format!(
-                                    "{}/{}",
-                                    config.provider.as_deref()?,
-                                    config.model.as_deref()?
-                                ))
-                            })
-                    });
+                let current_delegate_model =
+                    Self::configured_delegate_model_id(&profile_handle, agent_id);
                 if !model_exists
                     && (node_id.is_some() || current_delegate_model.as_deref() != Some(model_id))
                 {
@@ -263,25 +380,59 @@ impl LocalAgentHandle {
             }
         };
 
-        if let Some(model) = model.clone() {
-            profile_handle
-                .config
-                .delegate_model_overrides
-                .set(session_id, agent_id, model)
-                .await;
+        let persisted = if before.is_some() {
+            Some(
+                store
+                    .set_delegate_assignment(
+                        session_id,
+                        agent_id,
+                        model.clone(),
+                        parsed.expected_revision,
+                    )
+                    .await
+                    .map_err(|error| {
+                        match error {
+                        crate::session::error::SessionError::DelegateAssignmentRevisionConflict {
+                            expected,
+                            found,
+                        } => Error::invalid_params().data(serde_json::json!({
+                            "code": "delegate_assignment_conflict",
+                            "expected_revision": expected,
+                            "actual_revision": found,
+                            "message": "Delegate assignments changed; refresh before retrying",
+                        })),
+                        other => Error::into_internal_error(other),
+                    }
+                    })?,
+            )
         } else {
+            None
+        };
+        // The legacy cache is only used by storage backends without durable support.
+        let legacy_changed = if persisted.is_none() {
             profile_handle
                 .config
                 .delegate_model_overrides
-                .clear(session_id, agent_id)
-                .await;
+                .update(session_id, agent_id, model.clone())
+                .await
+        } else {
+            false
+        };
+        let revision = persisted.as_ref().map(|write| write.revision);
+        if legacy_changed || persisted.as_ref().is_some_and(|write| write.changed) {
+            profile_handle.emit_event(
+                session_id,
+                AgentEventKind::DelegateModelsChanged { revision },
+            );
         }
-
-        ext_json_response(&serde_json::json!({
-            "session_id": session_id,
-            "agent_id": agent_id,
-            "model": model,
-        }))
+        ext_json_response(&SetDelegateModelResponse {
+            version: DELEGATE_MODELS_VERSION,
+            session_id: session_id.to_owned(),
+            agent_id: agent_id.to_owned(),
+            model: model.into(),
+            revision: revision.into(),
+            durable: persisted.is_some(),
+        })
     }
 
     async fn profiles_response(&self) -> Result<serde_json::Value, Error> {

--- a/crates/agent/src/agent/handle/ext_profiles.rs
+++ b/crates/agent/src/agent/handle/ext_profiles.rs
@@ -300,7 +300,7 @@ impl LocalAgentHandle {
             .agent_registry()
             .get_agent(agent_id)
             .is_none()
-            && !(parsed.model_id.is_none()
+            && !(parsed.model_id.0.is_none()
                 && match &before {
                     Some(state) => state.overrides.contains_key(agent_id),
                     None => profile_handle
@@ -319,7 +319,7 @@ impl LocalAgentHandle {
             })));
         }
 
-        let model = match parsed.model_id {
+        let model = match parsed.model_id.0 {
             Some(model_id) => {
                 let model_id = model_id.trim();
                 if model_id.is_empty() {
@@ -395,7 +395,11 @@ impl LocalAgentHandle {
                         crate::session::error::SessionError::DelegateAssignmentRevisionConflict {
                             expected,
                             found,
-                        } => Error::invalid_params().data(serde_json::json!({
+                        } => Error::new(
+                            crate::control::delegate_models::DELEGATE_ASSIGNMENT_CONFLICT_ACP_CODE,
+                            "Delegate assignments changed; refresh before retrying",
+                        )
+                        .data(serde_json::json!({
                             "code": "delegate_assignment_conflict",
                             "expected_revision": expected,
                             "actual_revision": found,
@@ -418,7 +422,7 @@ impl LocalAgentHandle {
         } else {
             false
         };
-        let revision = persisted.as_ref().map(|write| write.revision);
+        let revision = persisted.as_ref().map(|write| write.assignments.revision);
         if legacy_changed || persisted.as_ref().is_some_and(|write| write.changed) {
             profile_handle.emit_event(
                 session_id,

--- a/crates/agent/src/agent/handle/tests/capabilities.rs
+++ b/crates/agent/src/agent/handle/tests/capabilities.rs
@@ -79,12 +79,21 @@ async fn test_querymt_capabilities_lists_control_surface() {
     assert_eq!(result["transport"]["mesh_transport"], "none");
     assert_eq!(result["features"]["mesh_invites"], false);
     assert_eq!(result["features"]["profiles"], false);
+    let methods = result["methods"].as_array().expect("methods array");
+    for unavailable in [
+        "querymt/profiles",
+        "querymt/session/setDelegateModel",
+        "querymt/session/delegateModels",
+    ] {
+        assert!(
+            !methods.iter().any(|method| method == unavailable),
+            "unexpected profile capability method {unavailable}"
+        );
+    }
     assert!(
-        !result["methods"]
-            .as_array()
-            .expect("methods array")
+        !notifications
             .iter()
-            .any(|method| method == "querymt/profiles")
+            .any(|method| method == "querymt/session/delegateModelsChanged")
     );
 }
 
@@ -96,11 +105,25 @@ async fn test_querymt_capabilities_advertises_profile_methods_when_configured() 
     let methods = result["methods"].as_array().expect("methods array");
 
     assert_eq!(result["features"]["profiles"], true);
+    let notifications = result["notifications"]
+        .as_array()
+        .expect("notifications array");
+    assert!(
+        notifications
+            .iter()
+            .any(|method| method == "querymt/session/delegateModelsChanged")
+    );
+    assert!(
+        !methods
+            .iter()
+            .any(|method| method == "querymt/session/delegateModelsChanged")
+    );
     for expected in [
         "querymt/profiles",
         "querymt/profile/agents",
         "querymt/profile/setActive",
         "querymt/session/setDelegateModel",
+        "querymt/session/delegateModels",
     ] {
         assert!(
             methods.iter().any(|method| method == expected),

--- a/crates/agent/src/agent/handle/tests/capabilities.rs
+++ b/crates/agent/src/agent/handle/tests/capabilities.rs
@@ -1,18 +1,5 @@
 use super::*;
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
 #[tokio::test]
 async fn test_querymt_capabilities_lists_control_surface() {
     let f = HandleFixture::new().await;

--- a/crates/agent/src/agent/handle/tests/core_b.rs
+++ b/crates/agent/src/agent/handle/tests/core_b.rs
@@ -196,11 +196,22 @@ async fn test_querymt_profile_agents_rejects_unknown_profile() {
     assert_eq!(err.code, agent_client_protocol::ErrorCode::InvalidParams);
 }
 
-#[tokio::test]
-async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
-    let (f, _profile_dir) =
-        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
-    register_bound_test_session(&f, "parent-1", "quorum").await;
+async fn ext_method_json(
+    handle: &LocalAgentHandle,
+    method: &str,
+    params: serde_json::Value,
+) -> serde_json::Value {
+    let response = handle
+        .ext_method(crate::acp::protocol::ExtRequest::new(
+            method,
+            raw_params(&params.to_string()),
+        ))
+        .await
+        .unwrap();
+    serde_json::from_str(response.0.get()).unwrap()
+}
+
+async fn persisted_delegate_parent(f: &HandleFixture) -> String {
     let runtime = f
         .handle
         .profiles()
@@ -208,51 +219,584 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
         .runtime_for_profile("quorum")
         .await
         .unwrap();
-    let profile_handle = runtime.agent().handle();
+    let session = runtime
+        .agent()
+        .handle()
+        .config
+        .provider
+        .history_store()
+        .create_session(None, None, None, None)
+        .await
+        .unwrap();
+    bind_test_profile(f, &session.public_id, "quorum").await;
+    session.public_id
+}
 
-    let req = crate::acp::protocol::ExtRequest::new(
-        "querymt/session/setDelegateModel",
-        raw_params(
-            r#"{"session_id":"parent-1","agent_id":"coder","model_id":"test/test-model","node_id":null}"#,
-        ),
-    );
-    let resp = f.handle.ext_method(req).await.expect("set delegate model");
-    let value: serde_json::Value = serde_json::from_str(resp.0.get()).expect("valid JSON");
-
-    assert_eq!(value["model"]["model_id"], "test/test-model");
-    assert_eq!(
-        profile_handle
+#[tokio::test]
+async fn delegate_profile_fixture_shares_storage_without_leaking_across_fixtures() {
+    let files = [
+        ("quorum.toml", QUORUM_PROFILE_TOML),
+        ("alpha.toml", ALPHA_PROFILE_TOML),
+    ];
+    let (first, _first_dir) = profile_fixture_with_files(&files).await;
+    let (second, _second_dir) = profile_fixture_with_files(&files).await;
+    let session = persisted_delegate_parent(&first).await;
+    let profiles = first.handle.profiles().unwrap();
+    let alpha = profiles.runtime_for_profile("alpha").await.unwrap();
+    let quorum = profiles.runtime_for_profile("quorum").await.unwrap();
+    assert!(Arc::ptr_eq(
+        &alpha.agent().storage_backend(),
+        &quorum.agent().storage_backend()
+    ));
+    assert!(
+        alpha
+            .agent()
+            .handle()
             .config
-            .delegate_model_overrides
-            .get("parent-1", "coder")
+            .provider
+            .history_store()
+            .get_session(&session)
             .await
             .unwrap()
-            .model_id,
-        "test/test-model"
+            .is_some()
     );
-
-    let clear_req = crate::acp::protocol::ExtRequest::new(
-        "querymt/session/setDelegateModel",
-        raw_params(
-            r#"{"session_id":"parent-1","agent_id":"coder","model_id":null,"node_id":null}"#,
-        ),
-    );
-    let clear_resp = f
+    let other = second
         .handle
-        .ext_method(clear_req)
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
         .await
-        .expect("clear delegate model");
-    let clear_value: serde_json::Value =
-        serde_json::from_str(clear_resp.0.get()).expect("valid JSON");
-
-    assert!(clear_value["model"].is_null());
+        .unwrap();
     assert!(
-        profile_handle
+        other
+            .agent()
+            .handle()
+            .config
+            .provider
+            .history_store()
+            .get_session(&session)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn delegate_assignments_custom_storage_uses_legacy_memory_without_false_notifications() {
+    let profile_dir = tempfile::tempdir().unwrap();
+    write_profile(profile_dir.path(), "quorum.toml", QUORUM_PROFILE_TOML);
+    let session = mock_session("legacy-parent");
+    let mut store = MockSessionStore::new();
+    store
+        .expect_get_session()
+        .returning(move |session_id| Ok((session_id == "legacy-parent").then(|| session.clone())))
+        .times(0..);
+    store
+        .expect_set_session_runtime_binding()
+        .returning(|_, _, _, _, _, _| Ok(()))
+        .times(1);
+    let event_storage = Arc::new(
+        crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into())
+            .await
+            .unwrap(),
+    );
+    let backend = Arc::new(TestStorageBackend {
+        session_store: Arc::new(store),
+        event_storage,
+    });
+    let f = HandleFixture::new()
+        .await
+        .with_profile_storage("quorum", profile_dir.path(), backend)
+        .await;
+    bind_test_profile(&f, "legacy-parent", "quorum").await;
+    let runtime = f
+        .handle
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
+        .await
+        .unwrap();
+    let handle = runtime.agent().handle();
+    let mut events = handle.subscribe_events();
+
+    let before = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": "legacy-parent"}),
+    )
+    .await;
+    assert_eq!(before["version"], 1);
+    assert_eq!(before["durable"], false);
+    assert!(before["revision"].is_null());
+
+    let set = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": "legacy-parent",
+            "agent_id": "coder",
+            "model_id": "test/test-model"
+        }),
+    )
+    .await;
+    assert_eq!(set["version"], 1);
+    assert_eq!(set["durable"], false);
+    assert!(set["revision"].is_null());
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if matches!(
+                events.recv().await.unwrap().kind(),
+                AgentEventKind::DelegateModelsChanged { revision: None }
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    let current = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": "legacy-parent"}),
+    )
+    .await;
+    assert_eq!(current["assignments"][0]["source"], "override");
+    let noop = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": "legacy-parent",
+            "agent_id": "coder",
+            "model_id": "test/test-model"
+        }),
+    )
+    .await;
+    assert!(noop["revision"].is_null());
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), events.recv())
+            .await
+            .is_err(),
+        "legacy no-op must not emit an invalidation"
+    );
+
+    let error = f
+        .handle
+        .ext_method(crate::acp::protocol::ExtRequest::new(
+            "querymt/session/setDelegateModel",
+            raw_params(
+                &serde_json::json!({
+                    "session_id": "legacy-parent",
+                    "agent_id": "coder",
+                    "model_id": null,
+                    "expected_revision": 0
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
+
+    handle
+        .config
+        .delegate_model_overrides
+        .set(
+            "legacy-parent",
+            "removed-role",
+            crate::delegation::DelegateModelOverride {
+                model_id: "test/test-model".into(),
+                node_id: None,
+            },
+        )
+        .await;
+    let orphaned = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": "legacy-parent"}),
+    )
+    .await;
+    assert_eq!(
+        orphaned["orphaned_overrides"][0]["agent_id"],
+        "removed-role"
+    );
+    ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": "legacy-parent",
+            "agent_id": "removed-role",
+            "model_id": null
+        }),
+    )
+    .await;
+    assert!(
+        handle
             .config
             .delegate_model_overrides
-            .get("parent-1", "coder")
+            .get("legacy-parent", "removed-role")
             .await
             .is_none()
+    );
+}
+
+#[tokio::test]
+async fn delegate_assignments_restore_after_full_profile_restart_from_temporary_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let profile_dir = dir.path().join("profiles");
+    std::fs::create_dir(&profile_dir).unwrap();
+    write_profile(&profile_dir, "quorum.toml", QUORUM_PROFILE_TOML);
+    let db = dir.path().join("sessions.db");
+    let storage = Arc::new(
+        crate::session::sqlite_storage::SqliteStorage::connect(db.clone())
+            .await
+            .unwrap(),
+    );
+    let first = HandleFixture::new()
+        .await
+        .with_profile_storage("quorum", &profile_dir, storage.clone())
+        .await;
+    let parent = persisted_delegate_parent(&first).await;
+    let sibling = persisted_delegate_parent(&first).await;
+    ext_method_json(&first.handle, "querymt/session/setDelegateModel", serde_json::json!({
+        "session_id": parent, "agent_id": "coder", "model_id": "test/test-model", "expected_revision": 0
+    })).await;
+    // Persistence includes the profile binding, not just the model JSON.
+    assert_eq!(
+        storage
+            .get_session_runtime_binding(&parent)
+            .await
+            .unwrap()
+            .unwrap()
+            .profile_id,
+        "quorum"
+    );
+    first.handle.profiles().unwrap().shutdown().await;
+    drop(first);
+    drop(storage);
+    let reopened = Arc::new(
+        crate::session::sqlite_storage::SqliteStorage::connect(db)
+            .await
+            .unwrap(),
+    );
+    let second = HandleFixture::new()
+        .await
+        .with_profile_storage("quorum", &profile_dir, reopened)
+        .await;
+    let snapshot = ext_method_json(
+        &second.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": parent}),
+    )
+    .await;
+    assert_eq!(snapshot["revision"], 1);
+    assert_eq!(
+        snapshot["assignments"][0]["model"]["model_id"],
+        "test/test-model"
+    );
+    let other = ext_method_json(
+        &second.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": sibling}),
+    )
+    .await;
+    assert_eq!(other["revision"], 0);
+    assert!(other["assignments"][0]["model"].is_null());
+    let response = ext_method_json(
+        &second.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": parent, "agent_id": "coder", "model_id": null, "expected_revision": 1
+        }),
+    )
+    .await;
+    assert_eq!(response["revision"], 2);
+    second.handle.profiles().unwrap().shutdown().await;
+}
+
+#[tokio::test]
+async fn delegate_assignment_user_fork_can_own_independent_routing() {
+    let (f, _dir) = profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let parent = persisted_delegate_parent(&f).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
+        .await
+        .unwrap();
+    let store = runtime.agent().handle().config.provider.history_store();
+    let fork = store
+        .create_session(
+            None,
+            None,
+            Some(parent.clone()),
+            Some(crate::session::domain::ForkOrigin::User),
+        )
+        .await
+        .unwrap();
+    bind_test_profile(&f, &fork.public_id, "quorum").await;
+    let result = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": fork.public_id}),
+    )
+    .await;
+    assert_eq!(result["editable"], true);
+    ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
+        "session_id": fork.public_id, "agent_id": "reviewer", "model_id": "test/test-model", "expected_revision": 0
+    })).await;
+    assert!(
+        store
+            .get_delegate_assignments(&parent)
+            .await
+            .unwrap()
+            .unwrap()
+            .overrides
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn delegate_assignment_readback_survives_reconnect_and_preserves_unavailable_models() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let session_id = persisted_delegate_parent(&f).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
+        .await
+        .unwrap();
+    let handle = runtime.agent().handle();
+    let model = crate::delegation::DelegateModelOverride {
+        model_id: "provider/removed-model".into(),
+        node_id: Some("offline-node".into()),
+    };
+    handle
+        .config
+        .provider
+        .history_store()
+        .set_delegate_assignment(&session_id, "coder", Some(model.clone()), None)
+        .await
+        .unwrap();
+    handle
+        .config
+        .provider
+        .history_store()
+        .set_delegate_assignment(&session_id, "removed-role", Some(model), None)
+        .await
+        .unwrap();
+    // A fresh handle has no loaded session actors or assignment cache.
+    let reconnected = LocalAgentHandle::from_config(f.handle.config.clone());
+    reconnected.set_profiles(f.handle.profiles().unwrap().clone());
+    let response = ext_method_json(
+        &reconnected,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": session_id}),
+    )
+    .await;
+    assert_eq!(response["revision"], 2);
+    assert_eq!(
+        response["assignments"][0]["model"]["model_id"],
+        "provider/removed-model"
+    );
+    assert_eq!(
+        response["assignments"][0]["model"]["node_id"],
+        "offline-node"
+    );
+    assert_eq!(
+        response["orphaned_overrides"][0]["agent_id"],
+        "removed-role"
+    );
+    assert!(handle.registry.lock().await.get(&session_id).is_none());
+    let clear = ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
+        "session_id": session_id, "agent_id": "removed-role", "model_id": null, "expected_revision": 2
+    })).await;
+    assert_eq!(clear["revision"], 3);
+}
+
+#[tokio::test]
+async fn delegate_assignment_child_cannot_edit_parent_routing() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let parent = persisted_delegate_parent(&f).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
+        .await
+        .unwrap();
+    let child = runtime
+        .agent()
+        .handle()
+        .config
+        .provider
+        .history_store()
+        .create_session(
+            None,
+            None,
+            Some(parent),
+            Some(crate::session::domain::ForkOrigin::Delegation),
+        )
+        .await
+        .unwrap();
+    bind_test_profile(&f, &child.public_id, "quorum").await;
+    let response = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": child.public_id}),
+    )
+    .await;
+    assert_eq!(response["editable"], false);
+    assert!(response["assignments"].as_array().unwrap().is_empty());
+    let error = f
+        .handle
+        .ext_method(crate::acp::protocol::ExtRequest::new(
+            "querymt/session/setDelegateModel",
+            raw_params(
+                &serde_json::json!({
+                    "session_id": child.public_id, "agent_id": "coder", "model_id": null
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
+}
+
+#[tokio::test]
+async fn delegate_assignment_changes_notify_and_failed_writes_do_not() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let session_id = persisted_delegate_parent(&f).await;
+    let runtime = f
+        .handle
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
+        .await
+        .unwrap();
+    let mut events = runtime.agent().handle().subscribe_events();
+    ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": session_id, "agent_id": "coder", "model_id": "test/test-model"
+        }),
+    )
+    .await;
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let event = events.recv().await.unwrap();
+            if matches!(event.kind(), AgentEventKind::DelegateModelsChanged { .. }) {
+                break event;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(event.session_id(), session_id);
+    let mut translator = crate::acp::shared::AcpLiveEventTranslator::new();
+    let notification = translator.translate_notification(&event).unwrap();
+    assert_eq!(
+        notification["method"],
+        "querymt/session/delegateModelsChanged"
+    );
+    assert_eq!(notification["params"]["version"], 1);
+    assert_eq!(notification["params"]["session_id"], session_id);
+    assert_eq!(notification["params"]["revision"], 1);
+    let stale = f.handle.ext_method(crate::acp::protocol::ExtRequest::new("querymt/session/setDelegateModel", raw_params(&serde_json::json!({
+        "session_id": session_id, "agent_id": "coder", "model_id": null, "expected_revision": 0
+    }).to_string()))).await;
+    assert!(stale.is_err());
+    let noop = ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
+        "session_id": session_id, "agent_id": "coder", "model_id": "test/test-model", "expected_revision": 1
+    })).await;
+    assert_eq!(noop["revision"], 1);
+    let no_change = tokio::time::timeout(std::time::Duration::from_millis(100), async {
+        loop {
+            if matches!(
+                events.recv().await.unwrap().kind(),
+                AgentEventKind::DelegateModelsChanged { .. }
+            ) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(no_change.is_err());
+}
+
+#[tokio::test]
+async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
+    let (f, _profile_dir) =
+        profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
+    let session_id = persisted_delegate_parent(&f).await;
+    let before = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"sessionId": session_id}),
+    )
+    .await;
+    assert_eq!(before["version"], 1);
+    assert_eq!(before["revision"], 0);
+    assert_eq!(before["durable"], true);
+    assert_eq!(before["editable"], true);
+    assert_eq!(before["assignments"][0]["agent_id"], "coder");
+    assert_eq!(before["assignments"][0]["source"], "profile_default");
+    assert_eq!(
+        before["assignments"][0]["configured_default_model_id"],
+        "test/test-model"
+    );
+    let set = ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
+        "session_id": session_id, "agent_id": "coder", "model_id": "test/test-model", "expected_revision": 0
+    })).await;
+    assert_eq!(set["version"], 1);
+    assert_eq!(set["revision"], 1);
+    assert_eq!(set["model"]["model_id"], "test/test-model");
+    let current = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": session_id}),
+    )
+    .await;
+    assert_eq!(current["assignments"][0]["source"], "override");
+    assert_eq!(current["assignments"][1]["source"], "profile_default");
+    let stale = f.handle.ext_method(crate::acp::protocol::ExtRequest::new("querymt/session/setDelegateModel", raw_params(&serde_json::json!({
+        "session_id": session_id, "agent_id": "coder", "model_id": null, "expected_revision": 0
+    }).to_string()))).await.unwrap_err();
+    assert_eq!(stale.data.unwrap()["code"], "delegate_assignment_conflict");
+    let cleared = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "sessionId": session_id, "agentId": "coder", "modelId": null, "expectedRevision": 1
+        }),
+    )
+    .await;
+    assert_eq!(cleared["revision"], 2);
+    assert!(cleared["model"].is_null());
+    let runtime = f
+        .handle
+        .profiles()
+        .unwrap()
+        .runtime_for_profile("quorum")
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .agent()
+            .handle()
+            .registry
+            .lock()
+            .await
+            .get(&session_id)
+            .is_none(),
+        "read/write must not materialize an actor"
     );
 }
 
@@ -260,24 +804,34 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
 async fn test_querymt_session_set_delegate_model_rejects_invalid_targets() {
     let (f, _profile_dir) =
         profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
-    register_bound_test_session(&f, "parent-1", "quorum").await;
-
+    let session_id = persisted_delegate_parent(&f).await;
     for params in [
-        r#"{"session_id":"missing","agent_id":"coder","model_id":null}"#,
-        r#"{"session_id":"parent-1","agent_id":"missing","model_id":null}"#,
-        r#"{"session_id":"parent-1","agent_id":"coder","model_id":"test/missing"}"#,
+        serde_json::json!({"session_id": "missing", "agent_id": "coder", "model_id": null}),
+        serde_json::json!({"session_id": session_id, "agent_id": "missing", "model_id": null}),
+        serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": "test/missing"}),
+        serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": " "}),
+        serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": null, "node_id": "node"}),
+        serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": "test/test-model", "node_id": "  "}),
+        serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": "test/test-model", "node_id": "unknown-node"}),
     ] {
         let req = crate::acp::protocol::ExtRequest::new(
             "querymt/session/setDelegateModel",
-            raw_params(params),
+            raw_params(&params.to_string()),
         );
-        let err = f
+        let error = f
             .handle
             .ext_method(req)
             .await
             .expect_err("invalid target should fail");
-        assert_eq!(err.code, agent_client_protocol::ErrorCode::InvalidParams);
+        assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
     }
+    let unchanged = ext_method_json(
+        &f.handle,
+        "querymt/session/delegateModels",
+        serde_json::json!({"session_id": session_id}),
+    )
+    .await;
+    assert_eq!(unchanged["revision"], 0);
 }
 
 #[tokio::test]

--- a/crates/agent/src/agent/handle/tests/core_b.rs
+++ b/crates/agent/src/agent/handle/tests/core_b.rs
@@ -326,6 +326,7 @@ async fn delegate_assignments_custom_storage_uses_legacy_memory_without_false_no
     )
     .await;
     assert_eq!(before["version"], 1);
+    assert_eq!(before["reasoning_effort_supported"], true);
     assert_eq!(before["durable"], false);
     assert!(before["revision"].is_null());
 
@@ -340,8 +341,10 @@ async fn delegate_assignments_custom_storage_uses_legacy_memory_without_false_no
     )
     .await;
     assert_eq!(set["version"], 1);
+    assert_eq!(set["reasoning_effort_supported"], true);
     assert_eq!(set["durable"], false);
     assert!(set["revision"].is_null());
+    assert!(set["reasoning_effort"].is_null());
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {
             if matches!(
@@ -362,6 +365,31 @@ async fn delegate_assignments_custom_storage_uses_legacy_memory_without_false_no
     )
     .await;
     assert_eq!(current["assignments"][0]["source"], "override");
+    assert!(current["assignments"][0]["reasoning_effort"].is_null());
+    let reasoning = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": "legacy-parent",
+            "agent_id": "coder",
+            "model_id": "test/test-model",
+            "reasoning_effort": "high"
+        }),
+    )
+    .await;
+    assert_eq!(reasoning["reasoning_effort"], "high");
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if matches!(
+                events.recv().await.unwrap().kind(),
+                AgentEventKind::DelegateModelsChanged { revision: None }
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
     let noop = ext_method_json(
         &f.handle,
         "querymt/session/setDelegateModel",
@@ -372,6 +400,7 @@ async fn delegate_assignments_custom_storage_uses_legacy_memory_without_false_no
         }),
     )
     .await;
+    assert_eq!(noop["reasoning_effort"], "high");
     assert!(noop["revision"].is_null());
     assert!(
         tokio::time::timeout(std::time::Duration::from_millis(100), events.recv())
@@ -458,10 +487,19 @@ async fn delegate_assignments_restore_after_full_profile_restart_from_temporary_
         .await;
     let parent = persisted_delegate_parent(&first).await;
     let sibling = persisted_delegate_parent(&first).await;
-    ext_method_json(&first.handle, "querymt/session/setDelegateModel", serde_json::json!({
-        "session_id": parent, "agent_id": "coder", "model_id": "test/test-model", "expected_revision": 0
-    })).await;
-    // Persistence includes the profile binding, not just the model JSON.
+    ext_method_json(
+        &first.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": parent,
+            "agent_id": "coder",
+            "model_id": "test/test-model",
+            "reasoning_effort": "high",
+            "expected_revision": 0
+        }),
+    )
+    .await;
+    // Persistence includes the profile binding, not just the route assignment.
     assert_eq!(
         storage
             .get_session_runtime_binding(&parent)
@@ -494,6 +532,7 @@ async fn delegate_assignments_restore_after_full_profile_restart_from_temporary_
         snapshot["assignments"][0]["model"]["model_id"],
         "test/test-model"
     );
+    assert_eq!(snapshot["assignments"][0]["reasoning_effort"], "high");
     let other = ext_method_json(
         &second.handle,
         "querymt/session/delegateModels",
@@ -619,7 +658,13 @@ async fn delegate_assignment_readback_survives_reconnect_and_preserves_unavailab
         .config
         .provider
         .history_store()
-        .set_delegate_assignment(&session_id, "removed-role", Some(model), None)
+        .set_delegate_assignment_with_reasoning(
+            &session_id,
+            "removed-role",
+            None,
+            Some(Some(crate::delegation::DelegateReasoningEffort::High)),
+            None,
+        )
         .await
         .unwrap();
     // A fresh handle has no loaded session actors or assignment cache.
@@ -644,10 +689,24 @@ async fn delegate_assignment_readback_survives_reconnect_and_preserves_unavailab
         response["orphaned_overrides"][0]["agent_id"],
         "removed-role"
     );
+    assert!(response["orphaned_overrides"][0]["model"].is_null());
+    assert_eq!(
+        response["orphaned_overrides"][0]["reasoning_effort"],
+        "high"
+    );
     assert!(handle.registry.lock().await.get(&session_id).is_none());
-    let clear = ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
-        "session_id": session_id, "agent_id": "removed-role", "model_id": null, "expected_revision": 2
-    })).await;
+    let clear = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": session_id,
+            "agent_id": "removed-role",
+            "model_id": null,
+            "reasoning_effort": null,
+            "expected_revision": 2
+        }),
+    )
+    .await;
     assert_eq!(clear["revision"], 3);
 }
 
@@ -791,6 +850,7 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
     )
     .await;
     assert_eq!(before["version"], 1);
+    assert_eq!(before["reasoning_effort_supported"], true);
     assert_eq!(before["revision"], 0);
     assert_eq!(before["durable"], true);
     assert_eq!(before["editable"], true);
@@ -800,12 +860,23 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
         before["assignments"][0]["configured_default_model_id"],
         "test/test-model"
     );
-    let set = ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
-        "session_id": session_id, "agent_id": "coder", "model_id": "test/test-model", "expected_revision": 0
-    })).await;
+    let set = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": session_id,
+            "agent_id": "coder",
+            "model_id": "test/test-model",
+            "reasoning_effort": "high",
+            "expected_revision": 0
+        }),
+    )
+    .await;
     assert_eq!(set["version"], 1);
+    assert_eq!(set["reasoning_effort_supported"], true);
     assert_eq!(set["revision"], 1);
     assert_eq!(set["model"]["model_id"], "test/test-model");
+    assert_eq!(set["reasoning_effort"], "high");
     let current = ext_method_json(
         &f.handle,
         "querymt/session/delegateModels",
@@ -813,6 +884,7 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
     )
     .await;
     assert_eq!(current["assignments"][0]["source"], "override");
+    assert_eq!(current["assignments"][0]["reasoning_effort"], "high");
     assert_eq!(current["assignments"][1]["source"], "profile_default");
     let stale = f.handle.ext_method(crate::acp::protocol::ExtRequest::new("querymt/session/setDelegateModel", raw_params(&serde_json::json!({
         "session_id": session_id, "agent_id": "coder", "model_id": null, "expected_revision": 0
@@ -824,16 +896,35 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
         )
     );
     assert_eq!(stale.data.unwrap()["code"], "delegate_assignment_conflict");
+    let model_cleared = ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "sessionId": session_id,
+            "agentId": "coder",
+            "modelId": null,
+            "expectedRevision": 1
+        }),
+    )
+    .await;
+    assert_eq!(model_cleared["revision"], 2);
+    assert!(model_cleared["model"].is_null());
+    assert_eq!(model_cleared["reasoning_effort"], "high");
     let cleared = ext_method_json(
         &f.handle,
         "querymt/session/setDelegateModel",
         serde_json::json!({
-            "sessionId": session_id, "agentId": "coder", "modelId": null, "expectedRevision": 1
+            "sessionId": session_id,
+            "agentId": "coder",
+            "modelId": null,
+            "reasoningEffort": null,
+            "expectedRevision": 2
         }),
     )
     .await;
-    assert_eq!(cleared["revision"], 2);
+    assert_eq!(cleared["revision"], 3);
     assert!(cleared["model"].is_null());
+    assert!(cleared["reasoning_effort"].is_null());
     let runtime = f
         .handle
         .profiles()
@@ -861,7 +952,8 @@ async fn test_querymt_session_set_delegate_model_rejects_invalid_targets() {
     let session_id = persisted_delegate_parent(&f).await;
     for params in [
         serde_json::json!({"session_id": "missing", "agent_id": "coder", "model_id": null}),
-        serde_json::json!({"session_id": session_id, "agent_id": "missing", "model_id": null}),
+        serde_json::json!({"session_id": session_id, "agent_id": "missing", "model_id": null, "reasoning_effort": null}),
+        serde_json::json!({"session_id": session_id, "agent_id": "missing", "model_id": null, "reasoning_effort": "high"}),
         serde_json::json!({"session_id": session_id, "agent_id": "coder"}),
         serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": "test/missing"}),
         serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": " "}),

--- a/crates/agent/src/agent/handle/tests/core_b.rs
+++ b/crates/agent/src/agent/handle/tests/core_b.rs
@@ -515,7 +515,7 @@ async fn delegate_assignments_restore_after_full_profile_restart_from_temporary_
 }
 
 #[tokio::test]
-async fn delegate_assignment_user_fork_can_own_independent_routing() {
+async fn delegate_assignment_user_fork_inherits_revision_zero_copy() {
     let (f, _dir) = profile_fixture_with_files(&[("quorum.toml", QUORUM_PROFILE_TOML)]).await;
     let parent = persisted_delegate_parent(&f).await;
     let runtime = f
@@ -526,35 +526,69 @@ async fn delegate_assignment_user_fork_can_own_independent_routing() {
         .await
         .unwrap();
     let store = runtime.agent().handle().config.provider.history_store();
-    let fork = store
-        .create_session(
-            None,
-            None,
-            Some(parent.clone()),
-            Some(crate::session::domain::ForkOrigin::User),
+    ext_method_json(
+        &f.handle,
+        "querymt/session/setDelegateModel",
+        serde_json::json!({
+            "session_id": parent,
+            "agent_id": "coder",
+            "model_id": "test/test-model",
+            "expected_revision": 0
+        }),
+    )
+    .await;
+    store
+        .add_message(
+            &parent,
+            crate::model::AgentMessage {
+                id: "fork-point".into(),
+                session_id: parent.clone(),
+                role: querymt::chat::ChatRole::User,
+                parts: vec![crate::model::MessagePart::Prompt {
+                    blocks: vec![crate::acp::protocol::ContentBlock::Text(
+                        crate::acp::protocol::TextContent::new("task"),
+                    )],
+                }],
+                created_at: 1,
+                parent_message_id: None,
+                source_provider: None,
+                source_model: None,
+            },
         )
         .await
         .unwrap();
-    bind_test_profile(&f, &fork.public_id, "quorum").await;
+    let fork_id = store
+        .fork_session(
+            &parent,
+            "fork-point",
+            crate::session::domain::ForkOrigin::User,
+        )
+        .await
+        .unwrap();
+    bind_test_profile(&f, &fork_id, "quorum").await;
     let result = ext_method_json(
         &f.handle,
         "querymt/session/delegateModels",
-        serde_json::json!({"session_id": fork.public_id}),
+        serde_json::json!({"session_id": fork_id}),
     )
     .await;
     assert_eq!(result["editable"], true);
-    ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
-        "session_id": fork.public_id, "agent_id": "reviewer", "model_id": "test/test-model", "expected_revision": 0
-    })).await;
-    assert!(
-        store
-            .get_delegate_assignments(&parent)
-            .await
-            .unwrap()
-            .unwrap()
-            .overrides
-            .is_empty()
+    assert_eq!(result["revision"], 0);
+    assert_eq!(
+        result["assignments"][0]["model"]["model_id"],
+        "test/test-model"
     );
+    ext_method_json(&f.handle, "querymt/session/setDelegateModel", serde_json::json!({
+        "session_id": fork_id, "agent_id": "reviewer", "model_id": "test/test-model", "expected_revision": 0
+    })).await;
+    let parent_state = store
+        .get_delegate_assignments(&parent)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(parent_state.revision, 1);
+    assert_eq!(parent_state.overrides["coder"].model_id, "test/test-model");
+    assert!(!parent_state.overrides.contains_key("reviewer"));
 }
 
 #[tokio::test]
@@ -709,6 +743,20 @@ async fn delegate_assignment_changes_notify_and_failed_writes_do_not() {
     assert_eq!(notification["params"]["version"], 1);
     assert_eq!(notification["params"]["session_id"], session_id);
     assert_eq!(notification["params"]["revision"], 1);
+    let handle = runtime.agent().handle();
+    let durable = handle
+        .config
+        .event_sink
+        .journal()
+        .load_session_stream(&session_id, None, None)
+        .await
+        .unwrap();
+    assert!(
+        durable
+            .iter()
+            .all(|event| { !matches!(event.kind, AgentEventKind::DelegateModelsChanged { .. }) }),
+        "invalidation hints must not be journaled"
+    );
     let stale = f.handle.ext_method(crate::acp::protocol::ExtRequest::new("querymt/session/setDelegateModel", raw_params(&serde_json::json!({
         "session_id": session_id, "agent_id": "coder", "model_id": null, "expected_revision": 0
     }).to_string()))).await;
@@ -769,6 +817,12 @@ async fn test_querymt_session_set_delegate_model_sets_and_clears_override() {
     let stale = f.handle.ext_method(crate::acp::protocol::ExtRequest::new("querymt/session/setDelegateModel", raw_params(&serde_json::json!({
         "session_id": session_id, "agent_id": "coder", "model_id": null, "expected_revision": 0
     }).to_string()))).await.unwrap_err();
+    assert_eq!(
+        stale.code,
+        agent_client_protocol::ErrorCode::Other(
+            crate::control::delegate_models::DELEGATE_ASSIGNMENT_CONFLICT_ACP_CODE
+        )
+    );
     assert_eq!(stale.data.unwrap()["code"], "delegate_assignment_conflict");
     let cleared = ext_method_json(
         &f.handle,
@@ -808,6 +862,7 @@ async fn test_querymt_session_set_delegate_model_rejects_invalid_targets() {
     for params in [
         serde_json::json!({"session_id": "missing", "agent_id": "coder", "model_id": null}),
         serde_json::json!({"session_id": session_id, "agent_id": "missing", "model_id": null}),
+        serde_json::json!({"session_id": session_id, "agent_id": "coder"}),
         serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": "test/missing"}),
         serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": " "}),
         serde_json::json!({"session_id": session_id, "agent_id": "coder", "model_id": null, "node_id": "node"}),

--- a/crates/agent/src/agent/handle/tests/core_b.rs
+++ b/crates/agent/src/agent/handle/tests/core_b.rs
@@ -196,21 +196,6 @@ async fn test_querymt_profile_agents_rejects_unknown_profile() {
     assert_eq!(err.code, agent_client_protocol::ErrorCode::InvalidParams);
 }
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let response = handle
-        .ext_method(crate::acp::protocol::ExtRequest::new(
-            method,
-            raw_params(&params.to_string()),
-        ))
-        .await
-        .unwrap();
-    serde_json::from_str(response.0.get()).unwrap()
-}
-
 async fn persisted_delegate_parent(f: &HandleFixture) -> String {
     let runtime = f
         .handle

--- a/crates/agent/src/agent/handle/tests/ext_auth.rs
+++ b/crates/agent/src/agent/handle/tests/ext_auth.rs
@@ -1,18 +1,5 @@
 use super::*;
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
 #[tokio::test]
 async fn set_api_token_rejects_empty_key() {
     let f = HandleFixture::new().await;

--- a/crates/agent/src/agent/handle/tests/mesh.rs
+++ b/crates/agent/src/agent/handle/tests/mesh.rs
@@ -3,19 +3,6 @@ use super::*;
 #[cfg(feature = "remote")]
 use crate::agent::remote::test_helpers::fixtures::get_test_mesh;
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
 #[cfg(feature = "remote")]
 #[tokio::test]
 async fn test_querymt_mesh_status_without_mesh_is_disabled() {

--- a/crates/agent/src/agent/handle/tests/mod.rs
+++ b/crates/agent/src/agent/handle/tests/mod.rs
@@ -228,6 +228,21 @@ fn raw_params(value: &str) -> Arc<serde_json::value::RawValue> {
     Arc::from(serde_json::value::RawValue::from_string(value.to_string()).unwrap())
 }
 
+async fn ext_method_json(
+    handle: &LocalAgentHandle,
+    method: &str,
+    params: serde_json::Value,
+) -> serde_json::Value {
+    let response = handle
+        .ext_method(crate::acp::protocol::ExtRequest::new(
+            method,
+            raw_params(&params.to_string()),
+        ))
+        .await
+        .expect("ext_method");
+    serde_json::from_str(response.0.get()).expect("valid JSON")
+}
+
 const ALPHA_PROFILE_TOML: &str = r#"
 [agent]
 provider = "test"

--- a/crates/agent/src/agent/handle/tests/mod.rs
+++ b/crates/agent/src/agent/handle/tests/mod.rs
@@ -36,6 +36,25 @@ struct RealStorageHandleFixture {
     _temp_dir: tempfile::TempDir,
 }
 
+struct TestStorageBackend {
+    session_store: Arc<dyn SessionStore>,
+    event_storage: Arc<crate::session::sqlite_storage::SqliteStorage>,
+}
+
+impl StorageBackend for TestStorageBackend {
+    fn session_store(&self) -> Arc<dyn SessionStore> {
+        self.session_store.clone()
+    }
+
+    fn event_journal(&self) -> Arc<dyn crate::session::projection::EventJournal> {
+        self.event_storage.clone()
+    }
+
+    fn view_store(&self) -> Option<Arc<dyn crate::session::projection::ViewStore>> {
+        Some(self.event_storage.clone())
+    }
+}
+
 impl HandleFixture {
     async fn new() -> Self {
         Self::with_list_sessions(vec![]).await
@@ -77,6 +96,21 @@ impl HandleFixture {
     }
 
     async fn with_profiles(self, active_profile_id: &str, profile_dir: &Path) -> Self {
+        let storage = Arc::new(
+            crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into())
+                .await
+                .expect("profile test storage"),
+        );
+        self.with_profile_storage(active_profile_id, profile_dir, storage)
+            .await
+    }
+
+    async fn with_profile_storage(
+        self,
+        active_profile_id: &str,
+        profile_dir: &Path,
+        storage: Arc<dyn crate::session::backend::StorageBackend>,
+    ) -> Self {
         let catalog: Arc<dyn ProfileCatalog> = Arc::new(
             crate::profiles::LocalProfileCatalog::builder()
                 .include_embedded_default(false)
@@ -89,7 +123,8 @@ impl HandleFixture {
             active_profile_id,
             AgentInfra {
                 plugin_registry: Arc::new(plugin_registry),
-                storage: None,
+                // The manager and its runtimes share explicit test storage, never the user DB.
+                storage: Some(storage),
                 session_mcp_attachment_source: None,
                 event_fanout: None,
             },

--- a/crates/agent/src/agent/handle/tests/remote_ext.rs
+++ b/crates/agent/src/agent/handle/tests/remote_ext.rs
@@ -7,19 +7,6 @@ use crate::agent::remote::scope::{MeshScopeId, scoped_node_manager_for_peer};
 #[cfg(feature = "remote")]
 use kameo::actor::Spawn;
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
 #[cfg(feature = "remote")]
 async fn register_remote_node(
     mesh: &crate::agent::remote::mesh::MeshHandle,

--- a/crates/agent/src/agent/handle/tests/schedule_get_remote.rs
+++ b/crates/agent/src/agent/handle/tests/schedule_get_remote.rs
@@ -8,20 +8,6 @@ use crate::agent::remote::scope::{MeshScopeId, scoped_node_manager_for_peer};
 use kameo::actor::Spawn;
 
 #[cfg(feature = "remote")]
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
-#[cfg(feature = "remote")]
 #[tokio::test]
 async fn test_querymt_schedule_get_remote_returns_schedule() {
     let mesh = crate::agent::remote::test_helpers::fixtures::get_test_mesh().await;

--- a/crates/agent/src/agent/handle/tests/scheduler.rs
+++ b/crates/agent/src/agent/handle/tests/scheduler.rs
@@ -1,19 +1,6 @@
 use super::*;
 use crate::session::backend::StorageBackend;
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
 async fn wait_for_condition<F, Fut>(mut f: F)
 where
     F: FnMut() -> Fut,

--- a/crates/agent/src/agent/handle/tests/session_ops_ext.rs
+++ b/crates/agent/src/agent/handle/tests/session_ops_ext.rs
@@ -1,18 +1,5 @@
 use super::*;
 
-async fn ext_method_json(
-    handle: &LocalAgentHandle,
-    method: &str,
-    params: serde_json::Value,
-) -> serde_json::Value {
-    let req = crate::acp::protocol::ExtRequest::new(
-        method,
-        std::sync::Arc::from(serde_json::value::RawValue::from_string(params.to_string()).unwrap()),
-    );
-    let resp = handle.ext_method(req).await.expect("ext_method");
-    serde_json::from_str(resp.0.get()).expect("valid JSON")
-}
-
 #[tokio::test]
 async fn querymt_session_undo_stack_returns_empty_stack_for_new_session() {
     let f = HandleFixture::new().await;

--- a/crates/agent/src/api/agent_tests.rs
+++ b/crates/agent/src/api/agent_tests.rs
@@ -663,6 +663,102 @@ async fn acp_list_sessions_pages_workspace_sessions_without_cross_workspace_leak
 }
 
 #[tokio::test]
+async fn acp_list_sessions_filters_by_session_scope_meta() -> Result<()> {
+    let agent = test_agent().await?;
+    let session_store = agent.storage_backend().session_store();
+    let root = session_store
+        .create_session(
+            Some("Root Session".to_string()),
+            Some("/tmp/scope".into()),
+            None,
+            None,
+        )
+        .await?;
+    let user_fork = session_store
+        .create_session(
+            Some("User Fork".to_string()),
+            Some("/tmp/scope".into()),
+            Some(root.public_id.clone()),
+            Some(crate::session::domain::ForkOrigin::User),
+        )
+        .await?;
+    let delegate = session_store
+        .create_session(
+            Some("Delegate Session".to_string()),
+            Some("/tmp/scope".into()),
+            Some(root.public_id.clone()),
+            Some(crate::session::domain::ForkOrigin::Delegation),
+        )
+        .await?;
+    let view_store = agent.storage_backend().view_store().expect("view store");
+
+    let all = AgentSessions::list_for_acp_from_view_store(
+        view_store.clone(),
+        AcpListSessionsRequest::new(),
+    )
+    .await?;
+    assert_eq!(all.total_count, 3);
+
+    let mut root_meta = crate::acp::protocol::Meta::new();
+    root_meta.insert(
+        "session_scope".to_string(),
+        serde_json::Value::String("root".to_string()),
+    );
+    let roots = AgentSessions::list_for_acp_from_view_store(
+        view_store.clone(),
+        AcpListSessionsRequest::new().meta(root_meta),
+    )
+    .await?;
+    assert_eq!(
+        roots
+            .sessions
+            .iter()
+            .map(|session| session.session_id.to_string())
+            .collect::<Vec<_>>(),
+        vec![root.public_id.clone()]
+    );
+
+    let mut delegates_meta = crate::acp::protocol::Meta::new();
+    delegates_meta.insert(
+        "sessionScope".to_string(),
+        serde_json::Value::String("delegates".to_string()),
+    );
+    let delegates = AgentSessions::list_for_acp_from_view_store(
+        view_store.clone(),
+        AcpListSessionsRequest::new().meta(delegates_meta),
+    )
+    .await?;
+    assert_eq!(
+        delegates
+            .sessions
+            .iter()
+            .map(|session| session.session_id.to_string())
+            .collect::<Vec<_>>(),
+        vec![delegate.public_id]
+    );
+
+    let mut forks_meta = crate::acp::protocol::Meta::new();
+    forks_meta.insert(
+        "session_scope".to_string(),
+        serde_json::Value::String("forks".to_string()),
+    );
+    let forks = AgentSessions::list_for_acp_from_view_store(
+        view_store,
+        AcpListSessionsRequest::new().meta(forks_meta),
+    )
+    .await?;
+    assert_eq!(
+        forks
+            .sessions
+            .iter()
+            .map(|session| session.session_id.to_string())
+            .collect::<Vec<_>>(),
+        vec![user_fork.public_id]
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn acp_session_list_includes_relationship_and_operational_meta() -> Result<()> {
     let storage =
         Arc::new(crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into()).await?);

--- a/crates/agent/src/api/sessions.rs
+++ b/crates/agent/src/api/sessions.rs
@@ -305,6 +305,7 @@ impl AgentSessions {
     ) -> std::result::Result<AcpSessionListPage, AcpSessionListError> {
         let cursor = AcpSessionCursor::parse(request.cursor.as_deref())?;
         let requested_cwd = request.cwd.map(|cwd| cwd.display().to_string());
+        let session_scope = acp_session_scope_from_meta(request.meta.as_ref());
         // ACP workspace requests load incrementally; global discovery remains a larger flat page.
         let limit = if requested_cwd.is_some() { 10 } else { 100 };
 
@@ -313,7 +314,7 @@ impl AgentSessions {
                 requested_cwd,
                 cursor.map(AcpSessionCursor::into_string),
                 limit,
-                SessionScope::All,
+                session_scope,
             )
             .await
             .map_err(anyhow::Error::from)?;
@@ -735,6 +736,20 @@ impl From<crate::session::projection::SessionGroup> for SessionGroup {
             total_count: group.total_count.map(|v| v as u64),
             next_cursor: group.next_cursor,
         }
+    }
+}
+
+fn acp_session_scope_from_meta(meta: Option<&Meta>) -> SessionScope {
+    let Some(meta) = meta else {
+        return SessionScope::All;
+    };
+
+    let value = meta
+        .get("session_scope")
+        .or_else(|| meta.get("sessionScope"));
+    match value {
+        Some(serde_json::Value::String(scope)) => SessionScope::from_option(Some(scope.clone())),
+        _ => SessionScope::All,
     }
 }
 

--- a/crates/agent/src/control/capabilities.rs
+++ b/crates/agent/src/control/capabilities.rs
@@ -107,6 +107,7 @@ pub fn get_capabilities(agent: &crate::LocalAgentHandle) -> CapabilitiesInfo {
             "querymt/profile/agents".to_string(),
             "querymt/profile/setActive".to_string(),
             "querymt/session/setDelegateModel".to_string(),
+            "querymt/session/delegateModels".to_string(),
         ]);
     }
 
@@ -124,6 +125,19 @@ pub fn get_capabilities(agent: &crate::LocalAgentHandle) -> CapabilitiesInfo {
             "querymt/remote/attachSession".to_string(),
             "querymt/remote/dismissSession".to_string(),
         ]);
+    }
+
+    let mut notifications = vec![
+        "querymt/mesh/nodesChanged".to_string(),
+        "querymt/mesh/joined".to_string(),
+        "querymt/mesh/peerExpired".to_string(),
+        "querymt/models/changed".to_string(),
+        "querymt/schedules/changed".to_string(),
+        crate::acp::shared::QMT_NOTIFICATION_DELEGATION_UPDATE.to_string(),
+    ];
+    if agent.profiles().is_some() {
+        notifications
+            .push(crate::acp::shared::QMT_NOTIFICATION_DELEGATE_MODELS_CHANGED.to_string());
     }
 
     CapabilitiesInfo {
@@ -157,13 +171,6 @@ pub fn get_capabilities(agent: &crate::LocalAgentHandle) -> CapabilitiesInfo {
             steering: true,
         },
         methods,
-        notifications: vec![
-            "querymt/mesh/nodesChanged".to_string(),
-            "querymt/mesh/joined".to_string(),
-            "querymt/mesh/peerExpired".to_string(),
-            "querymt/models/changed".to_string(),
-            "querymt/schedules/changed".to_string(),
-            "querymt/session/delegationUpdate".to_string(),
-        ],
+        notifications,
     }
 }

--- a/crates/agent/src/control/delegate_models.rs
+++ b/crates/agent/src/control/delegate_models.rs
@@ -39,17 +39,12 @@ impl<T> From<Option<T>> for RequiredNullable<T> {
 }
 
 /// An additive request field where omission preserves state and null clears it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum OptionalNullable<T> {
+    #[default]
     Missing,
     Null,
     Value(T),
-}
-
-impl<T> Default for OptionalNullable<T> {
-    fn default() -> Self {
-        Self::Missing
-    }
 }
 
 impl<'de, T> Deserialize<'de> for OptionalNullable<T>

--- a/crates/agent/src/control/delegate_models.rs
+++ b/crates/agent/src/control/delegate_models.rs
@@ -1,13 +1,36 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use typeshare::typeshare;
 
 use crate::delegation::DelegateModelOverride;
 
 pub const DELEGATE_MODELS_VERSION: u32 = 1;
+/// Distinct from ACP `InvalidParams` (`-32602`) so clients can refresh-and-retry.
+pub const DELEGATE_ASSIGNMENT_CONFLICT_ACP_CODE: i32 = -32020;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// JSON null serializes as `null`. Unlike `Option`, a missing field is invalid.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct RequiredNullable<T>(pub Option<T>);
+
+impl<'de, T> Deserialize<'de> for RequiredNullable<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Do not deserialize through `Option`: serde treats a missing field as
+        // `None` whenever the type calls `deserialize_option`. `Value` uses
+        // `deserialize_any`, so absence is `InvalidParams` and JSON null clears.
+        match serde_json::Value::deserialize(deserializer)? {
+            serde_json::Value::Null => Ok(Self(None)),
+            value => T::deserialize(value)
+                .map(|parsed| Self(Some(parsed)))
+                .map_err(serde::de::Error::custom),
+        }
+    }
+}
 
 impl<T> From<Option<T>> for RequiredNullable<T> {
     fn from(value: Option<T>) -> Self {
@@ -29,9 +52,10 @@ pub struct SetDelegateModelRequest {
     pub session_id: String,
     #[serde(alias = "agentId")]
     pub agent_id: String,
-    #[serde(default, alias = "modelId")]
+    /// Present and null clears the override. Omitted is invalid, not a wipe.
+    #[serde(alias = "modelId")]
     #[typeshare(typescript(type = "string | null"))]
-    pub model_id: Option<String>,
+    pub model_id: RequiredNullable<String>,
     #[serde(default, alias = "nodeId")]
     #[typeshare(typescript(type = "string | null"))]
     pub node_id: Option<String>,
@@ -106,4 +130,43 @@ pub struct DelegateModelsChangedNotification {
     #[typeshare(serialized_as = "number")]
     #[typeshare(typescript(type = "number | null"))]
     pub revision: RequiredNullable<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetDelegateModelRequest;
+
+    #[test]
+    fn omitted_model_id_is_rejected() {
+        let error = serde_json::from_str::<SetDelegateModelRequest>(
+            r#"{"session_id":"s","agent_id":"coder"}"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("model_id"));
+    }
+
+    #[test]
+    fn explicit_null_model_id_clears() {
+        let parsed: SetDelegateModelRequest =
+            serde_json::from_str(r#"{"session_id":"s","agent_id":"coder","model_id":null}"#)
+                .unwrap();
+        assert!(parsed.model_id.0.is_none());
+        assert!(parsed.node_id.is_none());
+    }
+
+    #[test]
+    fn camel_case_null_model_id_clears() {
+        let parsed: SetDelegateModelRequest =
+            serde_json::from_str(r#"{"sessionId":"s","agentId":"coder","modelId":null}"#).unwrap();
+        assert!(parsed.model_id.0.is_none());
+    }
+
+    #[test]
+    fn present_model_id_is_some() {
+        let parsed: SetDelegateModelRequest = serde_json::from_str(
+            r#"{"session_id":"s","agent_id":"coder","model_id":"test/test-model"}"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.model_id.0.as_deref(), Some("test/test-model"));
+    }
 }

--- a/crates/agent/src/control/delegate_models.rs
+++ b/crates/agent/src/control/delegate_models.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use typeshare::typeshare;
 
-use crate::delegation::DelegateModelOverride;
+use crate::delegation::{DelegateModelOverride, DelegateReasoningEffort};
 
 pub const DELEGATE_MODELS_VERSION: u32 = 1;
 /// Distinct from ACP `InvalidParams` (`-32602`) so clients can refresh-and-retry.
@@ -38,6 +38,48 @@ impl<T> From<Option<T>> for RequiredNullable<T> {
     }
 }
 
+/// An additive request field where omission preserves state and null clears it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptionalNullable<T> {
+    Missing,
+    Null,
+    Value(T),
+}
+
+impl<T> Default for OptionalNullable<T> {
+    fn default() -> Self {
+        Self::Missing
+    }
+}
+
+impl<'de, T> Deserialize<'de> for OptionalNullable<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match Option::<T>::deserialize(deserializer)? {
+            Some(value) => Self::Value(value),
+            None => Self::Null,
+        })
+    }
+}
+
+impl<T> OptionalNullable<T> {
+    pub fn as_update(&self) -> Option<Option<T>>
+    where
+        T: Clone,
+    {
+        match self {
+            Self::Missing => None,
+            Self::Null => Some(None),
+            Self::Value(value) => Some(Some(value.clone())),
+        }
+    }
+}
+
 #[typeshare]
 #[derive(Debug, Clone, Deserialize)]
 pub struct DelegateModelsRequest {
@@ -59,6 +101,10 @@ pub struct SetDelegateModelRequest {
     #[serde(default, alias = "nodeId")]
     #[typeshare(typescript(type = "string | null"))]
     pub node_id: Option<String>,
+    /// Omitted preserves the current setting; null restores parent-session inheritance.
+    #[serde(default, alias = "reasoningEffort")]
+    #[typeshare(typescript(type = "DelegateReasoningEffort | null"))]
+    pub reasoning_effort: OptionalNullable<DelegateReasoningEffort>,
     #[serde(default, alias = "expectedRevision")]
     #[typeshare(serialized_as = "Option<number>")]
     #[typeshare(typescript(type = "number | null"))]
@@ -84,19 +130,25 @@ pub struct DelegateAssignmentInfo {
     pub source: DelegateAssignmentSource,
     #[typeshare(typescript(type = "string | null"))]
     pub configured_default_model_id: RequiredNullable<String>,
+    #[typeshare(typescript(type = "DelegateReasoningEffort | null"))]
+    pub reasoning_effort: RequiredNullable<DelegateReasoningEffort>,
 }
 
 #[typeshare]
 #[derive(Debug, Clone, Serialize)]
 pub struct OrphanedDelegateAssignment {
     pub agent_id: String,
-    pub model: DelegateModelOverride,
+    #[typeshare(typescript(type = "DelegateModelOverride | null"))]
+    pub model: RequiredNullable<DelegateModelOverride>,
+    #[typeshare(typescript(type = "DelegateReasoningEffort | null"))]
+    pub reasoning_effort: RequiredNullable<DelegateReasoningEffort>,
 }
 
 #[typeshare]
 #[derive(Debug, Clone, Serialize)]
 pub struct DelegateAssignmentsInfo {
     pub version: u32,
+    pub reasoning_effort_supported: bool,
     pub session_id: String,
     pub profile_id: String,
     #[typeshare(serialized_as = "number")]
@@ -112,10 +164,13 @@ pub struct DelegateAssignmentsInfo {
 #[derive(Debug, Clone, Serialize)]
 pub struct SetDelegateModelResponse {
     pub version: u32,
+    pub reasoning_effort_supported: bool,
     pub session_id: String,
     pub agent_id: String,
     #[typeshare(typescript(type = "DelegateModelOverride | null"))]
     pub model: RequiredNullable<DelegateModelOverride>,
+    #[typeshare(typescript(type = "DelegateReasoningEffort | null"))]
+    pub reasoning_effort: RequiredNullable<DelegateReasoningEffort>,
     #[typeshare(serialized_as = "number")]
     #[typeshare(typescript(type = "number | null"))]
     pub revision: RequiredNullable<u64>,
@@ -134,7 +189,8 @@ pub struct DelegateModelsChangedNotification {
 
 #[cfg(test)]
 mod tests {
-    use super::SetDelegateModelRequest;
+    use super::{OptionalNullable, SetDelegateModelRequest};
+    use crate::delegation::DelegateReasoningEffort;
 
     #[test]
     fn omitted_model_id_is_rejected() {
@@ -152,6 +208,7 @@ mod tests {
                 .unwrap();
         assert!(parsed.model_id.0.is_none());
         assert!(parsed.node_id.is_none());
+        assert_eq!(parsed.reasoning_effort, OptionalNullable::Missing);
     }
 
     #[test]
@@ -168,5 +225,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parsed.model_id.0.as_deref(), Some("test/test-model"));
+    }
+
+    #[test]
+    fn reasoning_effort_distinguishes_missing_null_and_value() {
+        let missing: SetDelegateModelRequest =
+            serde_json::from_str(r#"{"session_id":"s","agent_id":"coder","model_id":null}"#)
+                .unwrap();
+        let clear: SetDelegateModelRequest = serde_json::from_str(
+            r#"{"session_id":"s","agent_id":"coder","model_id":null,"reasoning_effort":null}"#,
+        )
+        .unwrap();
+        let high: SetDelegateModelRequest = serde_json::from_str(
+            r#"{"session_id":"s","agent_id":"coder","model_id":null,"reasoningEffort":"high"}"#,
+        )
+        .unwrap();
+        assert_eq!(missing.reasoning_effort, OptionalNullable::Missing);
+        assert_eq!(clear.reasoning_effort, OptionalNullable::Null);
+        assert_eq!(
+            high.reasoning_effort,
+            OptionalNullable::Value(DelegateReasoningEffort::High)
+        );
     }
 }

--- a/crates/agent/src/control/delegate_models.rs
+++ b/crates/agent/src/control/delegate_models.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+use typeshare::typeshare;
+
+use crate::delegation::DelegateModelOverride;
+
+pub const DELEGATE_MODELS_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RequiredNullable<T>(pub Option<T>);
+
+impl<T> From<Option<T>> for RequiredNullable<T> {
+    fn from(value: Option<T>) -> Self {
+        Self(value)
+    }
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Deserialize)]
+pub struct DelegateModelsRequest {
+    #[serde(alias = "sessionId")]
+    pub session_id: String,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Deserialize)]
+pub struct SetDelegateModelRequest {
+    #[serde(alias = "sessionId")]
+    pub session_id: String,
+    #[serde(alias = "agentId")]
+    pub agent_id: String,
+    #[serde(default, alias = "modelId")]
+    #[typeshare(typescript(type = "string | null"))]
+    pub model_id: Option<String>,
+    #[serde(default, alias = "nodeId")]
+    #[typeshare(typescript(type = "string | null"))]
+    pub node_id: Option<String>,
+    #[serde(default, alias = "expectedRevision")]
+    #[typeshare(serialized_as = "Option<number>")]
+    #[typeshare(typescript(type = "number | null"))]
+    pub expected_revision: Option<u64>,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegateAssignmentSource {
+    Override,
+    ProfileDefault,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Serialize)]
+pub struct DelegateAssignmentInfo {
+    pub agent_id: String,
+    pub name: String,
+    pub description: String,
+    #[typeshare(typescript(type = "DelegateModelOverride | null"))]
+    pub model: RequiredNullable<DelegateModelOverride>,
+    pub source: DelegateAssignmentSource,
+    #[typeshare(typescript(type = "string | null"))]
+    pub configured_default_model_id: RequiredNullable<String>,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedDelegateAssignment {
+    pub agent_id: String,
+    pub model: DelegateModelOverride,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Serialize)]
+pub struct DelegateAssignmentsInfo {
+    pub version: u32,
+    pub session_id: String,
+    pub profile_id: String,
+    #[typeshare(serialized_as = "number")]
+    #[typeshare(typescript(type = "number | null"))]
+    pub revision: RequiredNullable<u64>,
+    pub durable: bool,
+    pub editable: bool,
+    pub assignments: Vec<DelegateAssignmentInfo>,
+    pub orphaned_overrides: Vec<OrphanedDelegateAssignment>,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Serialize)]
+pub struct SetDelegateModelResponse {
+    pub version: u32,
+    pub session_id: String,
+    pub agent_id: String,
+    #[typeshare(typescript(type = "DelegateModelOverride | null"))]
+    pub model: RequiredNullable<DelegateModelOverride>,
+    #[typeshare(serialized_as = "number")]
+    #[typeshare(typescript(type = "number | null"))]
+    pub revision: RequiredNullable<u64>,
+    pub durable: bool,
+}
+
+#[typeshare]
+#[derive(Debug, Clone, Serialize)]
+pub struct DelegateModelsChangedNotification {
+    pub version: u32,
+    pub session_id: String,
+    #[typeshare(serialized_as = "number")]
+    #[typeshare(typescript(type = "number | null"))]
+    pub revision: RequiredNullable<u64>,
+}

--- a/crates/agent/src/control/delegation_notifications.rs
+++ b/crates/agent/src/control/delegation_notifications.rs
@@ -38,6 +38,11 @@ pub struct DelegationUpdateNotification {
     pub objective: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_session_id: Option<String>,
+    /// Confirmed child model, not the parent's current preference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_provider_node_id: Option<String>,
     #[typeshare(serialized_as = "number")]
     pub requested_at: i64,
     #[typeshare(serialized_as = "Option<number>")]
@@ -66,6 +71,8 @@ enum PendingDelegationTransition {
     Forked {
         session_id: String,
         child_session_id: String,
+        selected_model_id: Option<String>,
+        selected_provider_node_id: Option<String>,
         timestamp: i64,
     },
     Finished {
@@ -148,6 +155,8 @@ impl DelegationUpdateProjector {
                     target_agent_id: delegation.target_agent_id.clone(),
                     objective: delegation.objective.clone(),
                     child_session_id: None,
+                    selected_model_id: None,
+                    selected_provider_node_id: None,
                     requested_at: timestamp,
                     forked_at: None,
                     finished_at: None,
@@ -172,11 +181,15 @@ impl DelegationUpdateProjector {
                 child_session_id,
                 origin: ForkOrigin::Delegation,
                 fork_point_ref,
+                selected_model_id,
+                selected_provider_node_id,
                 ..
             } => {
                 let transition = PendingDelegationTransition::Forked {
                     session_id: parent_session_id.clone(),
                     child_session_id: child_session_id.clone(),
+                    selected_model_id: selected_model_id.clone(),
+                    selected_provider_node_id: selected_provider_node_id.clone(),
                     timestamp,
                 };
                 if !self.apply_transition(fork_point_ref, transition.clone()) {
@@ -249,6 +262,8 @@ impl DelegationUpdateProjector {
             PendingDelegationTransition::Forked {
                 session_id,
                 child_session_id,
+                selected_model_id,
+                selected_provider_node_id,
                 timestamp,
             } => {
                 if timestamp < snapshot.requested_at
@@ -260,6 +275,8 @@ impl DelegationUpdateProjector {
                 }
                 snapshot.session_id = session_id;
                 snapshot.child_session_id = Some(child_session_id);
+                snapshot.selected_model_id = selected_model_id;
+                snapshot.selected_provider_node_id = selected_provider_node_id;
                 snapshot.forked_at = Some(
                     snapshot
                         .forked_at
@@ -429,6 +446,8 @@ mod tests {
                 fork_point_type: ForkPointType::MessageIndex,
                 fork_point_ref: "delegation-1".into(),
                 instructions: None,
+                selected_model_id: Some("provider/model".into()),
+                selected_provider_node_id: Some("node".into()),
             },
         );
         let completed = event(
@@ -448,14 +467,51 @@ mod tests {
         let forked = projector.project_event(&forked).unwrap();
         assert_eq!(forked.state, DelegationUpdateState::Forked);
         assert_eq!(forked.child_session_id.as_deref(), Some("child-1"));
+        assert_eq!(forked.selected_model_id.as_deref(), Some("provider/model"));
+        assert_eq!(forked.selected_provider_node_id.as_deref(), Some("node"));
         assert_eq!(forked.target_agent_id, "coder");
 
         let completed = projector.project_event(&completed).unwrap();
         assert_eq!(completed.state, DelegationUpdateState::Completed);
         assert_eq!(completed.child_session_id.as_deref(), Some("child-1"));
         assert_eq!(completed.result_summary.as_deref(), Some("done"));
+        assert_eq!(
+            completed.selected_model_id.as_deref(),
+            Some("provider/model")
+        );
+        assert_eq!(completed.selected_provider_node_id.as_deref(), Some("node"));
         assert_eq!(completed.finished_at, Some(3));
         assert_eq!(projector.project_event(&requested), Some(completed));
+    }
+
+    #[test]
+    fn historical_fork_without_model_provenance_projects_unknown() {
+        let mut projector = DelegationUpdateProjector::default();
+        projector.project_event(&event(
+            1,
+            AgentEventKind::DelegationRequested {
+                delegation: delegation(),
+                tool_call_id: None,
+            },
+        ));
+        let update = projector
+            .project_event(&event(
+                2,
+                AgentEventKind::SessionForked {
+                    parent_session_id: "parent-1".into(),
+                    child_session_id: "child-1".into(),
+                    target_agent_id: "coder".into(),
+                    origin: ForkOrigin::Delegation,
+                    fork_point_type: ForkPointType::ProgressEntry,
+                    fork_point_ref: "delegation-1".into(),
+                    instructions: None,
+                    selected_model_id: None,
+                    selected_provider_node_id: None,
+                },
+            ))
+            .unwrap();
+        assert!(update.selected_model_id.is_none());
+        assert!(update.selected_provider_node_id.is_none());
     }
 
     #[test]
@@ -522,6 +578,8 @@ mod tests {
                 fork_point_type: ForkPointType::ProgressEntry,
                 fork_point_ref: "delegation-1".into(),
                 instructions: None,
+                selected_model_id: Some("provider/model".into()),
+                selected_provider_node_id: Some("node".into()),
             },
         ));
 
@@ -560,6 +618,8 @@ mod tests {
                 fork_point_type: ForkPointType::ProgressEntry,
                 fork_point_ref: "delegation-1".into(),
                 instructions: None,
+                selected_model_id: Some("provider/model".into()),
+                selected_provider_node_id: Some("node".into()),
             },
         ));
 
@@ -610,6 +670,8 @@ mod tests {
                     fork_point_type: ForkPointType::ProgressEntry,
                     fork_point_ref: "delegation-1".into(),
                     instructions: None,
+                    selected_model_id: Some("provider/model".into()),
+                    selected_provider_node_id: Some("node".into()),
                 },
             ))
             .unwrap();
@@ -618,6 +680,8 @@ mod tests {
         assert_eq!(update.finished_at, completed.finished_at);
         assert_eq!(update.result_summary, completed.result_summary);
         assert_eq!(update.child_session_id.as_deref(), Some("child-1"));
+        assert_eq!(update.selected_model_id.as_deref(), Some("provider/model"));
+        assert_eq!(update.selected_provider_node_id.as_deref(), Some("node"));
     }
 
     #[test]
@@ -673,6 +737,8 @@ mod tests {
                     fork_point_type: ForkPointType::ProgressEntry,
                     fork_point_ref: "delegation-1".into(),
                     instructions: None,
+                    selected_model_id: Some("provider/model".into()),
+                    selected_provider_node_id: Some("node".into()),
                 },
             ),
             event(
@@ -690,6 +756,14 @@ mod tests {
         assert_eq!(updates[0].state, DelegationUpdateState::Completed);
         assert_eq!(updates[0].child_session_id.as_deref(), Some("child-1"));
         assert_eq!(updates[0].tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(
+            updates[0].selected_model_id.as_deref(),
+            Some("provider/model")
+        );
+        assert_eq!(
+            updates[0].selected_provider_node_id.as_deref(),
+            Some("node")
+        );
     }
 
     #[test]

--- a/crates/agent/src/control/mod.rs
+++ b/crates/agent/src/control/mod.rs
@@ -1,4 +1,5 @@
 pub mod capabilities;
+pub mod delegate_models;
 pub mod delegation_notifications;
 pub mod mesh;
 pub mod notifications;

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -933,11 +933,38 @@ async fn execute_delegation(
         .await;
     }
 
-    if let Some(model_override) = ctx
+    let model_override = match ctx
         .delegate_model_overrides
-        .get(&parent_session_id, &delegation.target_agent_id)
+        .resolve(
+            ctx.store.as_ref(),
+            &parent_session_id,
+            &delegation.target_agent_id,
+        )
         .await
     {
+        Ok(model) => model,
+        Err(error) => {
+            let _ = session_ref.shutdown().await;
+            fail_delegation(
+                DelegationFailureContext {
+                    event_sink: &ctx.event_sink,
+                    delegator: &ctx.delegator,
+                    store: &ctx.store,
+                    hooks: Some(&ctx.hooks),
+                    config: &ctx.config,
+                    parent_session_id: &parent_session_id,
+                    delegation_id: &delegation.public_id,
+                    target_agent_id: Some(&delegation.target_agent_id),
+                    objective: Some(&delegation.objective),
+                },
+                &format!("Failed to read delegate model assignment: {error}"),
+            )
+            .await;
+            ctx.active_delegations.lock().await.remove(&delegation_id);
+            return;
+        }
+    };
+    if let Some(model_override) = model_override {
         #[cfg(feature = "remote")]
         let provider_node_id = match model_override.node_id.as_deref() {
             Some(node_id) => match crate::agent::remote::NodeId::parse(node_id) {
@@ -1033,6 +1060,33 @@ async fn execute_delegation(
         return;
     }
 
+    let selected_model = match session_ref.get_session_control().await {
+        Ok(control) => (
+            control.effective_model.model_id,
+            control.effective_model.provider_node_id,
+        ),
+        Err(error) => {
+            let _ = session_ref.shutdown().await;
+            fail_delegation(
+                DelegationFailureContext {
+                    event_sink: &ctx.event_sink,
+                    delegator: &ctx.delegator,
+                    store: &ctx.store,
+                    hooks: Some(&ctx.hooks),
+                    config: &ctx.config,
+                    parent_session_id: &parent_session_id,
+                    delegation_id: &delegation.public_id,
+                    target_agent_id: Some(&delegation.target_agent_id),
+                    objective: Some(&delegation.objective),
+                },
+                &format!("Failed to confirm delegate model before prompt: {error}"),
+            )
+            .await;
+            ctx.active_delegations.lock().await.remove(&delegation_id);
+            return;
+        }
+    };
+
     emit_delegation_event(
         &ctx.delegator,
         &ctx.event_sink,
@@ -1045,6 +1099,8 @@ async fn execute_delegation(
             fork_point_type: ForkPointType::ProgressEntry,
             fork_point_ref: delegation.public_id.clone(),
             instructions: delegation.context.clone(),
+            selected_model_id: Some(selected_model.0),
+            selected_provider_node_id: selected_model.1,
         },
     );
 

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -933,7 +933,7 @@ async fn execute_delegation(
         .await;
     }
 
-    let model_override = match ctx
+    let route_overrides = match ctx
         .delegate_model_overrides
         .resolve(
             ctx.store.as_ref(),
@@ -942,7 +942,7 @@ async fn execute_delegation(
         )
         .await
     {
-        Ok(model) => model,
+        Ok(overrides) => overrides,
         Err(error) => {
             let _ = session_ref.shutdown().await;
             fail_delegation(
@@ -964,7 +964,7 @@ async fn execute_delegation(
             return;
         }
     };
-    if let Some(model_override) = model_override {
+    if let Some(model_override) = route_overrides.model {
         #[cfg(feature = "remote")]
         let provider_node_id = match model_override.node_id.as_deref() {
             Some(node_id) => match crate::agent::remote::NodeId::parse(node_id) {
@@ -1031,13 +1031,16 @@ async fn execute_delegation(
     }
 
     // Apply this after any model override because SetSessionModel rebuilds the
-    // child's LLM configuration. None deliberately propagates the parent's Auto setting.
+    // child's LLM configuration. No role override inherits the parent's current setting.
+    let delegate_reasoning_effort = route_overrides
+        .reasoning_effort
+        .map_or(parent_reasoning_effort, |effort| effort.session_effort());
     if let Err(err) = session_ref
-        .set_reasoning_effort(parent_reasoning_effort)
+        .set_reasoning_effort(delegate_reasoning_effort)
         .await
     {
         let error_message = format!(
-            "Failed to inherit reasoning effort for delegate '{}': {err}",
+            "Failed to apply reasoning effort for delegate '{}': {err}",
             delegation.target_agent_id
         );
         let _ = session_ref.shutdown().await;

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -1073,9 +1073,12 @@ async fn execute_delegation(
             // Missing selected_model_id is allowed on SessionForked. If confirmed
             // model identity later becomes a hard execution/audit precondition,
             // consider failing the delegation here instead of degrading.
-            warn!(
-                "Failed to confirm delegate model for '{}': {error}",
-                delegation.target_agent_id
+            tracing::warn!(
+                delegation_id = %delegation.public_id,
+                child_session_id = %child_session_id,
+                target_agent_id = %delegation.target_agent_id,
+                error = %error,
+                "Failed to confirm delegate model"
             );
             (None, None)
         }

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -1069,6 +1069,10 @@ async fn execute_delegation(
             control.effective_model.provider_node_id,
         ),
         Err(error) => {
+            // Provenance only: the child is already created, routed, and configured.
+            // Missing selected_model_id is allowed on SessionForked. If confirmed
+            // model identity later becomes a hard execution/audit precondition,
+            // consider failing the delegation here instead of degrading.
             warn!(
                 "Failed to confirm delegate model for '{}': {error}",
                 delegation.target_agent_id

--- a/crates/agent/src/delegation/core.rs
+++ b/crates/agent/src/delegation/core.rs
@@ -1065,28 +1065,15 @@ async fn execute_delegation(
 
     let selected_model = match session_ref.get_session_control().await {
         Ok(control) => (
-            control.effective_model.model_id,
+            Some(control.effective_model.model_id),
             control.effective_model.provider_node_id,
         ),
         Err(error) => {
-            let _ = session_ref.shutdown().await;
-            fail_delegation(
-                DelegationFailureContext {
-                    event_sink: &ctx.event_sink,
-                    delegator: &ctx.delegator,
-                    store: &ctx.store,
-                    hooks: Some(&ctx.hooks),
-                    config: &ctx.config,
-                    parent_session_id: &parent_session_id,
-                    delegation_id: &delegation.public_id,
-                    target_agent_id: Some(&delegation.target_agent_id),
-                    objective: Some(&delegation.objective),
-                },
-                &format!("Failed to confirm delegate model before prompt: {error}"),
-            )
-            .await;
-            ctx.active_delegations.lock().await.remove(&delegation_id);
-            return;
+            warn!(
+                "Failed to confirm delegate model for '{}': {error}",
+                delegation.target_agent_id
+            );
+            (None, None)
         }
     };
 
@@ -1102,7 +1089,7 @@ async fn execute_delegation(
             fork_point_type: ForkPointType::ProgressEntry,
             fork_point_ref: delegation.public_id.clone(),
             instructions: delegation.context.clone(),
-            selected_model_id: Some(selected_model.0),
+            selected_model_id: selected_model.0,
             selected_provider_node_id: selected_model.1,
         },
     );

--- a/crates/agent/src/delegation/mod.rs
+++ b/crates/agent/src/delegation/mod.rs
@@ -5,7 +5,10 @@ mod summarizer;
 
 // Re-export public items from core
 pub use core::*;
-pub use model_overrides::{DelegateModelOverride, DelegateModelOverrideStore};
+pub(crate) use model_overrides::DelegateRouteOverrides;
+pub use model_overrides::{
+    DelegateModelOverride, DelegateModelOverrideStore, DelegateReasoningEffort,
+};
 
 // Re-export summarizer
 pub use summarizer::DelegationSummarizer;

--- a/crates/agent/src/delegation/model_overrides.rs
+++ b/crates/agent/src/delegation/model_overrides.rs
@@ -11,9 +11,69 @@ pub struct DelegateModelOverride {
     pub node_id: Option<String>,
 }
 
+#[typeshare]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegateReasoningEffort {
+    Auto,
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl DelegateReasoningEffort {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        }
+    }
+
+    pub(crate) fn session_effort(self) -> Option<querymt::chat::ReasoningEffort> {
+        use querymt::chat::ReasoningEffort;
+        match self {
+            Self::Auto => None,
+            Self::Low => Some(ReasoningEffort::Low),
+            Self::Medium => Some(ReasoningEffort::Medium),
+            Self::High => Some(ReasoningEffort::High),
+            Self::Max => Some(ReasoningEffort::Max),
+        }
+    }
+}
+
+impl std::str::FromStr for DelegateReasoningEffort {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "auto" => Ok(Self::Auto),
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "max" => Ok(Self::Max),
+            _ => Err(format!("Invalid delegate reasoning effort: {value}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DelegateRouteOverrides {
+    pub model: Option<DelegateModelOverride>,
+    pub reasoning_effort: Option<DelegateReasoningEffort>,
+}
+
+#[derive(Debug, Default)]
+struct DelegateOverrideCacheState {
+    values: HashMap<(String, String), DelegateRouteOverrides>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct DelegateModelOverrideStore {
-    overrides: Arc<RwLock<HashMap<(String, String), DelegateModelOverride>>>,
+    state: Arc<RwLock<DelegateOverrideCacheState>>,
 }
 
 impl DelegateModelOverrideStore {
@@ -23,10 +83,11 @@ impl DelegateModelOverrideStore {
         agent_id: impl Into<String>,
         model: DelegateModelOverride,
     ) {
-        self.overrides
-            .write()
-            .await
-            .insert((parent_session_id.into(), agent_id.into()), model);
+        let parent_session_id = parent_session_id.into();
+        let agent_id = agent_id.into();
+        let _ = self
+            .update_route(&parent_session_id, &agent_id, Some(model), None)
+            .await;
     }
 
     pub async fn get(
@@ -34,52 +95,77 @@ impl DelegateModelOverrideStore {
         parent_session_id: &str,
         agent_id: &str,
     ) -> Option<DelegateModelOverride> {
-        self.overrides
+        self.get_route(parent_session_id, agent_id).await.model
+    }
+
+    /// Clear only the model override, matching a request with omitted reasoning.
+    pub async fn clear(&self, parent_session_id: &str, agent_id: &str) {
+        let _ = self
+            .update_route(parent_session_id, agent_id, None, None)
+            .await;
+    }
+
+    pub async fn get_reasoning(
+        &self,
+        parent_session_id: &str,
+        agent_id: &str,
+    ) -> Option<DelegateReasoningEffort> {
+        self.get_route(parent_session_id, agent_id)
+            .await
+            .reasoning_effort
+    }
+
+    pub(crate) async fn get_route(
+        &self,
+        parent_session_id: &str,
+        agent_id: &str,
+    ) -> DelegateRouteOverrides {
+        self.state
             .read()
             .await
+            .values
             .get(&(parent_session_id.to_string(), agent_id.to_string()))
             .cloned()
+            .unwrap_or_default()
     }
 
-    pub async fn clear(&self, parent_session_id: &str, agent_id: &str) {
-        self.overrides
-            .write()
-            .await
-            .remove(&(parent_session_id.to_string(), agent_id.to_string()));
-    }
-
-    pub(crate) async fn update(
+    pub(crate) async fn update_route(
         &self,
         parent_session_id: &str,
         agent_id: &str,
         model: Option<DelegateModelOverride>,
-    ) -> bool {
+        reasoning_effort: Option<Option<DelegateReasoningEffort>>,
+    ) -> (bool, DelegateRouteOverrides) {
         let key = (parent_session_id.to_string(), agent_id.to_string());
-        let mut overrides = self.overrides.write().await;
-        if overrides.get(&key) == model.as_ref() {
-            return false;
+        let mut state = self.state.write().await;
+        let current = state.values.get(&key).cloned().unwrap_or_default();
+        let mut next = current.clone();
+        next.model = model;
+        if let Some(reasoning_effort) = reasoning_effort {
+            next.reasoning_effort = reasoning_effort;
         }
-        match model {
-            Some(model) => {
-                overrides.insert(key, model);
-            }
-            None => {
-                overrides.remove(&key);
-            }
+        if next == current {
+            return (false, current);
         }
-        true
+        if next.model.is_none() && next.reasoning_effort.is_none() {
+            state.values.remove(&key);
+        } else {
+            state.values.insert(key, next.clone());
+        }
+        (true, next)
     }
 
-    pub(crate) async fn list_parent(
+    pub(crate) async fn list_parent_routes(
         &self,
         parent_session_id: &str,
-    ) -> BTreeMap<String, DelegateModelOverride> {
-        self.overrides
+    ) -> BTreeMap<String, DelegateRouteOverrides> {
+        self.state
             .read()
             .await
+            .values
             .iter()
             .filter(|((session_id, _), _)| session_id == parent_session_id)
-            .map(|((_, agent_id), model)| (agent_id.clone(), model.clone()))
+            .map(|((_, agent_id), value)| (agent_id.clone(), value.clone()))
             .collect()
     }
 
@@ -89,17 +175,20 @@ impl DelegateModelOverrideStore {
         store: &dyn crate::session::store::SessionStore,
         parent_session_id: &str,
         agent_id: &str,
-    ) -> crate::session::error::SessionResult<Option<DelegateModelOverride>> {
+    ) -> crate::session::error::SessionResult<DelegateRouteOverrides> {
         match store.get_delegate_assignments(parent_session_id).await? {
-            Some(state) => Ok(state.overrides.get(agent_id).cloned()),
-            None => Ok(self.get(parent_session_id, agent_id).await),
+            Some(state) => Ok(DelegateRouteOverrides {
+                model: state.overrides.get(agent_id).cloned(),
+                reasoning_effort: state.reasoning_overrides.get(agent_id).copied(),
+            }),
+            None => Ok(self.get_route(parent_session_id, agent_id).await),
         }
     }
 
     pub async fn clear_parent(&self, parent_session_id: &str) {
-        self.overrides
-            .write()
-            .await
+        let mut state = self.state.write().await;
+        state
+            .values
             .retain(|(session_id, _), _| session_id != parent_session_id);
     }
 }
@@ -133,6 +222,7 @@ mod tests {
                 .resolve(&storage, &parent.public_id, "coder")
                 .await
                 .unwrap()
+                .model
                 .is_none()
         );
         storage
@@ -143,7 +233,8 @@ mod tests {
             cache
                 .resolve(&storage, &parent.public_id, "coder")
                 .await
-                .unwrap(),
+                .unwrap()
+                .model,
             Some(new)
         );
         storage
@@ -155,6 +246,7 @@ mod tests {
                 .resolve(&storage, &parent.public_id, "coder")
                 .await
                 .unwrap()
+                .model
                 .is_none()
         );
         assert!(cache.resolve(&storage, "missing", "coder").await.is_err());
@@ -164,7 +256,8 @@ mod tests {
             cache
                 .resolve(&unsupported, &parent.public_id, "coder")
                 .await
-                .unwrap(),
+                .unwrap()
+                .model,
             Some(old)
         );
     }
@@ -191,16 +284,39 @@ mod tests {
             Some(second.clone())
         );
 
-        assert_eq!(
-            store.list_parent("parent-1").await,
-            BTreeMap::from([
-                ("coder".into(), first.clone()),
-                ("reviewer".into(), second.clone()),
-            ])
+        let routes = store.list_parent_routes("parent-1").await;
+        assert_eq!(routes["coder"].model, Some(first.clone()));
+        assert_eq!(routes["reviewer"].model, Some(second.clone()));
+        let (changed, route) = store
+            .update_route(
+                "parent-1",
+                "coder",
+                Some(first.clone()),
+                Some(Some(DelegateReasoningEffort::High)),
+            )
+            .await;
+        assert!(changed);
+        assert_eq!(route.model, Some(first.clone()));
+        assert_eq!(route.reasoning_effort, Some(DelegateReasoningEffort::High));
+        let (changed, route) = store.update_route("parent-1", "coder", None, None).await;
+        assert!(changed);
+        assert!(route.model.is_none());
+        assert_eq!(route.reasoning_effort, Some(DelegateReasoningEffort::High));
+        let (changed, route) = store
+            .update_route("parent-1", "coder", None, Some(None))
+            .await;
+        assert!(changed);
+        assert_eq!(route, DelegateRouteOverrides::default());
+        assert!(
+            store
+                .list_parent_routes("parent-1")
+                .await
+                .get("coder")
+                .is_none()
         );
-        assert!(!store.update("parent-1", "coder", Some(first)).await);
-        assert!(store.update("parent-1", "coder", None).await);
-        assert!(!store.update("parent-1", "coder", None).await);
+        let (changed, route) = store.update_route("parent-1", "coder", None, None).await;
+        assert!(!changed);
+        assert_eq!(route, DelegateRouteOverrides::default());
         assert_eq!(store.get("parent-1", "coder").await, None);
         assert_eq!(store.get("parent-2", "coder").await, Some(second));
 

--- a/crates/agent/src/delegation/model_overrides.rs
+++ b/crates/agent/src/delegation/model_overrides.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use typeshare::typeshare;
 
+#[typeshare]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DelegateModelOverride {
     pub model_id: String,
@@ -46,6 +48,54 @@ impl DelegateModelOverrideStore {
             .remove(&(parent_session_id.to_string(), agent_id.to_string()));
     }
 
+    pub(crate) async fn update(
+        &self,
+        parent_session_id: &str,
+        agent_id: &str,
+        model: Option<DelegateModelOverride>,
+    ) -> bool {
+        let key = (parent_session_id.to_string(), agent_id.to_string());
+        let mut overrides = self.overrides.write().await;
+        if overrides.get(&key) == model.as_ref() {
+            return false;
+        }
+        match model {
+            Some(model) => {
+                overrides.insert(key, model);
+            }
+            None => {
+                overrides.remove(&key);
+            }
+        }
+        true
+    }
+
+    pub(crate) async fn list_parent(
+        &self,
+        parent_session_id: &str,
+    ) -> BTreeMap<String, DelegateModelOverride> {
+        self.overrides
+            .read()
+            .await
+            .iter()
+            .filter(|((session_id, _), _)| session_id == parent_session_id)
+            .map(|((_, agent_id), model)| (agent_id.clone(), model.clone()))
+            .collect()
+    }
+
+    /// Durable storage wins even when it contains no override; never resurrect stale cache entries.
+    pub(crate) async fn resolve(
+        &self,
+        store: &dyn crate::session::store::SessionStore,
+        parent_session_id: &str,
+        agent_id: &str,
+    ) -> crate::session::error::SessionResult<Option<DelegateModelOverride>> {
+        match store.get_delegate_assignments(parent_session_id).await? {
+            Some(state) => Ok(state.overrides.get(agent_id).cloned()),
+            None => Ok(self.get(parent_session_id, agent_id).await),
+        }
+    }
+
     pub async fn clear_parent(&self, parent_session_id: &str) {
         self.overrides
             .write()
@@ -57,6 +107,67 @@ impl DelegateModelOverrideStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn durable_delegate_assignments_override_memory_and_propagate_failures() {
+        use crate::session::store::SessionStore;
+        let storage = crate::session::sqlite_storage::SqliteStorage::connect(":memory:".into())
+            .await
+            .unwrap();
+        let parent = storage
+            .create_session(None, None, None, None)
+            .await
+            .unwrap();
+        let cache = DelegateModelOverrideStore::default();
+        let old = DelegateModelOverride {
+            model_id: "provider/stale".into(),
+            node_id: None,
+        };
+        let new = DelegateModelOverride {
+            model_id: "provider/new".into(),
+            node_id: Some("node".into()),
+        };
+        cache.set(&parent.public_id, "coder", old.clone()).await;
+        assert!(
+            cache
+                .resolve(&storage, &parent.public_id, "coder")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        storage
+            .set_delegate_assignment(&parent.public_id, "coder", Some(new.clone()), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            cache
+                .resolve(&storage, &parent.public_id, "coder")
+                .await
+                .unwrap(),
+            Some(new)
+        );
+        storage
+            .set_delegate_assignment(&parent.public_id, "coder", None, None)
+            .await
+            .unwrap();
+        assert!(
+            cache
+                .resolve(&storage, &parent.public_id, "coder")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(cache.resolve(&storage, "missing", "coder").await.is_err());
+        // Existing custom storage implementations retain their explicit in-memory behavior.
+        let unsupported = crate::test_utils::MockSessionStore::new();
+        assert_eq!(
+            cache
+                .resolve(&unsupported, &parent.public_id, "coder")
+                .await
+                .unwrap(),
+            Some(old)
+        );
+    }
 
     #[tokio::test]
     async fn overrides_are_isolated_and_clearable() {
@@ -74,13 +185,22 @@ mod tests {
         store.set("parent-1", "reviewer", second.clone()).await;
         store.set("parent-2", "coder", second.clone()).await;
 
-        assert_eq!(store.get("parent-1", "coder").await, Some(first));
+        assert_eq!(store.get("parent-1", "coder").await, Some(first.clone()));
         assert_eq!(
             store.get("parent-1", "reviewer").await,
             Some(second.clone())
         );
 
-        store.clear("parent-1", "coder").await;
+        assert_eq!(
+            store.list_parent("parent-1").await,
+            BTreeMap::from([
+                ("coder".into(), first.clone()),
+                ("reviewer".into(), second.clone()),
+            ])
+        );
+        assert!(!store.update("parent-1", "coder", Some(first)).await);
+        assert!(store.update("parent-1", "coder", None).await);
+        assert!(!store.update("parent-1", "coder", None).await);
         assert_eq!(store.get("parent-1", "coder").await, None);
         assert_eq!(store.get("parent-2", "coder").await, Some(second));
 

--- a/crates/agent/src/delegation/model_overrides.rs
+++ b/crates/agent/src/delegation/model_overrides.rs
@@ -308,11 +308,10 @@ mod tests {
         assert!(changed);
         assert_eq!(route, DelegateRouteOverrides::default());
         assert!(
-            store
+            !store
                 .list_parent_routes("parent-1")
                 .await
-                .get("coder")
-                .is_none()
+                .contains_key("coder")
         );
         let (changed, route) = store.update_route("parent-1", "coder", None, None).await;
         assert!(!changed);

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -825,6 +825,10 @@ pub fn classify_durability(kind: &AgentEventKind) -> Durability {
         AgentEventKind::RemoteSessionSyncCompleted { .. } => Durability::Ephemeral,
         AgentEventKind::RemoteProviderHeartbeat { .. } => Durability::Ephemeral,
         AgentEventKind::StreamRecovering { .. } => Durability::Ephemeral,
+        // Rationale: the assignment table is authoritative. This is a live
+        // ACP invalidation hint, not a commit record, and must not pollute
+        // the durable journal or break older journal loaders.
+        AgentEventKind::DelegateModelsChanged { .. } => Durability::Ephemeral,
 
         // Everything else is durable by default.
         _ => Durability::Durable,
@@ -1157,6 +1161,18 @@ mod tests {
             node_id: Some("node-1".into()),
         };
         assert_eq!(classify_durability(&kind), Durability::Ephemeral);
+    }
+
+    #[test]
+    fn classify_delegate_models_changed_is_ephemeral() {
+        assert_eq!(
+            classify_durability(&AgentEventKind::DelegateModelsChanged { revision: Some(1) }),
+            Durability::Ephemeral
+        );
+        assert_eq!(
+            classify_durability(&AgentEventKind::DelegateModelsChanged { revision: None }),
+            Durability::Ephemeral
+        );
     }
 
     #[test]

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -423,6 +423,12 @@ pub enum AgentEventKind {
     ArtifactRecorded {
         artifact: Artifact,
     },
+    /// Invalidation hint; clients read the authoritative assignment snapshot after this event.
+    DelegateModelsChanged {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[typeshare(serialized_as = "Option<number>")]
+        revision: Option<u64>,
+    },
     DelegationRequested {
         delegation: Delegation,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -475,6 +481,12 @@ pub enum AgentEventKind {
         fork_point_type: ForkPointType,
         fork_point_ref: String,
         instructions: Option<String>,
+        /// Model confirmed by the child session before its first prompt.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        selected_model_id: Option<String>,
+        /// Mesh node confirmed with the selected model, or None for local execution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        selected_provider_node_id: Option<String>,
     },
     /// Emitted once at session creation with environment configuration
     SessionConfigured {
@@ -945,6 +957,41 @@ mod tests {
             kind,
             AgentEventKind::UserPromptBlock {
                 client_prompt_id: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn delegate_models_changed_without_revision_omits_event_field() {
+        let value =
+            serde_json::to_value(AgentEventKind::DelegateModelsChanged { revision: None }).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({"type": "delegate_models_changed", "data": {}})
+        );
+    }
+
+    #[test]
+    fn historical_session_fork_without_model_provenance_deserializes() {
+        let value = serde_json::json!({
+            "type": "session_forked",
+            "data": {
+                "parent_session_id": "parent",
+                "child_session_id": "child",
+                "target_agent_id": "coder",
+                "origin": "delegation",
+                "fork_point_type": "progress_entry",
+                "fork_point_ref": "delegation-1",
+                "instructions": null
+            }
+        });
+        let kind: AgentEventKind = serde_json::from_value(value).unwrap();
+        assert!(matches!(
+            kind,
+            AgentEventKind::SessionForked {
+                selected_model_id: None,
+                selected_provider_node_id: None,
                 ..
             }
         ));

--- a/crates/agent/src/session/error.rs
+++ b/crates/agent/src/session/error.rs
@@ -66,6 +66,10 @@ pub enum SessionError {
     #[error("session control revision conflict: expected {expected}, found {found}")]
     SessionControlRevisionConflict { expected: u64, found: u64 },
 
+    /// A delegate assignment snapshot was superseded by another writer.
+    #[error("delegate assignment revision conflict: expected {expected}, found {found}")]
+    DelegateAssignmentRevisionConflict { expected: u64, found: u64 },
+
     /// Provider error (from LLM operations)
     #[error("Provider error: {0}")]
     ProviderError(#[from] LLMError),
@@ -108,6 +112,11 @@ impl From<SessionError> for LLMError {
             SessionError::SessionControlRevisionConflict { expected, found } => {
                 LLMError::InvalidRequest(format!(
                     "session control revision conflict: expected {expected}, found {found}"
+                ))
+            }
+            SessionError::DelegateAssignmentRevisionConflict { expected, found } => {
+                LLMError::InvalidRequest(format!(
+                    "delegate assignment revision conflict: expected {expected}, found {found}"
                 ))
             }
             SessionError::ForkPointTypeMismatch { expected, actual } => {

--- a/crates/agent/src/session/sqlite_storage/migrations.rs
+++ b/crates/agent/src/session/sqlite_storage/migrations.rs
@@ -86,8 +86,23 @@ fn migration_0017_delegate_assignments(conn: &mut Connection) -> Result<(), rusq
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS session_delegate_assignments (
             session_id INTEGER PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
-            revision INTEGER NOT NULL CHECK (revision >= 0),
-            overrides_json TEXT NOT NULL
+            revision INTEGER NOT NULL CHECK (revision >= 0)
+        );
+        CREATE TABLE IF NOT EXISTS session_delegate_assignment_overrides (
+            session_id INTEGER NOT NULL REFERENCES session_delegate_assignments(session_id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL,
+            model_id TEXT,
+            provider_node_id TEXT,
+            reasoning_effort TEXT,
+            PRIMARY KEY (session_id, agent_id),
+            CHECK (length(agent_id) > 0 AND agent_id = trim(agent_id)),
+            CHECK (model_id IS NULL OR (length(model_id) > 0 AND model_id = trim(model_id))),
+            CHECK (provider_node_id IS NULL OR (
+                model_id IS NOT NULL AND length(provider_node_id) > 0
+                AND provider_node_id = trim(provider_node_id)
+            )),
+            CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('auto', 'low', 'medium', 'high', 'max')),
+            CHECK (model_id IS NOT NULL OR reasoning_effort IS NOT NULL)
         );",
     )
 }

--- a/crates/agent/src/session/sqlite_storage/migrations.rs
+++ b/crates/agent/src/session/sqlite_storage/migrations.rs
@@ -76,7 +76,21 @@ pub(super) const MIGRATIONS: &[Migration] = &[
         version: "0016_remote_sync_progress",
         apply: migration_0016_remote_sync_progress,
     },
+    Migration {
+        version: "0017_delegate_assignments",
+        apply: migration_0017_delegate_assignments,
+    },
 ];
+
+fn migration_0017_delegate_assignments(conn: &mut Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS session_delegate_assignments (
+            session_id INTEGER PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+            revision INTEGER NOT NULL CHECK (revision >= 0),
+            overrides_json TEXT NOT NULL
+        );",
+    )
+}
 
 pub(super) fn apply_migrations(conn: &mut Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -40,38 +40,75 @@ fn read_delegate_assignments(
 ) -> SessionResult<(i64, DelegateAssignments)> {
     let row = conn
         .query_row(
-            "SELECT s.id, d.revision, d.overrides_json FROM sessions s
-         LEFT JOIN session_delegate_assignments d ON d.session_id = s.id WHERE s.public_id = ?1",
+            "SELECT s.id, d.revision FROM sessions s
+             LEFT JOIN session_delegate_assignments d ON d.session_id = s.id
+             WHERE s.public_id = ?1",
             [session_id],
-            |row| {
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, Option<i64>>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                ))
-            },
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<i64>>(1)?)),
         )
         .optional()?;
-    let (id, revision, json) =
-        row.ok_or_else(|| SessionError::SessionNotFound(session_id.to_owned()))?;
+    let (id, revision) = row.ok_or_else(|| SessionError::SessionNotFound(session_id.to_owned()))?;
     let revision = u64::try_from(revision.unwrap_or(0))
         .map_err(|_| SessionError::DatabaseError("Negative delegate assignment revision".into()))?;
-    let overrides = match json {
-        Some(json) => serde_json::from_str(&json)?,
-        None => Default::default(),
-    };
-    validate_delegate_assignments(&overrides, SessionError::DatabaseError)?;
+    let mut stmt = conn.prepare(
+        "SELECT agent_id, model_id, provider_node_id, reasoning_effort
+         FROM session_delegate_assignment_overrides WHERE session_id = ?1",
+    )?;
+    let rows = stmt.query_map([id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, Option<String>>(3)?,
+        ))
+    })?;
+    let mut overrides = std::collections::BTreeMap::new();
+    let mut reasoning_overrides = std::collections::BTreeMap::new();
+    for row in rows {
+        let (agent_id, model_id, node_id, reasoning_effort) = row?;
+        if model_id.is_none() && (node_id.is_some() || reasoning_effort.is_none()) {
+            return Err(SessionError::DatabaseError(
+                "Invalid delegate assignment row".into(),
+            ));
+        }
+        if let Some(model_id) = model_id {
+            overrides.insert(
+                agent_id.clone(),
+                crate::delegation::DelegateModelOverride { model_id, node_id },
+            );
+        }
+        if let Some(reasoning_effort) = reasoning_effort {
+            let reasoning_effort = reasoning_effort.parse().map_err(|error: String| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    3,
+                    rusqlite::types::Type::Text,
+                    Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
+                )
+            })?;
+            reasoning_overrides.insert(agent_id, reasoning_effort);
+        }
+    }
+    validate_delegate_assignments(
+        &overrides,
+        &reasoning_overrides,
+        SessionError::DatabaseError,
+    )?;
     Ok((
         id,
         DelegateAssignments {
             revision,
             overrides,
+            reasoning_overrides,
         },
     ))
 }
 
 fn validate_delegate_assignments(
     overrides: &std::collections::BTreeMap<String, crate::delegation::DelegateModelOverride>,
+    reasoning_overrides: &std::collections::BTreeMap<
+        String,
+        crate::delegation::DelegateReasoningEffort,
+    >,
     error: impl Fn(String) -> SessionError,
 ) -> SessionResult<()> {
     for (agent_id, model) in overrides {
@@ -86,6 +123,14 @@ fn validate_delegate_assignments(
         {
             return Err(error("Invalid delegate assignment identity".into()));
         }
+    }
+    if reasoning_overrides
+        .keys()
+        .any(|agent_id| agent_id.is_empty() || agent_id.trim() != agent_id)
+    {
+        return Err(error(
+            "Invalid delegate reasoning assignment identity".into(),
+        ));
     }
     Ok(())
 }
@@ -584,13 +629,22 @@ impl SessionStore for SqliteStorage {
                 )?;
             }
 
-            // User forks inherit routing preferences, but delegated children do not.
+            // User forks inherit an independent routing snapshot; delegated children do not.
             if fork_origin == ForkOrigin::User {
-                tx.execute(
-                    "INSERT INTO session_delegate_assignments (session_id, revision, overrides_json)
-                     SELECT ?1, 0, overrides_json FROM session_delegate_assignments WHERE session_id = ?2",
+                let copied = tx.execute(
+                    "INSERT INTO session_delegate_assignments (session_id, revision)
+                     SELECT ?1, 0 FROM session_delegate_assignments WHERE session_id = ?2",
                     params![new_session_internal_id, source_session_internal_id],
                 )?;
+                if copied > 0 {
+                    tx.execute(
+                        "INSERT INTO session_delegate_assignment_overrides
+                         (session_id, agent_id, model_id, provider_node_id, reasoning_effort)
+                         SELECT ?1, agent_id, model_id, provider_node_id, reasoning_effort
+                         FROM session_delegate_assignment_overrides WHERE session_id = ?2",
+                        params![new_session_internal_id, source_session_internal_id],
+                    )?;
+                }
             }
 
             // Forks inherit an independent copy of the source session's control state.
@@ -842,6 +896,24 @@ impl SessionStore for SqliteStorage {
         model: Option<crate::delegation::DelegateModelOverride>,
         expected_revision: Option<u64>,
     ) -> SessionResult<DelegateAssignmentWrite> {
+        self.set_delegate_assignment_with_reasoning(
+            session_id,
+            agent_id,
+            model,
+            None,
+            expected_revision,
+        )
+        .await
+    }
+
+    async fn set_delegate_assignment_with_reasoning(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        model: Option<crate::delegation::DelegateModelOverride>,
+        reasoning_effort: Option<Option<crate::delegation::DelegateReasoningEffort>>,
+        expected_revision: Option<u64>,
+    ) -> SessionResult<DelegateAssignmentWrite> {
         let mut candidate = std::collections::BTreeMap::new();
         if let Some(model) = &model {
             candidate.insert(agent_id.to_owned(), model.clone());
@@ -850,7 +922,15 @@ impl SessionStore for SqliteStorage {
                 "Delegate IDs must be nonempty and normalized".into(),
             ));
         }
-        validate_delegate_assignments(&candidate, SessionError::InvalidOperation)?;
+        let mut reasoning_candidate = std::collections::BTreeMap::new();
+        if let Some(Some(reasoning_effort)) = reasoning_effort {
+            reasoning_candidate.insert(agent_id.to_owned(), reasoning_effort);
+        }
+        validate_delegate_assignments(
+            &candidate,
+            &reasoning_candidate,
+            SessionError::InvalidOperation,
+        )?;
         let session_id = session_id.to_owned();
         let agent_id = agent_id.to_owned();
         self.run_blocking_session(move |conn| {
@@ -860,32 +940,87 @@ impl SessionStore for SqliteStorage {
             if let Some(expected) = expected_revision
                 && expected != state.revision
             {
-                return Err(SessionError::DelegateAssignmentRevisionConflict { expected, found: state.revision });
+                return Err(SessionError::DelegateAssignmentRevisionConflict {
+                    expected,
+                    found: state.revision,
+                });
             }
-            if state.overrides.get(&agent_id) == model.as_ref() {
+            let model_unchanged = state.overrides.get(&agent_id) == model.as_ref();
+            let reasoning_unchanged = reasoning_effort
+                .as_ref()
+                .is_none_or(|value| state.reasoning_overrides.get(&agent_id) == value.as_ref());
+            if model_unchanged && reasoning_unchanged {
                 return Ok(DelegateAssignmentWrite {
                     assignments: state,
                     changed: false,
                 });
             }
             match model {
-                Some(model) => { state.overrides.insert(agent_id, model); }
-                None => { state.overrides.remove(&agent_id); }
+                Some(model) => {
+                    state.overrides.insert(agent_id.clone(), model);
+                }
+                None => {
+                    state.overrides.remove(&agent_id);
+                }
             }
-            let revision = i64::try_from(state.revision).ok().and_then(|r| r.checked_add(1))
-                .ok_or_else(|| SessionError::InvalidOperation("Delegate assignment revision exhausted".into()))?;
+            if let Some(reasoning_effort) = reasoning_effort {
+                match reasoning_effort {
+                    Some(reasoning_effort) => {
+                        state
+                            .reasoning_overrides
+                            .insert(agent_id.clone(), reasoning_effort);
+                    }
+                    None => {
+                        state.reasoning_overrides.remove(&agent_id);
+                    }
+                }
+            }
+            let revision = i64::try_from(state.revision)
+                .ok()
+                .and_then(|r| r.checked_add(1))
+                .ok_or_else(|| {
+                    SessionError::InvalidOperation("Delegate assignment revision exhausted".into())
+                })?;
             state.revision = revision as u64;
             tx.execute(
-                "INSERT INTO session_delegate_assignments (session_id, revision, overrides_json) VALUES (?1, ?2, ?3)
-                 ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision, overrides_json = excluded.overrides_json",
-                params![id, revision, serde_json::to_string(&state.overrides)?],
+                "INSERT INTO session_delegate_assignments (session_id, revision) VALUES (?1, ?2)
+                 ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision",
+                params![id, revision],
             )?;
+            let current_model = state.overrides.get(&agent_id);
+            let current_reasoning = state.reasoning_overrides.get(&agent_id);
+            if current_model.is_none() && current_reasoning.is_none() {
+                tx.execute(
+                    "DELETE FROM session_delegate_assignment_overrides
+                     WHERE session_id = ?1 AND agent_id = ?2",
+                    params![id, agent_id],
+                )?;
+            } else {
+                let reasoning_effort = current_reasoning.map(|effort| effort.as_str());
+                tx.execute(
+                    "INSERT INTO session_delegate_assignment_overrides
+                     (session_id, agent_id, model_id, provider_node_id, reasoning_effort)
+                     VALUES (?1, ?2, ?3, ?4, ?5)
+                     ON CONFLICT(session_id, agent_id) DO UPDATE SET
+                       model_id = excluded.model_id,
+                       provider_node_id = excluded.provider_node_id,
+                       reasoning_effort = excluded.reasoning_effort",
+                    params![
+                        id,
+                        agent_id,
+                        current_model.map(|model| model.model_id.as_str()),
+                        current_model.and_then(|model| model.node_id.as_deref()),
+                        reasoning_effort,
+                    ],
+                )?;
+            }
             tx.commit()?;
             Ok(DelegateAssignmentWrite {
                 assignments: state,
                 changed: true,
             })
-        }).await
+        })
+        .await
     }
 
     async fn commit_session_control(

--- a/crates/agent/src/session/sqlite_storage/session_store.rs
+++ b/crates/agent/src/session/sqlite_storage/session_store.rs
@@ -26,13 +26,69 @@ use crate::session::repository::{
     ProgressRepository, SessionRepository, TaskRepository,
 };
 use crate::session::store::{
-    CustomModel, LLMConfig, RemoteSessionBookmark, Session, SessionExecutionConfig, SessionStore,
-    TaskPatch, extract_llm_config_values,
+    CustomModel, DelegateAssignmentWrite, DelegateAssignments, LLMConfig, RemoteSessionBookmark,
+    Session, SessionExecutionConfig, SessionStore, TaskPatch, extract_llm_config_values,
 };
 use std::collections::HashMap;
 
 use super::SqliteStorage;
 use super::row_parsers::{parse_llm_config_row, parse_llm_params};
+
+fn read_delegate_assignments(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+) -> SessionResult<(i64, DelegateAssignments)> {
+    let row = conn
+        .query_row(
+            "SELECT s.id, d.revision, d.overrides_json FROM sessions s
+         LEFT JOIN session_delegate_assignments d ON d.session_id = s.id WHERE s.public_id = ?1",
+            [session_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let (id, revision, json) =
+        row.ok_or_else(|| SessionError::SessionNotFound(session_id.to_owned()))?;
+    let revision = u64::try_from(revision.unwrap_or(0))
+        .map_err(|_| SessionError::DatabaseError("Negative delegate assignment revision".into()))?;
+    let overrides = match json {
+        Some(json) => serde_json::from_str(&json)?,
+        None => Default::default(),
+    };
+    validate_delegate_assignments(&overrides, SessionError::DatabaseError)?;
+    Ok((
+        id,
+        DelegateAssignments {
+            revision,
+            overrides,
+        },
+    ))
+}
+
+fn validate_delegate_assignments(
+    overrides: &std::collections::BTreeMap<String, crate::delegation::DelegateModelOverride>,
+    error: impl Fn(String) -> SessionError,
+) -> SessionResult<()> {
+    for (agent_id, model) in overrides {
+        if agent_id.is_empty()
+            || agent_id.trim() != agent_id
+            || model.model_id.is_empty()
+            || model.model_id.trim() != model.model_id
+            || model
+                .node_id
+                .as_ref()
+                .is_some_and(|node_id| node_id.is_empty() || node_id.trim() != node_id)
+        {
+            return Err(error("Invalid delegate assignment identity".into()));
+        }
+    }
+    Ok(())
+}
 
 fn insert_intent_snapshot(
     conn: &rusqlite::Connection,
@@ -528,6 +584,15 @@ impl SessionStore for SqliteStorage {
                 )?;
             }
 
+            // User forks inherit routing preferences, but delegated children do not.
+            if fork_origin == ForkOrigin::User {
+                tx.execute(
+                    "INSERT INTO session_delegate_assignments (session_id, revision, overrides_json)
+                     SELECT ?1, 0, overrides_json FROM session_delegate_assignments WHERE session_id = ?2",
+                    params![new_session_internal_id, source_session_internal_id],
+                )?;
+            }
+
             // Forks inherit an independent copy of the source session's control state.
             tx.execute(
                 "INSERT INTO session_control_states
@@ -757,6 +822,70 @@ impl SessionStore for SqliteStorage {
             }))
         })
         .await
+    }
+
+    async fn get_delegate_assignments(
+        &self,
+        session_id: &str,
+    ) -> SessionResult<Option<DelegateAssignments>> {
+        let session_id = session_id.to_owned();
+        self.run_blocking_session(move |conn| {
+            read_delegate_assignments(conn, &session_id).map(|(_, state)| Some(state))
+        })
+        .await
+    }
+
+    async fn set_delegate_assignment(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        model: Option<crate::delegation::DelegateModelOverride>,
+        expected_revision: Option<u64>,
+    ) -> SessionResult<DelegateAssignmentWrite> {
+        let mut candidate = std::collections::BTreeMap::new();
+        if let Some(model) = &model {
+            candidate.insert(agent_id.to_owned(), model.clone());
+        } else if agent_id.is_empty() || agent_id.trim() != agent_id {
+            return Err(SessionError::InvalidOperation(
+                "Delegate IDs must be nonempty and normalized".into(),
+            ));
+        }
+        validate_delegate_assignments(&candidate, SessionError::InvalidOperation)?;
+        let session_id = session_id.to_owned();
+        let agent_id = agent_id.to_owned();
+        self.run_blocking_session(move |conn| {
+            // An immediate transaction protects the read/modify/write across independent connections.
+            let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+            let (id, mut state) = read_delegate_assignments(&tx, &session_id)?;
+            if let Some(expected) = expected_revision
+                && expected != state.revision
+            {
+                return Err(SessionError::DelegateAssignmentRevisionConflict { expected, found: state.revision });
+            }
+            if state.overrides.get(&agent_id) == model.as_ref() {
+                return Ok(DelegateAssignmentWrite {
+                    assignments: state,
+                    changed: false,
+                });
+            }
+            match model {
+                Some(model) => { state.overrides.insert(agent_id, model); }
+                None => { state.overrides.remove(&agent_id); }
+            }
+            let revision = i64::try_from(state.revision).ok().and_then(|r| r.checked_add(1))
+                .ok_or_else(|| SessionError::InvalidOperation("Delegate assignment revision exhausted".into()))?;
+            state.revision = revision as u64;
+            tx.execute(
+                "INSERT INTO session_delegate_assignments (session_id, revision, overrides_json) VALUES (?1, ?2, ?3)
+                 ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision, overrides_json = excluded.overrides_json",
+                params![id, revision, serde_json::to_string(&state.overrides)?],
+            )?;
+            tx.commit()?;
+            Ok(DelegateAssignmentWrite {
+                assignments: state,
+                changed: true,
+            })
+        }).await
     }
 
     async fn commit_session_control(

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -224,6 +224,7 @@ async fn delegate_assignments_are_read_only_revisioned_and_session_scoped() {
         .unwrap();
     assert_eq!(original.revision, 0);
     assert!(original.overrides.is_empty());
+    assert!(original.reasoning_overrides.is_empty());
     let rows = storage
         .conn_for_test()
         .lock()
@@ -246,12 +247,27 @@ async fn delegate_assignments_are_read_only_revisioned_and_session_scoped() {
     assert!(one.changed);
     assert_eq!(one.assignments.revision, 1);
     assert_eq!(one.assignments.overrides["coder"], model);
+    let reasoning = storage
+        .set_delegate_assignment_with_reasoning(
+            &first.public_id,
+            "coder",
+            Some(model.clone()),
+            Some(Some(crate::delegation::DelegateReasoningEffort::High)),
+            Some(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(reasoning.assignments.revision, 2);
+    assert_eq!(
+        reasoning.assignments.reasoning_overrides["coder"],
+        crate::delegation::DelegateReasoningEffort::High
+    );
     let noop = storage
-        .set_delegate_assignment(&first.public_id, "coder", Some(model.clone()), Some(1))
+        .set_delegate_assignment(&first.public_id, "coder", Some(model.clone()), Some(2))
         .await
         .unwrap();
     assert!(!noop.changed);
-    assert_eq!(noop.assignments, one.assignments);
+    assert_eq!(noop.assignments, reasoning.assignments);
     let stale = storage
         .set_delegate_assignment(&first.public_id, "coder", None, Some(0))
         .await
@@ -260,20 +276,45 @@ async fn delegate_assignments_are_read_only_revisioned_and_session_scoped() {
         stale,
         SessionError::DelegateAssignmentRevisionConflict {
             expected: 0,
-            found: 1
+            found: 2
         }
     ));
     let two = storage
         .set_delegate_assignment(&first.public_id, "reviewer", Some(model.clone()), None)
         .await
         .unwrap();
-    assert_eq!(two.assignments.revision, 2);
+    assert_eq!(two.assignments.revision, 3);
     let cleared = storage
-        .set_delegate_assignment(&first.public_id, "coder", None, Some(2))
+        .set_delegate_assignment_with_reasoning(
+            &first.public_id,
+            "coder",
+            None,
+            Some(None),
+            Some(3),
+        )
         .await
         .unwrap();
-    assert_eq!(cleared.assignments.revision, 3);
+    assert_eq!(cleared.assignments.revision, 4);
     assert!(!cleared.assignments.overrides.contains_key("coder"));
+    assert!(
+        !cleared
+            .assignments
+            .reasoning_overrides
+            .contains_key("coder")
+    );
+    let cleared_rows = storage
+        .conn_for_test()
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM session_delegate_assignment_overrides o
+             JOIN sessions s ON s.id = o.session_id
+             WHERE s.public_id = ?1 AND o.agent_id = 'coder'",
+            [&first.public_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(cleared_rows, 0, "empty role overrides must delete the row");
     assert_eq!(cleared.assignments.overrides["reviewer"], model);
     assert!(
         storage
@@ -451,15 +492,44 @@ async fn delegate_assignments_rollback_failed_writes_and_do_not_hide_corruption(
             .unwrap(),
         before.assignments
     );
-    storage.run_blocking(|conn| conn.execute_batch(
-        "DROP TRIGGER reject_delegate_update; UPDATE session_delegate_assignments SET overrides_json = 'broken';"
-    )).await.unwrap();
+    storage
+        .run_blocking(|conn| {
+            conn.execute_batch(
+                "DROP TRIGGER reject_delegate_update;
+         PRAGMA ignore_check_constraints = ON;
+         INSERT INTO session_delegate_assignment_overrides
+           (session_id, agent_id, model_id, provider_node_id, reasoning_effort)
+         SELECT id, 'broken', NULL, NULL, NULL
+         FROM sessions WHERE public_id = (SELECT public_id FROM sessions LIMIT 1);
+         PRAGMA ignore_check_constraints = OFF;",
+            )
+        })
+        .await
+        .unwrap();
     assert!(
         storage
             .get_delegate_assignments(&parent.public_id)
             .await
             .is_err(),
-        "corrupt state must not be displayed as inheritance"
+        "empty corrupt rows must not be displayed as inheritance"
+    );
+    storage
+        .run_blocking(|conn| {
+            conn.execute_batch(
+                "PRAGMA ignore_check_constraints = ON;
+                 UPDATE session_delegate_assignment_overrides
+                 SET reasoning_effort = 'invalid' WHERE agent_id = 'broken';
+                 PRAGMA ignore_check_constraints = OFF;",
+            )
+        })
+        .await
+        .unwrap();
+    assert!(
+        storage
+            .get_delegate_assignments(&parent.public_id)
+            .await
+            .is_err(),
+        "invalid reasoning values must not be displayed as inheritance"
     );
 }
 
@@ -475,7 +545,13 @@ async fn delegate_assignments_user_forks_inherit_but_delegate_children_do_not() 
         node_id: None,
     };
     storage
-        .set_delegate_assignment(&parent.public_id, "coder", Some(model.clone()), None)
+        .set_delegate_assignment_with_reasoning(
+            &parent.public_id,
+            "coder",
+            Some(model.clone()),
+            Some(Some(crate::delegation::DelegateReasoningEffort::Low)),
+            None,
+        )
         .await
         .unwrap();
     storage
@@ -513,6 +589,15 @@ async fn delegate_assignments_user_forks_inherit_but_delegate_children_do_not() 
             .overrides["coder"],
         model
     );
+    assert_eq!(
+        storage
+            .get_delegate_assignments(&fork)
+            .await
+            .unwrap()
+            .unwrap()
+            .reasoning_overrides["coder"],
+        crate::delegation::DelegateReasoningEffort::Low
+    );
     assert!(
         storage
             .get_delegate_assignments(&child)
@@ -538,8 +623,9 @@ async fn delegate_assignments_user_forks_inherit_but_delegate_children_do_not() 
 }
 
 #[test]
-fn delegate_assignment_migration_preserves_existing_records() {
+fn delegate_assignment_migration_creates_normalized_schema_and_preserves_sessions() {
     let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
     // Model an upgrade from main's prior schema rather than only testing fresh databases.
     for migration in MIGRATIONS
         .iter()
@@ -554,14 +640,101 @@ fn delegate_assignment_migration_preserves_existing_records() {
         .unwrap();
     (migration.apply)(&mut conn).unwrap();
     (migration.apply)(&mut conn).unwrap();
+
+    for (table, expected_columns) in [
+        (
+            "session_delegate_assignments",
+            vec!["session_id", "revision"],
+        ),
+        (
+            "session_delegate_assignment_overrides",
+            vec![
+                "session_id",
+                "agent_id",
+                "model_id",
+                "provider_node_id",
+                "reasoning_effort",
+            ],
+        ),
+    ] {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap();
+        let columns = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(columns, expected_columns, "unexpected schema for {table}");
+    }
+
     let name: String = conn
         .query_row(
             "SELECT name FROM sessions WHERE public_id = 'existing'",
             [],
-            |r| r.get(0),
+            |row| row.get(0),
         )
         .unwrap();
     assert_eq!(name, "Keep me");
+    conn.execute(
+        "INSERT INTO session_delegate_assignments (session_id, revision)
+         SELECT id, 0 FROM sessions WHERE public_id = 'existing'",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO session_delegate_assignment_overrides
+         (session_id, agent_id, model_id, provider_node_id, reasoning_effort)
+         SELECT id, 'reasoner', NULL, NULL, 'high' FROM sessions WHERE public_id = 'existing'",
+        [],
+    )
+    .unwrap();
+    let reasoning_only: (Option<String>, String) = conn
+        .query_row(
+            "SELECT model_id, reasoning_effort FROM session_delegate_assignment_overrides
+             WHERE agent_id = 'reasoner'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(reasoning_only, (None, "high".into()));
+    assert!(
+        conn.execute(
+            "INSERT INTO session_delegate_assignment_overrides
+             (session_id, agent_id, model_id, provider_node_id, reasoning_effort)
+             SELECT id, 'invalid', NULL, NULL, 'extreme' FROM sessions WHERE public_id = 'existing'",
+            [],
+        )
+        .is_err(),
+        "invalid reasoning values must fail the schema constraint"
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO session_delegate_assignment_overrides
+             (session_id, agent_id, model_id, provider_node_id, reasoning_effort)
+             SELECT id, 'empty', NULL, NULL, NULL FROM sessions WHERE public_id = 'existing'",
+            [],
+        )
+        .is_err(),
+        "empty role rows must fail the schema constraint"
+    );
+
+    conn.execute("DELETE FROM sessions WHERE public_id = 'existing'", [])
+        .unwrap();
+    for table in [
+        "session_delegate_assignments",
+        "session_delegate_assignment_overrides",
+    ] {
+        let count: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            count, 0,
+            "deleting the session must cascade through {table}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -244,8 +244,8 @@ async fn delegate_assignments_are_read_only_revisioned_and_session_scoped() {
         .await
         .unwrap();
     assert!(one.changed);
-    assert_eq!(one.revision, 1);
-    assert_eq!(one.overrides["coder"], model);
+    assert_eq!(one.assignments.revision, 1);
+    assert_eq!(one.assignments.overrides["coder"], model);
     let noop = storage
         .set_delegate_assignment(&first.public_id, "coder", Some(model.clone()), Some(1))
         .await
@@ -267,14 +267,14 @@ async fn delegate_assignments_are_read_only_revisioned_and_session_scoped() {
         .set_delegate_assignment(&first.public_id, "reviewer", Some(model.clone()), None)
         .await
         .unwrap();
-    assert_eq!(two.revision, 2);
+    assert_eq!(two.assignments.revision, 2);
     let cleared = storage
         .set_delegate_assignment(&first.public_id, "coder", None, Some(2))
         .await
         .unwrap();
-    assert_eq!(cleared.revision, 3);
-    assert!(!cleared.overrides.contains_key("coder"));
-    assert_eq!(cleared.overrides["reviewer"], model);
+    assert_eq!(cleared.assignments.revision, 3);
+    assert!(!cleared.assignments.overrides.contains_key("coder"));
+    assert_eq!(cleared.assignments.overrides["reviewer"], model);
     assert!(
         storage
             .get_delegate_assignments(&second.public_id)
@@ -383,7 +383,7 @@ async fn delegate_assignments_survive_reopen_and_detect_cross_connection_conflic
         .await
         .unwrap();
     assert!(!noop.changed, "cross-connection no-op must be explicit");
-    assert_eq!(noop.revision, 1);
+    assert_eq!(noop.assignments.revision, 1);
     let (a, b) = tokio::join!(
         first.set_delegate_assignment(&parent.public_id, "a", Some(model.clone()), Some(1)),
         second.set_delegate_assignment(&parent.public_id, "b", Some(model), Some(1)),

--- a/crates/agent/src/session/sqlite_storage/tests.rs
+++ b/crates/agent/src/session/sqlite_storage/tests.rs
@@ -205,6 +205,366 @@ fn migration_0014_adds_session_control_tables() {
 }
 
 #[tokio::test]
+async fn delegate_assignments_are_read_only_revisioned_and_session_scoped() {
+    use crate::delegation::DelegateModelOverride;
+    use crate::session::error::SessionError;
+    let storage = SqliteStorage::connect(":memory:".into()).await.unwrap();
+    let first = storage
+        .create_session(None, None, None, None)
+        .await
+        .unwrap();
+    let second = storage
+        .create_session(None, None, None, None)
+        .await
+        .unwrap();
+    let original = storage
+        .get_delegate_assignments(&first.public_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(original.revision, 0);
+    assert!(original.overrides.is_empty());
+    let rows = storage
+        .conn_for_test()
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM session_delegate_assignments",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 0, "read must not create assignment state");
+    let model = DelegateModelOverride {
+        model_id: "provider/model".into(),
+        node_id: Some("mesh-node".into()),
+    };
+    let one = storage
+        .set_delegate_assignment(&first.public_id, "coder", Some(model.clone()), Some(0))
+        .await
+        .unwrap();
+    assert!(one.changed);
+    assert_eq!(one.revision, 1);
+    assert_eq!(one.overrides["coder"], model);
+    let noop = storage
+        .set_delegate_assignment(&first.public_id, "coder", Some(model.clone()), Some(1))
+        .await
+        .unwrap();
+    assert!(!noop.changed);
+    assert_eq!(noop.assignments, one.assignments);
+    let stale = storage
+        .set_delegate_assignment(&first.public_id, "coder", None, Some(0))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        stale,
+        SessionError::DelegateAssignmentRevisionConflict {
+            expected: 0,
+            found: 1
+        }
+    ));
+    let two = storage
+        .set_delegate_assignment(&first.public_id, "reviewer", Some(model.clone()), None)
+        .await
+        .unwrap();
+    assert_eq!(two.revision, 2);
+    let cleared = storage
+        .set_delegate_assignment(&first.public_id, "coder", None, Some(2))
+        .await
+        .unwrap();
+    assert_eq!(cleared.revision, 3);
+    assert!(!cleared.overrides.contains_key("coder"));
+    assert_eq!(cleared.overrides["reviewer"], model);
+    assert!(
+        storage
+            .get_delegate_assignments(&second.public_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .overrides
+            .is_empty()
+    );
+    assert!(matches!(
+        storage.get_delegate_assignments("missing").await,
+        Err(SessionError::SessionNotFound(_))
+    ));
+    assert!(
+        storage
+            .set_delegate_assignment("missing", "coder", None, None)
+            .await
+            .is_err()
+    );
+    assert!(
+        storage
+            .set_delegate_assignment(&first.public_id, "", None, None)
+            .await
+            .is_err()
+    );
+    assert!(
+        storage
+            .set_delegate_assignment(&first.public_id, " coder ", Some(model.clone()), None)
+            .await
+            .is_err()
+    );
+    assert!(
+        storage
+            .set_delegate_assignment(
+                &first.public_id,
+                "coder",
+                Some(DelegateModelOverride {
+                    model_id: " provider/model ".into(),
+                    node_id: None
+                }),
+                None
+            )
+            .await
+            .is_err()
+    );
+    assert!(
+        storage
+            .set_delegate_assignment(
+                &first.public_id,
+                "coder",
+                Some(DelegateModelOverride {
+                    model_id: "provider/model".into(),
+                    node_id: Some(" ".into())
+                }),
+                None
+            )
+            .await
+            .is_err()
+    );
+    storage.delete_session(&first.public_id).await.unwrap();
+    let count = storage
+        .conn_for_test()
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM session_delegate_assignments",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0, "deleting a parent cascades to assignments");
+}
+
+#[tokio::test]
+async fn delegate_assignments_survive_reopen_and_detect_cross_connection_conflicts() {
+    use crate::delegation::DelegateModelOverride;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("sessions.db");
+    let storage = SqliteStorage::connect(path.clone()).await.unwrap();
+    let parent = storage
+        .create_session(None, None, None, None)
+        .await
+        .unwrap();
+    let model = DelegateModelOverride {
+        model_id: "provider/retired-model".into(),
+        node_id: Some("offline-node".into()),
+    };
+    storage
+        .set_delegate_assignment(&parent.public_id, "coder", Some(model.clone()), Some(0))
+        .await
+        .unwrap();
+    drop(storage);
+    let first = SqliteStorage::connect(path.clone()).await.unwrap();
+    let second = SqliteStorage::connect(path).await.unwrap();
+    assert_eq!(
+        first
+            .get_delegate_assignments(&parent.public_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .overrides["coder"],
+        model
+    );
+    let noop = second
+        .set_delegate_assignment(&parent.public_id, "coder", Some(model.clone()), None)
+        .await
+        .unwrap();
+    assert!(!noop.changed, "cross-connection no-op must be explicit");
+    assert_eq!(noop.revision, 1);
+    let (a, b) = tokio::join!(
+        first.set_delegate_assignment(&parent.public_id, "a", Some(model.clone()), Some(1)),
+        second.set_delegate_assignment(&parent.public_id, "b", Some(model), Some(1)),
+    );
+    assert_ne!(
+        a.is_ok(),
+        b.is_ok(),
+        "exactly one writer can consume revision 1"
+    );
+    let error = a.err().or_else(|| b.err()).unwrap();
+    assert!(matches!(
+        error,
+        crate::session::error::SessionError::DelegateAssignmentRevisionConflict {
+            expected: 1,
+            found: 2
+        }
+    ));
+    assert_eq!(
+        first
+            .get_delegate_assignments(&parent.public_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .revision,
+        2
+    );
+}
+
+#[tokio::test]
+async fn delegate_assignments_rollback_failed_writes_and_do_not_hide_corruption() {
+    use crate::delegation::DelegateModelOverride;
+    let storage = SqliteStorage::connect(":memory:".into()).await.unwrap();
+    let parent = storage
+        .create_session(None, None, None, None)
+        .await
+        .unwrap();
+    let model = DelegateModelOverride {
+        model_id: "provider/model".into(),
+        node_id: None,
+    };
+    let before = storage
+        .set_delegate_assignment(&parent.public_id, "coder", Some(model.clone()), None)
+        .await
+        .unwrap();
+    storage
+        .run_blocking(|conn| {
+            conn.execute_batch(
+        "CREATE TRIGGER reject_delegate_update BEFORE UPDATE ON session_delegate_assignments
+         BEGIN SELECT RAISE(ABORT, 'rejected update'); END;"
+    )
+        })
+        .await
+        .unwrap();
+    assert!(
+        storage
+            .set_delegate_assignment(&parent.public_id, "reviewer", Some(model), Some(1))
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        storage
+            .get_delegate_assignments(&parent.public_id)
+            .await
+            .unwrap()
+            .unwrap(),
+        before.assignments
+    );
+    storage.run_blocking(|conn| conn.execute_batch(
+        "DROP TRIGGER reject_delegate_update; UPDATE session_delegate_assignments SET overrides_json = 'broken';"
+    )).await.unwrap();
+    assert!(
+        storage
+            .get_delegate_assignments(&parent.public_id)
+            .await
+            .is_err(),
+        "corrupt state must not be displayed as inheritance"
+    );
+}
+
+#[tokio::test]
+async fn delegate_assignments_user_forks_inherit_but_delegate_children_do_not() {
+    let storage = SqliteStorage::connect(":memory:".into()).await.unwrap();
+    let parent = storage
+        .create_session(None, None, None, None)
+        .await
+        .unwrap();
+    let model = crate::delegation::DelegateModelOverride {
+        model_id: "provider/model".into(),
+        node_id: None,
+    };
+    storage
+        .set_delegate_assignment(&parent.public_id, "coder", Some(model.clone()), None)
+        .await
+        .unwrap();
+    storage
+        .add_message(
+            &parent.public_id,
+            AgentMessage {
+                id: "fork-point".into(),
+                session_id: parent.public_id.clone(),
+                role: ChatRole::User,
+                parts: vec![MessagePart::Prompt {
+                    blocks: vec![ContentBlock::Text(TextContent::new("task"))],
+                }],
+                created_at: 1,
+                parent_message_id: None,
+                source_provider: None,
+                source_model: None,
+            },
+        )
+        .await
+        .unwrap();
+    let fork = storage
+        .fork_session(&parent.public_id, "fork-point", ForkOrigin::User)
+        .await
+        .unwrap();
+    let child = storage
+        .fork_session(&parent.public_id, "fork-point", ForkOrigin::Delegation)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .get_delegate_assignments(&fork)
+            .await
+            .unwrap()
+            .unwrap()
+            .overrides["coder"],
+        model
+    );
+    assert!(
+        storage
+            .get_delegate_assignments(&child)
+            .await
+            .unwrap()
+            .unwrap()
+            .overrides
+            .is_empty()
+    );
+    storage
+        .set_delegate_assignment(&fork, "coder", None, Some(0))
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .get_delegate_assignments(&parent.public_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .overrides["coder"],
+        model
+    );
+}
+
+#[test]
+fn delegate_assignment_migration_preserves_existing_records() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    // Model an upgrade from main's prior schema rather than only testing fresh databases.
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|m| m.version != "0017_delegate_assignments")
+    {
+        (migration.apply)(&mut conn).unwrap();
+    }
+    conn.execute("INSERT INTO sessions (public_id, name, created_at, updated_at) VALUES ('existing', 'Keep me', '2026-09-07T00:00:00Z', '2026-09-07T00:00:00Z')", []).unwrap();
+    let migration = MIGRATIONS
+        .iter()
+        .find(|m| m.version == "0017_delegate_assignments")
+        .unwrap();
+    (migration.apply)(&mut conn).unwrap();
+    (migration.apply)(&mut conn).unwrap();
+    let name: String = conn
+        .query_row(
+            "SELECT name FROM sessions WHERE public_id = 'existing'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(name, "Keep me");
+}
+
+#[tokio::test]
 async fn session_control_commit_is_revisioned_and_session_scoped() {
     let storage = SqliteStorage::connect(":memory:".into())
         .await

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -166,14 +166,6 @@ pub struct DelegateAssignmentWrite {
     pub changed: bool,
 }
 
-impl std::ops::Deref for DelegateAssignmentWrite {
-    type Target = DelegateAssignments;
-
-    fn deref(&self) -> &Self::Target {
-        &self.assignments
-    }
-}
-
 /// Stored session-scoped execution configuration snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionExecutionConfig {

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -152,6 +152,28 @@ pub struct TaskPatch {
     pub cancellation_reason: Option<String>,
 }
 
+/// Authoritative delegate overrides for one parent session. Empty means inheritance.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegateAssignments {
+    pub revision: u64,
+    pub overrides: std::collections::BTreeMap<String, crate::delegation::DelegateModelOverride>,
+}
+
+/// Atomic assignment-write result, including whether the transaction changed state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegateAssignmentWrite {
+    pub assignments: DelegateAssignments,
+    pub changed: bool,
+}
+
+impl std::ops::Deref for DelegateAssignmentWrite {
+    type Target = DelegateAssignments;
+
+    fn deref(&self) -> &Self::Target {
+        &self.assignments
+    }
+}
+
 /// Stored session-scoped execution configuration snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionExecutionConfig {
@@ -262,6 +284,29 @@ pub trait SessionStore: Send + Sync {
 
     /// Retrieves session metadata by its unique ID.
     async fn get_session(&self, session_id: &str) -> SessionResult<Option<Session>>;
+
+    /// None means this storage backend does not support durable assignments.
+    /// Supporting backends return an empty snapshot for an existing, unconfigured session.
+    async fn get_delegate_assignments(
+        &self,
+        _session_id: &str,
+    ) -> SessionResult<Option<DelegateAssignments>> {
+        Ok(None)
+    }
+
+    /// Atomically change one role, preserving other roles. None removes the override.
+    /// Legacy clients may omit expected_revision; clients with a snapshot should supply it.
+    async fn set_delegate_assignment(
+        &self,
+        _session_id: &str,
+        _agent_id: &str,
+        _model: Option<crate::delegation::DelegateModelOverride>,
+        _expected_revision: Option<u64>,
+    ) -> SessionResult<DelegateAssignmentWrite> {
+        Err(SessionError::InvalidOperation(
+            "Durable delegate assignments are unsupported".into(),
+        ))
+    }
 
     /// Lists all available sessions.
     async fn list_sessions(&self) -> SessionResult<Vec<Session>>;

--- a/crates/agent/src/session/store.rs
+++ b/crates/agent/src/session/store.rs
@@ -157,6 +157,8 @@ pub struct TaskPatch {
 pub struct DelegateAssignments {
     pub revision: u64,
     pub overrides: std::collections::BTreeMap<String, crate::delegation::DelegateModelOverride>,
+    pub reasoning_overrides:
+        std::collections::BTreeMap<String, crate::delegation::DelegateReasoningEffort>,
 }
 
 /// Atomic assignment-write result, including whether the transaction changed state.
@@ -286,7 +288,7 @@ pub trait SessionStore: Send + Sync {
         Ok(None)
     }
 
-    /// Atomically change one role, preserving other roles. None removes the override.
+    /// Atomically change one role's model, preserving other roles.
     /// Legacy clients may omit expected_revision; clients with a snapshot should supply it.
     async fn set_delegate_assignment(
         &self,
@@ -298,6 +300,24 @@ pub trait SessionStore: Send + Sync {
         Err(SessionError::InvalidOperation(
             "Durable delegate assignments are unsupported".into(),
         ))
+    }
+
+    /// Atomically change one role while preserving an omitted reasoning override.
+    async fn set_delegate_assignment_with_reasoning(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        model: Option<crate::delegation::DelegateModelOverride>,
+        reasoning_effort: Option<Option<crate::delegation::DelegateReasoningEffort>>,
+        expected_revision: Option<u64>,
+    ) -> SessionResult<DelegateAssignmentWrite> {
+        if reasoning_effort.is_some() {
+            return Err(SessionError::InvalidOperation(
+                "Durable delegate reasoning assignments are unsupported".into(),
+            ));
+        }
+        self.set_delegate_assignment(session_id, agent_id, model, expected_revision)
+            .await
     }
 
     /// Lists all available sessions.

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -1266,6 +1266,7 @@ export interface SessionMeta {
 export interface SetDelegateModelRequest {
 	session_id: string;
 	agent_id: string;
+	/** Present and null clears the override. Omitted is invalid, not a wipe. */
 	model_id: string | null;
 	node_id?: string | null;
 	expected_revision?: number | null;

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -273,6 +273,10 @@ export type AgentEventKind =
 	| { type: "artifact_recorded", data: {
 	artifact: Artifact;
 }}
+	/** Invalidation hint; clients read the authoritative assignment snapshot after this event. */
+	| { type: "delegate_models_changed", data: {
+	revision?: number;
+}}
 	| { type: "delegation_requested", data: {
 	delegation: Delegation;
 	tool_call_id?: string;
@@ -321,6 +325,10 @@ export type AgentEventKind =
 	fork_point_type: string;
 	fork_point_ref: string;
 	instructions?: string;
+	/** Model confirmed by the child session before its first prompt. */
+	selected_model_id?: string;
+	/** Mesh node confirmed with the selected model, or None for local execution. */
+	selected_provider_node_id?: string;
 }}
 	/** Emitted once at session creation with environment configuration */
 	| { type: "session_configured", data: {
@@ -744,6 +752,51 @@ export interface CreateScheduleControlRequest {
 	max_runs?: number;
 }
 
+export enum DelegateAssignmentSource {
+	Override = "override",
+	ProfileDefault = "profile_default",
+}
+
+export interface DelegateAssignmentInfo {
+	agent_id: string;
+	name: string;
+	description: string;
+	model: DelegateModelOverride | null;
+	source: DelegateAssignmentSource;
+	configured_default_model_id: string | null;
+}
+
+export interface DelegateModelOverride {
+	model_id: string;
+	node_id?: string;
+}
+
+export interface OrphanedDelegateAssignment {
+	agent_id: string;
+	model: DelegateModelOverride;
+}
+
+export interface DelegateAssignmentsInfo {
+	version: number;
+	session_id: string;
+	profile_id: string;
+	revision: number | null;
+	durable: boolean;
+	editable: boolean;
+	assignments: DelegateAssignmentInfo[];
+	orphaned_overrides: OrphanedDelegateAssignment[];
+}
+
+export interface DelegateModelsChangedNotification {
+	version: number;
+	session_id: string;
+	revision: number | null;
+}
+
+export interface DelegateModelsRequest {
+	session_id: string;
+}
+
 export enum DelegationUpdateState {
 	Requested = "requested",
 	Forked = "forked",
@@ -761,6 +814,9 @@ export interface DelegationUpdateNotification {
 	targetAgentId: string;
 	objective: string;
 	childSessionId?: string;
+	/** Confirmed child model, not the parent's current preference. */
+	selectedModelId?: string;
+	selectedProviderNodeId?: string;
 	requestedAt: number;
 	forkedAt?: number;
 	finishedAt?: number;
@@ -1205,6 +1261,23 @@ export interface SessionMeta {
 	userMessageCount: number;
 	hasErrors: boolean;
 	runtimeStatus: SessionRuntimeStatus;
+}
+
+export interface SetDelegateModelRequest {
+	session_id: string;
+	agent_id: string;
+	model_id?: string | null;
+	node_id?: string | null;
+	expected_revision?: number | null;
+}
+
+export interface SetDelegateModelResponse {
+	version: number;
+	session_id: string;
+	agent_id: string;
+	model: DelegateModelOverride | null;
+	revision: number | null;
+	durable: boolean;
 }
 
 /**

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -764,20 +764,18 @@ export interface DelegateAssignmentInfo {
 	model: DelegateModelOverride | null;
 	source: DelegateAssignmentSource;
 	configured_default_model_id: string | null;
-}
-
-export interface DelegateModelOverride {
-	model_id: string;
-	node_id?: string;
+	reasoning_effort: DelegateReasoningEffort | null;
 }
 
 export interface OrphanedDelegateAssignment {
 	agent_id: string;
-	model: DelegateModelOverride;
+	model: DelegateModelOverride | null;
+	reasoning_effort: DelegateReasoningEffort | null;
 }
 
 export interface DelegateAssignmentsInfo {
 	version: number;
+	reasoning_effort_supported: boolean;
 	session_id: string;
 	profile_id: string;
 	revision: number | null;
@@ -785,6 +783,11 @@ export interface DelegateAssignmentsInfo {
 	editable: boolean;
 	assignments: DelegateAssignmentInfo[];
 	orphaned_overrides: OrphanedDelegateAssignment[];
+}
+
+export interface DelegateModelOverride {
+	model_id: string;
+	node_id?: string;
 }
 
 export interface DelegateModelsChangedNotification {
@@ -1269,14 +1272,18 @@ export interface SetDelegateModelRequest {
 	/** Present and null clears the override. Omitted is invalid, not a wipe. */
 	model_id: string | null;
 	node_id?: string | null;
+	/** Omitted preserves the current setting; null restores parent-session inheritance. */
+	reasoning_effort?: DelegateReasoningEffort | null;
 	expected_revision?: number | null;
 }
 
 export interface SetDelegateModelResponse {
 	version: number;
+	reasoning_effort_supported: boolean;
 	session_id: string;
 	agent_id: string;
 	model: DelegateModelOverride | null;
+	reasoning_effort: DelegateReasoningEffort | null;
 	revision: number | null;
 	durable: boolean;
 }
@@ -1326,6 +1333,14 @@ export interface UsageInfo {
 	reasoning_tokens?: number;
 	cache_read?: number;
 	cache_write?: number;
+}
+
+export enum DelegateReasoningEffort {
+	Auto = "auto",
+	Low = "low",
+	Medium = "medium",
+	High = "high",
+	Max = "max",
 }
 
 /**

--- a/crates/agent/ui/src/generated/types.ts
+++ b/crates/agent/ui/src/generated/types.ts
@@ -1266,7 +1266,7 @@ export interface SessionMeta {
 export interface SetDelegateModelRequest {
 	session_id: string;
 	agent_id: string;
-	model_id?: string | null;
+	model_id: string | null;
 	node_id?: string | null;
 	expected_revision?: number | null;
 }

--- a/docs/docs/agent/delegation.md
+++ b/docs/docs/agent/delegation.md
@@ -151,8 +151,9 @@ Reads do not set models, replay client preferences, or create session actors.
 ```
 
 The response includes `version`, `session_id`, `agent_id`, confirmed `model`,
-`reasoning_effort`, `revision`, and `durable`. Omit `node_id` (or use `null`) for a
-local model. Reset the model with `model_id: null` and no node. The optional
+`reasoning_effort`, `revision`, and `durable`. Every write must include `model_id`;
+omitting it is `InvalidParams`. Omit `node_id` (or use `null`) for a local model.
+Reset the model with an explicit `model_id: null` and no node. The optional
 `reasoning_effort` field preserves the existing setting when omitted, clears it back
 to parent-session inheritance when null, and accepts `auto`, `low`, `medium`, `high`,
 or `max`. Snake-case request fields also accept their camelCase aliases. An empty

--- a/docs/docs/agent/delegation.md
+++ b/docs/docs/agent/delegation.md
@@ -148,7 +148,8 @@ and `durable`. Omit `node_id` (or use `null`) for a local model. Reset with
 aliases. An empty node string is rejected rather than silently selecting local execution.
 
 Use the revision from readback to avoid lost updates. A stale write fails without
-changing anything, using ACP InvalidParams with error data:
+changing anything. The ACP error code is `-32020`, not `InvalidParams`
+(`-32602`), with this error data:
 
 ```json
 {

--- a/docs/docs/agent/delegation.md
+++ b/docs/docs/agent/delegation.md
@@ -70,6 +70,145 @@ system = """You are a planner agent. Your role is to:
 5. Review and integrate delegate results"""
 ```
 
+## Session-Scoped Delegate Models (ACP)
+
+A delegate's profile configuration supplies its default model. A parent session can
+explicitly override that model for **future delegations**, without changing the
+profile, another parent session, or a child that is already running. The override
+is read during child setup, before its first prompt; a change racing with setup
+is not guaranteed to affect that already-starting child.
+
+### Read assignments
+
+Check `querymt/capabilities` for `querymt/session/delegateModels` and
+`querymt/session/setDelegateModel`. Call:
+
+```json
+{"method":"querymt/session/delegateModels","params":{"session_id":"parent-session-id"}}
+```
+
+An illustrative result is:
+
+```json
+{
+  "version": 1,
+  "session_id": "parent-session-id",
+  "profile_id": "quorum",
+  "revision": 2,
+  "durable": true,
+  "editable": true,
+  "assignments": [
+    {
+      "agent_id": "coder",
+      "name": "Coder",
+      "description": "Writes code",
+      "model": {"model_id": "provider/model", "node_id": "mesh-node-id"},
+      "source": "override",
+      "configured_default_model_id": "provider/default-model"
+    }
+  ],
+  "orphaned_overrides": []
+}
+```
+
+- `model` is the stored override, or `null` to inherit. It is returned even if the
+  model has disappeared from the current catalog or its node is offline.
+- `source` is `override` or `profile_default`. A failed read is **unknown**, not
+  proof of inheritance. Do not substitute a recent/default catalog entry.
+- `configured_default_model_id` is the local delegate's configured provider/model,
+  also included by `querymt/profile/agents`. It may be `null` for a remote delegate.
+  It is **not** a resolved Mesh route, a runtime availability guarantee, or the model
+  that generated an existing child's messages.
+- `orphaned_overrides` contains `{agent_id, model}` entries for removed profile
+  roles. They remain visible and can be explicitly cleared; reads never delete them.
+- `editable` is false for delegated child sessions. User-created forks can own
+  independent assignments. The session must have a valid persisted profile binding;
+  no prior actor load is required.
+
+Reads do not set models, replay client preferences, or create session actors.
+
+### Change one assignment
+
+```json
+{
+  "method": "querymt/session/setDelegateModel",
+  "params": {
+    "session_id": "parent-session-id",
+    "agent_id": "coder",
+    "model_id": "provider/model",
+    "node_id": "mesh-node-id",
+    "expected_revision": 2
+  }
+}
+```
+
+The response includes `version`, `session_id`, `agent_id`, confirmed `model`, `revision`,
+and `durable`. Omit `node_id` (or use `null`) for a local model. Reset with
+`model_id: null` and no node. Snake-case request fields also accept their camelCase
+aliases. An empty node string is rejected rather than silently selecting local execution.
+
+Use the revision from readback to avoid lost updates. A stale write fails without
+changing anything, using ACP InvalidParams with error data:
+
+```json
+{
+  "code": "delegate_assignment_conflict",
+  "expected_revision": 2,
+  "actual_revision": 3,
+  "message": "Delegate assignments changed; refresh before retrying"
+}
+```
+
+Refresh and let the user review a conflict; do not blindly retry. Writes to an
+unchanged value keep the revision. The revision covers all roles in that parent
+session; a changed role increments it once. Multiple setter calls are not an atomic
+bulk operation: retain per-role confirmations and handle partial failure before
+sending a new session's first prompt.
+
+Older clients may omit `expected_revision`; their writes are unconditional but
+atomically preserve other roles. SQLite persists assignments across close, reload,
+and restart. Deleting a parent cascades to its assignments. A user fork copies
+assignments independently with revision zero; delegated children do not inherit
+that assignment map.
+
+### Notifications and recovery
+
+On changes, stdio and WebSocket event streams send the advertised
+`querymt/session/delegateModelsChanged` invalidation hint:
+
+```json
+{"method":"querymt/session/delegateModelsChanged","params":{"version":1,"session_id":"parent-session-id","revision":3}}
+```
+
+Notifications use existing session event routing/ownership rules. They are not a
+cross-process database watcher or a guaranteed event for every commit: the write
+and event publication are separate. Always read back on reconnect and refresh on
+focus when other processes may write. The returned state, not an event history scan, is authoritative.
+
+Delegation updates and load snapshots also expose `selectedModelId` and
+`selectedProviderNodeId` once a child has been configured. These optional fields
+come from that child's confirmed control state immediately before the fork event
+and first prompt. Older fork events omit them. Use them for historical execution
+provenance; do not rewrite them from today's parent assignment settings.
+
+Custom `SessionStore` implementations that do not implement durable assignments
+retain the legacy in-memory path. They report `durable: false` and `revision: null`,
+and reject an `expected_revision`. Do not promise persistence or compare-and-swap
+for those backends. Legacy in-memory overrides are not automatically migrated;
+clients must explicitly apply any desired saved setup.
+
+### Testing and database isolation
+
+Profile tests must inject temporary or in-memory storage into `AgentInfra`; the
+profile manager and its runtimes must use the same isolated storage. `storage: None`
+means **use the normal user database**, not an in-memory test database.
+
+As defense in depth, run tests with a fresh `QMT_SESSIONS_DB`, `QMT_HOME`, and
+`HOME`, and use a filesystem sandbox that hides the real home and other worktrees.
+Never launch development builds against a live sessions database to test migrations.
+The delegate-assignment migration is `0017_delegate_assignments`, after the event
+source identity and remote sync progress migrations already present on `main`.
+
 ## Delegation Lifecycle
 
 ### 1. Delegation Request

--- a/docs/docs/agent/delegation.md
+++ b/docs/docs/agent/delegation.md
@@ -92,6 +92,7 @@ An illustrative result is:
 ```json
 {
   "version": 1,
+  "reasoning_effort_supported": true,
   "session_id": "parent-session-id",
   "profile_id": "quorum",
   "revision": 2,
@@ -104,7 +105,8 @@ An illustrative result is:
       "description": "Writes code",
       "model": {"model_id": "provider/model", "node_id": "mesh-node-id"},
       "source": "override",
-      "configured_default_model_id": "provider/default-model"
+      "configured_default_model_id": "provider/default-model",
+      "reasoning_effort": "high"
     }
   ],
   "orphaned_overrides": []
@@ -119,8 +121,13 @@ An illustrative result is:
   also included by `querymt/profile/agents`. It may be `null` for a remote delegate.
   It is **not** a resolved Mesh route, a runtime availability guarantee, or the model
   that generated an existing child's messages.
-- `orphaned_overrides` contains `{agent_id, model}` entries for removed profile
-  roles. They remain visible and can be explicitly cleared; reads never delete them.
+- `reasoning_effort_supported` is true when the additive setter/readback field is
+  available. Clients must hide reasoning controls when an older backend omits it.
+- `reasoning_effort` is `null` to inherit the parent session at delegation time, or
+  `auto`, `low`, `medium`, `high`, or `max` for an explicit role override.
+- `orphaned_overrides` contains `{agent_id, model, reasoning_effort}` entries for
+  removed profile roles. Model can be `null` for reasoning-only overrides. They
+  remain visible and can be explicitly cleared; reads never delete them.
 - `editable` is false for delegated child sessions. User-created forks can own
   independent assignments. The session must have a valid persisted profile binding;
   no prior actor load is required.
@@ -137,15 +144,19 @@ Reads do not set models, replay client preferences, or create session actors.
     "agent_id": "coder",
     "model_id": "provider/model",
     "node_id": "mesh-node-id",
+    "reasoning_effort": "high",
     "expected_revision": 2
   }
 }
 ```
 
-The response includes `version`, `session_id`, `agent_id`, confirmed `model`, `revision`,
-and `durable`. Omit `node_id` (or use `null`) for a local model. Reset with
-`model_id: null` and no node. Snake-case request fields also accept their camelCase
-aliases. An empty node string is rejected rather than silently selecting local execution.
+The response includes `version`, `session_id`, `agent_id`, confirmed `model`,
+`reasoning_effort`, `revision`, and `durable`. Omit `node_id` (or use `null`) for a
+local model. Reset the model with `model_id: null` and no node. The optional
+`reasoning_effort` field preserves the existing setting when omitted, clears it back
+to parent-session inheritance when null, and accepts `auto`, `low`, `medium`, `high`,
+or `max`. Snake-case request fields also accept their camelCase aliases. An empty
+node string is rejected rather than silently selecting local execution.
 
 Use the revision from readback to avoid lost updates. A stale write fails without
 changing anything. The ACP error code is `-32020`, not `InvalidParams`
@@ -167,10 +178,11 @@ bulk operation: retain per-role confirmations and handle partial failure before
 sending a new session's first prompt.
 
 Older clients may omit `expected_revision`; their writes are unconditional but
-atomically preserve other roles. SQLite persists assignments across close, reload,
-and restart. Deleting a parent cascades to its assignments. A user fork copies
-assignments independently with revision zero; delegated children do not inherit
-that assignment map.
+atomically preserve other roles and any omitted reasoning setting. SQLite stores one
+revision row per parent session and one relational override row per configured role;
+there are no JSON assignment blobs. Deleting a parent cascades to its assignments. A
+user fork copies assignments independently with revision zero; delegated children do
+not inherit that assignment map.
 
 ### Notifications and recovery
 


### PR DESCRIPTION
## Summary

- persist session-scoped delegate model overrides with revisioned compare-and-swap updates
- expose capability-gated ACP read/write methods and delegate-model invalidation notifications
- preserve local and Mesh model identity, unavailable overrides, orphaned roles, and selected child execution provenance
- keep delegated children read-only while user-created forks inherit independent assignment state
- document durable SQLite and run-only custom-store behavior

## Validation

- `cargo check -p querymt-agent --all-targets --features oauth,dbus-secret-service,remote`
- `cargo check -p querymt-agent --all-targets`
- `cargo test -p querymt-agent delegate_assignment --features remote -- --nocapture`: 14 passed
- `cargo test -p querymt-agent --features remote -- --test-threads=1`: 1,988 passed, 3 ignored, plus integration and doc tests
- `cargo fmt --all -- --check`
- `git diff --check`

All Cargo checks and tests ran with isolated temporary `HOME`, `QMT_HOME`, XDG paths, and session database paths; no live QueryMT database was accessed.

## Integration

- based on current `main`
- uses `0017_delegate_assignments` after the existing `0015_event_source_identity` and `0016_remote_sync_progress` migrations
- desktop integration is submitted separately in `querymt-desktop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added session-scoped delegate model listing and assignment management.
  - Delegate assignments now support durable persistence, revision tracking, profile defaults, editability status, orphaned overrides, and reasoning-effort settings.
  - Added notifications when delegate model assignments change.
  - Delegation records now include selected model and provider information.
  - Added validation and conflict handling for concurrent or invalid assignment updates.
  - Session listings now support filtering by session scope.

- **Documentation**
  - Documented delegate model APIs, reasoning-effort settings, responses, notifications, persistence, and revision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->