### PR TITLE
fix: cancallable middlewares

### DIFF
--- a/crates/agent/src/agent/execution/mod.rs
+++ b/crates/agent/src/agent/execution/mod.rs
@@ -309,7 +309,7 @@ pub(crate) async fn execute_cycle_state_machine(
     let mut last_objective_checkpoint_step = 0usize;
 
     state = driver
-        .run_turn_start(state, Some(&exec_ctx.runtime))
+        .run_turn_start_cancellable(state, Some(&exec_ctx.runtime), &exec_ctx.cancellation_token)
         .instrument(info_span!(
             "agent.execution.middleware.turn_start",
             session_id = %exec_ctx.session_id
@@ -397,7 +397,11 @@ pub(crate) async fn execute_cycle_state_machine(
                 let context = refresh_objective_fragment(&context, exec_ctx);
                 let state = ExecutionState::BeforeLlmCall { context };
                 let state = driver
-                    .run_step_start(state, Some(&exec_ctx.runtime))
+                    .run_step_start_cancellable(
+                        state,
+                        Some(&exec_ctx.runtime),
+                        &exec_ctx.cancellation_token,
+                    )
                     .instrument(info_span!(
                         "agent.execution.middleware.step_start",
                         session_id = %exec_ctx.session_id
@@ -430,7 +434,11 @@ pub(crate) async fn execute_cycle_state_machine(
 
             ExecutionState::AfterLlm { .. } => {
                 let state = driver
-                    .run_after_llm(state, Some(&exec_ctx.runtime))
+                    .run_after_llm_cancellable(
+                        state,
+                        Some(&exec_ctx.runtime),
+                        &exec_ctx.cancellation_token,
+                    )
                     .instrument(info_span!(
                         "agent.execution.middleware.after_llm",
                         session_id = %exec_ctx.session_id
@@ -497,7 +505,11 @@ pub(crate) async fn execute_cycle_state_machine(
                     context,
                 };
                 let state = driver
-                    .run_processing_tool_calls(state, Some(&exec_ctx.runtime))
+                    .run_processing_tool_calls_cancellable(
+                        state,
+                        Some(&exec_ctx.runtime),
+                        &exec_ctx.cancellation_token,
+                    )
                     .instrument(info_span!(
                         "agent.execution.middleware.processing_tool_calls",
                         session_id = %exec_ctx.session_id
@@ -569,11 +581,12 @@ pub(crate) async fn execute_cycle_state_machine(
                     continue;
                 }
                 let turn_end_state = driver
-                    .run_turn_end(
+                    .run_turn_end_cancellable(
                         ExecutionState::Complete {
                             context: fallback_context,
                         },
                         Some(&exec_ctx.runtime),
+                        &exec_ctx.cancellation_token,
                     )
                     .instrument(info_span!(
                         "agent.execution.middleware.turn_end",

--- a/crates/agent/src/middleware/driver.rs
+++ b/crates/agent/src/middleware/driver.rs
@@ -4,6 +4,7 @@ use crate::middleware::{ExecutionState, Result};
 use async_trait::async_trait;
 use log::{debug, trace};
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info_span, instrument};
 
 /// Trait for middleware that runs at specific lifecycle phases
@@ -97,8 +98,23 @@ impl CompositeDriver {
         state: ExecutionState,
         runtime: Option<&Arc<SessionRuntime>>,
     ) -> Result<ExecutionState> {
-        self.run_phase(state, runtime, MiddlewarePhase::TurnStart)
+        self.run_phase(state, runtime, MiddlewarePhase::TurnStart, None)
             .await
+    }
+
+    pub async fn run_turn_start_cancellable(
+        &self,
+        state: ExecutionState,
+        runtime: Option<&Arc<SessionRuntime>>,
+        cancellation_token: &CancellationToken,
+    ) -> Result<ExecutionState> {
+        self.run_phase(
+            state,
+            runtime,
+            MiddlewarePhase::TurnStart,
+            Some(cancellation_token),
+        )
+        .await
     }
 
     pub async fn run_step_start(
@@ -106,8 +122,23 @@ impl CompositeDriver {
         state: ExecutionState,
         runtime: Option<&Arc<SessionRuntime>>,
     ) -> Result<ExecutionState> {
-        self.run_phase(state, runtime, MiddlewarePhase::StepStart)
+        self.run_phase(state, runtime, MiddlewarePhase::StepStart, None)
             .await
+    }
+
+    pub async fn run_step_start_cancellable(
+        &self,
+        state: ExecutionState,
+        runtime: Option<&Arc<SessionRuntime>>,
+        cancellation_token: &CancellationToken,
+    ) -> Result<ExecutionState> {
+        self.run_phase(
+            state,
+            runtime,
+            MiddlewarePhase::StepStart,
+            Some(cancellation_token),
+        )
+        .await
     }
 
     pub async fn run_after_llm(
@@ -115,8 +146,23 @@ impl CompositeDriver {
         state: ExecutionState,
         runtime: Option<&Arc<SessionRuntime>>,
     ) -> Result<ExecutionState> {
-        self.run_phase(state, runtime, MiddlewarePhase::AfterLlm)
+        self.run_phase(state, runtime, MiddlewarePhase::AfterLlm, None)
             .await
+    }
+
+    pub async fn run_after_llm_cancellable(
+        &self,
+        state: ExecutionState,
+        runtime: Option<&Arc<SessionRuntime>>,
+        cancellation_token: &CancellationToken,
+    ) -> Result<ExecutionState> {
+        self.run_phase(
+            state,
+            runtime,
+            MiddlewarePhase::AfterLlm,
+            Some(cancellation_token),
+        )
+        .await
     }
 
     pub async fn run_processing_tool_calls(
@@ -124,8 +170,23 @@ impl CompositeDriver {
         state: ExecutionState,
         runtime: Option<&Arc<SessionRuntime>>,
     ) -> Result<ExecutionState> {
-        self.run_phase(state, runtime, MiddlewarePhase::ProcessingToolCalls)
+        self.run_phase(state, runtime, MiddlewarePhase::ProcessingToolCalls, None)
             .await
+    }
+
+    pub async fn run_processing_tool_calls_cancellable(
+        &self,
+        state: ExecutionState,
+        runtime: Option<&Arc<SessionRuntime>>,
+        cancellation_token: &CancellationToken,
+    ) -> Result<ExecutionState> {
+        self.run_phase(
+            state,
+            runtime,
+            MiddlewarePhase::ProcessingToolCalls,
+            Some(cancellation_token),
+        )
+        .await
     }
 
     pub async fn run_turn_end(
@@ -133,8 +194,23 @@ impl CompositeDriver {
         state: ExecutionState,
         runtime: Option<&Arc<SessionRuntime>>,
     ) -> Result<ExecutionState> {
-        self.run_phase(state, runtime, MiddlewarePhase::TurnEnd)
+        self.run_phase(state, runtime, MiddlewarePhase::TurnEnd, None)
             .await
+    }
+
+    pub async fn run_turn_end_cancellable(
+        &self,
+        state: ExecutionState,
+        runtime: Option<&Arc<SessionRuntime>>,
+        cancellation_token: &CancellationToken,
+    ) -> Result<ExecutionState> {
+        self.run_phase(
+            state,
+            runtime,
+            MiddlewarePhase::TurnEnd,
+            Some(cancellation_token),
+        )
+        .await
     }
 
     pub fn reset(&self) {
@@ -191,6 +267,7 @@ impl CompositeDriver {
         state: ExecutionState,
         runtime: Option<&Arc<SessionRuntime>>,
         phase: MiddlewarePhase,
+        cancellation_token: Option<&CancellationToken>,
     ) -> Result<ExecutionState> {
         let state_name = state.name();
         trace!(
@@ -224,38 +301,30 @@ impl CompositeDriver {
                 output_state = tracing::field::Empty,
                 terminal = tracing::field::Empty,
             );
-            current = match phase {
-                MiddlewarePhase::TurnStart => {
-                    driver
-                        .on_turn_start(current, runtime)
-                        .instrument(span.clone())
-                        .await?
+            if cancellation_token.is_some_and(CancellationToken::is_cancelled) {
+                current = ExecutionState::Cancelled;
+            } else {
+                let invocation = match phase {
+                    MiddlewarePhase::TurnStart => driver.on_turn_start(current, runtime),
+                    MiddlewarePhase::StepStart => driver.on_step_start(current, runtime),
+                    MiddlewarePhase::AfterLlm => driver.on_after_llm(current, runtime),
+                    MiddlewarePhase::ProcessingToolCalls => {
+                        driver.on_processing_tool_calls(current, runtime)
+                    }
+                    MiddlewarePhase::TurnEnd => driver.on_turn_end(current, runtime),
                 }
-                MiddlewarePhase::StepStart => {
-                    driver
-                        .on_step_start(current, runtime)
-                        .instrument(span.clone())
-                        .await?
-                }
-                MiddlewarePhase::AfterLlm => {
-                    driver
-                        .on_after_llm(current, runtime)
-                        .instrument(span.clone())
-                        .await?
-                }
-                MiddlewarePhase::ProcessingToolCalls => {
-                    driver
-                        .on_processing_tool_calls(current, runtime)
-                        .instrument(span.clone())
-                        .await?
-                }
-                MiddlewarePhase::TurnEnd => {
-                    driver
-                        .on_turn_end(current, runtime)
-                        .instrument(span.clone())
-                        .await?
-                }
-            };
+                .instrument(span.clone());
+
+                current = if let Some(token) = cancellation_token {
+                    tokio::select! {
+                        biased;
+                        _ = token.cancelled() => ExecutionState::Cancelled,
+                        result = invocation => result?,
+                    }
+                } else {
+                    invocation.await?
+                };
+            }
 
             let new_state_name = current.name();
             span.record("output_state", new_state_name);

--- a/crates/agent/src/middleware/driver_tests.rs
+++ b/crates/agent/src/middleware/driver_tests.rs
@@ -11,6 +11,7 @@ use crate::test_utils::{
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 #[tokio::test]
@@ -113,7 +114,9 @@ async fn test_composite_driver_cancelled_halts() {
     assert_eq!(counter.count.load(Ordering::SeqCst), 0);
 }
 
-struct PendingDriver;
+struct PendingDriver {
+    started: Arc<Notify>,
+}
 
 #[async_trait::async_trait]
 impl MiddlewareDriver for PendingDriver {
@@ -122,6 +125,7 @@ impl MiddlewareDriver for PendingDriver {
         _state: ExecutionState,
         _runtime: Option<&Arc<crate::agent::core::SessionRuntime>>,
     ) -> crate::middleware::Result<ExecutionState> {
+        self.started.notify_one();
         std::future::pending().await
     }
 
@@ -153,7 +157,10 @@ async fn test_composite_driver_skips_middleware_when_already_cancelled() {
 
 #[tokio::test]
 async fn test_composite_driver_interrupts_running_middleware() {
-    let composite = Arc::new(CompositeDriver::new(vec![Arc::new(PendingDriver)]));
+    let middleware_started = Arc::new(Notify::new());
+    let composite = Arc::new(CompositeDriver::new(vec![Arc::new(PendingDriver {
+        started: middleware_started.clone(),
+    })]));
     let context = test_context("sess-1", 0);
     let token = CancellationToken::new();
     let task_token = token.clone();
@@ -163,7 +170,7 @@ async fn test_composite_driver_interrupts_running_middleware() {
             .await
     });
 
-    tokio::task::yield_now().await;
+    middleware_started.notified().await;
     token.cancel();
 
     let result = tokio::time::timeout(std::time::Duration::from_secs(1), task)

--- a/crates/agent/src/middleware/driver_tests.rs
+++ b/crates/agent/src/middleware/driver_tests.rs
@@ -11,6 +11,7 @@ use crate::test_utils::{
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio_util::sync::CancellationToken;
 
 #[tokio::test]
 async fn test_composite_driver_empty_passes_through() {
@@ -110,6 +111,67 @@ async fn test_composite_driver_cancelled_halts() {
 
     assert!(matches!(result, ExecutionState::Cancelled));
     assert_eq!(counter.count.load(Ordering::SeqCst), 0);
+}
+
+struct PendingDriver;
+
+#[async_trait::async_trait]
+impl MiddlewareDriver for PendingDriver {
+    async fn on_turn_end(
+        &self,
+        _state: ExecutionState,
+        _runtime: Option<&Arc<crate::agent::core::SessionRuntime>>,
+    ) -> crate::middleware::Result<ExecutionState> {
+        std::future::pending().await
+    }
+
+    fn reset(&self) {}
+
+    fn name(&self) -> &'static str {
+        "PendingDriver"
+    }
+}
+
+#[tokio::test]
+async fn test_composite_driver_skips_middleware_when_already_cancelled() {
+    let counter = Arc::new(CountingDriver {
+        count: AtomicUsize::new(0),
+    });
+    let composite = CompositeDriver::new(vec![counter.clone()]);
+    let context = test_context("sess-1", 0);
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let result = composite
+        .run_turn_start_cancellable(ExecutionState::BeforeLlmCall { context }, None, &token)
+        .await
+        .unwrap();
+
+    assert!(matches!(result, ExecutionState::Cancelled));
+    assert_eq!(counter.count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn test_composite_driver_interrupts_running_middleware() {
+    let composite = Arc::new(CompositeDriver::new(vec![Arc::new(PendingDriver)]));
+    let context = test_context("sess-1", 0);
+    let token = CancellationToken::new();
+    let task_token = token.clone();
+    let task = tokio::spawn(async move {
+        composite
+            .run_turn_end_cancellable(ExecutionState::Complete { context }, None, &task_token)
+            .await
+    });
+
+    tokio::task::yield_now().await;
+    token.cancel();
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+        .await
+        .expect("middleware cancellation should be prompt")
+        .expect("middleware task should not panic")
+        .expect("middleware cancellation should not error");
+    assert!(matches!(result, ExecutionState::Cancelled));
 }
 
 #[tokio::test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cooperative cancellation support for agent execution phases.
  - Running operations can now stop promptly when cancellation is requested.
  - Already-cancelled operations skip middleware processing and report a cancelled state.

- **Bug Fixes**
  - Prevents execution from remaining stuck when middleware does not return.

- **Tests**
  - Added coverage for pre-cancelled operations and cancellation during active processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->